### PR TITLE
Update thez2zpodcast.md

### DIFF
--- a/site/zcashsocialmedia/thez2zpodcast.md
+++ b/site/zcashsocialmedia/thez2zpodcast.md
@@ -12,7 +12,7 @@ Stay up to date on future episodes:
 
 [Spotify](https://open.spotify.com/show/3teWxE0EQaeohCM268Lpnf)
 
-[Anchor FM](https://anchor.fm/zec-hub/episodes/Zcash-narratives-with-David-from-Zcash-Media-e1o2b36)
+[Spotify for Podcaster](https://podcasters.spotify.com/pod/show/zec-hub/episodes/Zcash-narratives-with-David-from-Zcash-Media-e1o2b36)
 
 
 **Episode List**


### PR DESCRIPTION
AnchorFM doesn't exist anymore. It is now part of Spotify and is called Spotify for Podcaster. Because of that, the link to the podcast was updated to the following:

[Spotify for Podcaster](https://podcasters.spotify.com/pod/show/zec-hub/episodes/Zcash-narratives-with-David-from-Zcash-Media-e1o2b36)

________________________________________________________


AnchorFM ya no existe. Ahora forma parte de Spotify y se llama Spotify for Podcaster. Por esto el enlace al podcast fue actualizado por el siguiente:

[Spotify for Podcaster](https://podcasters.spotify.com/pod/show/zec-hub/episodes/Zcash-narratives-with-David-from-Zcash-Media-e1o2b36)