### PR TITLE
Remove "Unified Address" from YWallet features

### DIFF
--- a/site/Using_Zcash/Wallets.md
+++ b/site/Using_Zcash/Wallets.md
@@ -11,7 +11,7 @@
 ![logo](https://i.ibb.co/z4QxCWp/ywalletcard.png "Ywallet")
 - Devices: Mobile | Desktop
 - Pools: Transparent | Sapling | Orchard
-- Features: WarpSync | Shielded Memo | Unified Address | Cold Storage | Voting | Pool Transfer | Payment Request | TEX Address
+- Features: WarpSync | Shielded Memo | Cold Storage | Voting | Pool Transfer | Payment Request | TEX Address
 
 ---
 


### PR DESCRIPTION
YWallet does not fully implement ZIP 316, the Unified Address specification. It differs from the specification both in its treatment of transparent address generation, and in that it does not handle change being sent to the wallet's internal keys; restoring a seed from a ZIP 316-compliant wallet will not show the correct balance, because all change outputs will be missing. For example, using the same seed, my YWallet balance is almost zero whereas the correct balance (as seen in Zashi) is ~4 ZEC. I have not checked the behavior of other wallets; I believe this might be a problem for Zingo as well.