### PR TITLE
fix: update broken system architecture link

### DIFF
--- a/site/guides/Zingolib_and_Zaino_Tutorial.md
+++ b/site/guides/Zingolib_and_Zaino_Tutorial.md
@@ -11,7 +11,7 @@
 
 ## Big Picture
 
-[System Architecture](https://github.com/zingolabs/zaino/blob/dev/docs/live_system_architecture.pdf)
+[System Architecture](https://github.com/zingolabs/zaino/blob/dev/docs/zaino_live_system_architecture.pdf)
 
 - Zcash User Installs/Compiles Zingolib Which gives access to zingo-cli. They can send/recieve ZEC as needed.
 - Zingo-cli connects to zaino either locally or via a secure channel online (Zcash user doesnt care how this works!)


### PR DESCRIPTION
Replaced dead link to live_system_architecture.pdf with the correct zaino_live_system_architecture.pdf path in Zingolib_and_Zaino_Tutorial.md to ensure the doc renders properly.