### PR TITLE
Move abandoned wallet to the bottom

### DIFF
--- a/site/Using_Zcash/Wallets.md
+++ b/site/Using_Zcash/Wallets.md
@@ -4,8 +4,8 @@
 
 ## [Zashi](https://electriccoin.co/zashi/)
 ![logo](https://i.ibb.co/HgsHnpN/zashiwallet.png "Zashi")
-- Devices: Mobile 
-- Pools: Transparent | Sapling | Orchard 
+- Devices: Mobile
+- Pools: Transparent | Sapling | Orchard
 - Features: Spend before Sync | Unified Address | Shielded Memo
 
 ---
@@ -13,7 +13,7 @@
 ## [Ywallet](https://ywallet.app/installation/)
 ![logo](https://i.ibb.co/z4QxCWp/ywalletcard.png "Ywallet")
 - Devices: Mobile | Desktop
-- Pools: Transparent | Sapling | Orchard 
+- Pools: Transparent | Sapling | Orchard
 - Features: WarpSync | Shielded Memo | Unified Address | Cold Storage | Voting | Pool Transfer
 
 ---
@@ -28,49 +28,40 @@
 
 ## [Zingo!](https://www.zingolabs.org/)
 ![logo](https://i.ibb.co/bdJ49Ld/zingocard.png "Zingo!")
-- Devices: Mobile 
-- Pools: Transparent | Sapling | Orchard 
+- Devices: Mobile
+- Pools: Transparent | Sapling | Orchard
 - Features: BlazeSync | Shielded Memo | Financial Insights | Unified Address
-
----
-
-## Nighthawk - Not Maintained Anymore!
-### Restore you wallet in Zashi
-![logo](https://i.ibb.co/vL2FxGk/nighthawkcard.png "Nighthawk")
-- Devices: Mobile 
-- Pools: Transparent | Sapling 
-- Features: Spend before Sync | Unified Address | Shielded memo 
 
 ---
 
 ## [Edge](https://edge.app)
 ![logo](https://i.ibb.co/qCmmHk4/edgecard.png "Edge")
-- Devices: Mobile 
-- Pools: Transparent | Sapling 
+- Devices: Mobile
+- Pools: Transparent | Sapling
 - Features: Spend before Sync | Multi Coin | Unified Address | Shielded memo | Automatic Shielding
 
 ---
 
 ## [Unstoppable](https://unstoppable.money)
 ![logo](https://i.ibb.co/KXnS26y/unstoppablecard.png "Unstoppable")
-- Devices: Mobile 
-- Pools: Transparent | Sapling 
+- Devices: Mobile
+- Pools: Transparent | Sapling
 - Features: Spend before Sync | Multi Coin | Unified Address
 
 ---
 
 ## [eZcash](https://blog.nerdbank.net/ezcash-app)
 ![logo](https://i.ibb.co/C0q3jvw/e-Zcash-1.png "eZcash")
-- Devices: Desktop 
-- Pools: Transparent | Sapling | Orchard 
+- Devices: Desktop
+- Pools: Transparent | Sapling | Orchard
 - Features: Shielded Memo | Address Check | Unified Address | Automatic Shielding
 
 ---
 
 ## [Zingo! PC](https://github.com/zingolabs/zingo-pc)
 ![logo](https://i.ibb.co/bdJ49Ld/zingocard.png "Zingo!")
-- Devices: Desktop 
-- Pools: Transparent | Sapling | Orchard 
+- Devices: Desktop
+- Pools: Transparent | Sapling | Orchard
 - Features: BlazeSync | Shielded Memo | Financial Insights | Unified Address
 
 ---
@@ -93,8 +84,8 @@
 
 ## [Brave](https://brave.com/web3-privacy/)
 ![logo](https://i.ibb.co/6yqMNwZ/image-2024-01-13-170934865.png "Brave")
-- Devices: Web 
-- Pools: Transparent | (in-development) 
+- Devices: Web
+- Pools: Transparent | (in-development)
 - Features: Spend before Sync | Unified Address | Secure File Transfer
 
 ---
@@ -150,5 +141,14 @@
 ## [Ledger](https://www.ledger.com/coin/wallet/zcash)
 ![logo](https://i.ibb.co/2qX6WCF/Desktop-Wallets.png "Ledger")
 - Devices: Hardware
-- Pools: Transparent | (in-development) 
+- Pools: Transparent | (in-development)
 - Features: Synchronizer | Multi Coin
+
+---
+
+## Nighthawk - Not Maintained Anymore!
+### Restore you wallet in Zashi
+![logo](https://i.ibb.co/vL2FxGk/nighthawkcard.png "Nighthawk")
+- Devices: Mobile
+- Pools: Transparent | Sapling
+- Features: Spend before Sync | Unified Address | Shielded memo


### PR DESCRIPTION
I'd actually rather see useless wallets (due to abandoned state) removed from the list. But if it's going to be on the list, let's at least move it to the end.