### PR TITLE
fix: typos in documentation files

### DIFF
--- a/Hackathon/zchat/Zchat.md
+++ b/Hackathon/zchat/Zchat.md
@@ -14,7 +14,7 @@ The app allows players to connect their Zcash shielded wallet in order to use 
 
 Sending Messages and Processing Payments
 
-• Sending Messages: Players can send messages by selecting their preferred user to chat with from the list of users. Each message is cryptographically encrypted and it is end to end. On the backend, it is also cryptographically encrypted hence a different message hash is stored in the database so if it is leaked, it will useless as another layer of encryption is present. As messeges are sent it is updated in real time with the help of websocketsthachat transaction includes a memo field with a specially crafted JSON payload. The memo format helps the backend system process and verify the bet.
+• Sending Messages: Players can send messages by selecting their preferred user to chat with from the list of users. Each message is cryptographically encrypted and it is end to end. On the backend, it is also cryptographically encrypted hence a different message hash is stored in the database so if it is leaked, it will useless as another layer of encryption is present. As messages are sent it is updated in real time with the help of websocketsthachat transaction includes a memo field with a specially crafted JSON payload. The memo format helps the backend system process and verify the bet.
 
 • Processing Payments: Payments are initiated with two options: Request and Send. On Request, users can scan a QR Code to quickly transfer the payment details to their wallet address. On send, users can send funds only requiring and amount input and then quickly processes it as soon as transactions enter the mempool, without waiting for full confirmations.
 

--- a/newsletter/ZecWeekly73.md
+++ b/newsletter/ZecWeekly73.md
@@ -11,7 +11,7 @@ Hi everyone, its been a while since i've written one of these! Eventful week, co
 
 #### This Week's Education Piece
 
-Today's education piece is a recent video posted by Hanh. Here he describes the challenges in maintaining adequete transaction privacy when transferring funds between pools. Each wallet 'builds' transactions differently and this will become important when finding solutions for exchanges to consider for Zcash deposits in future. 
+Today's education piece is a recent video posted by Hanh. Here he describes the challenges in maintaining adequate transaction privacy when transferring funds between pools. Each wallet 'builds' transactions differently and this will become important when finding solutions for exchanges to consider for Zcash deposits in future. 
 
 https://youtu.be/SeWcFUrOiAk?feature=shared
 
@@ -55,7 +55,7 @@ https://youtu.be/SeWcFUrOiAk?feature=shared
 
 [Bitcoin fees hit 20 month high, Avg fee $40 - Cointelegraph](https://cointelegraph.com/news/bitcoin-fees-20-month-high-miner-revenues-match-69k-btc-price)
 
-[Arbirtrum hit by outage due to Traffic surge - Coindesk](https://www.coindesk.com/tech/2023/12/15/arbitrum-hit-by-partial-outage-due-to-traffic-surge)
+[Arbitrum hit by outage due to Traffic surge - Coindesk](https://www.coindesk.com/tech/2023/12/15/arbitrum-hit-by-partial-outage-due-to-traffic-surge)
 
 [Ledger exploit now fixed - Trustnodes](https://www.trustnodes.com/2023/12/14/ledger-exploit-now-fixed)
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `messeges` to `messages`
Corrected `adequete` to `adequate`
Corrected `Arbirtrum` to`Arbitrum`

Please review the changes and let me know if any additional changes are needed.