### PR TITLE
Add Zashi to Mobile Wallets

### DIFF
--- a/site/Using_Zcash/Wallets/Mobile_Wallets.md
+++ b/site/Using_Zcash/Wallets/Mobile_Wallets.md
@@ -147,3 +147,21 @@ Learn more about the different types of Zcash pools [<img src="https://raw.githu
 | Synchronizer | Multi Coin |
 
 </aside>
+
+----
+
+<a href="https://electriccoin.co/zashi/">
+    <img src="https://i.ibb.co/NyjCPrX/zashi.png" alt="zashi" width="150" height="100"/>
+</a>
+
+<aside>
+
+### [Zashi](https://electriccoin.co/zashi/)
+
+#### Pools
+| Transparent | Sapling | Orchard |
+
+#### Features
+| Synchronizer | Unified Address | Shielded Memo |
+
+</aside>


### PR DESCRIPTION
Adding Zashi to the Mobile Wallet section, following my use of Zashi Mobile wallet app on iOS (android not available yet) and the information provided on Electric Coin Co's blog post announcing Zashi.
Blog Post -> https://electriccoin.co/blog/meet-zashi-eccs-new-mobile-wallet-for-zcash/

Related Dework Task: https://app.dework.xyz/zechub-2424/main-space-20666?taskId=cdfedff9-2989-4ae0-8d16-1e14d2226161

Uadress: u1546wrk63fdgjcazncdq9fg2h34s24ue9s3cz2y3kznxjcm89utcel257qmrk2de6wk5lmjft2znprnf444cjae2eyrrl0x3g9q6snjhsz0qphc8h79ksq700amtylu97zjvnaccgy695kzd6k8dn6x0cyfafjsh3rms0z68gea3e5hjade6kex6xkk3yx8qjvss4yhqatcgavffr8ma