### PR TITLE
Zcash Community Grants proposal submission guide

### DIFF
--- a/site/Zcash_Organizations/Zcash_Community_Grants.md
+++ b/site/Zcash_Organizations/Zcash_Community_Grants.md
@@ -32,6 +32,130 @@ The Zcash Community Grants is an independent organization from the Electric Coin
 
 The Electric Coin Company receives 8% of the [Zcash development fund](https://zips.z.cash/zip-1014). They use these funds to support third party development teams and also for internal operations.
 
+## How to Submit a Zcash Community Grants (ZCG) Proposal
+
+The **Zcash Community Grants (ZCG)** program funds projects that grow and strengthen the Zcash ecosystem — including software, infrastructure, research, education, and community initiatives.
+
+Submitting a proposal is open to anyone.
+
+The process has **three main stages**:
+
+1. Prepare your proposal  
+2. Submit it on GitHub  
+3. Share it on the Zcash Community Forum for discussion  
+
+After this, the ZCG committee reviews your proposal and decides whether to approve funding.
+
+
+## 1️⃣ Prepare Your Proposal
+
+Before submitting, prepare a clear written proposal that explains:
+
+### Problem Statement
+What problem or opportunity does your project address?
+
+### Proposed Solution
+What will you build or deliver?
+
+### Impact on Zcash
+How will your project benefit the ecosystem?
+
+### Team Background
+Include:
+- names or organization
+- relevant experience
+- prior work (if available)
+
+### Milestones
+Break your project into measurable deliverables.
+
+### Budget
+Include:
+- total amount requested
+- how funds will be used
+- milestone-based payments (if applicable)
+
+### Timeline
+How long the project will take.
+
+### Success Metrics
+How progress and success will be measured.
+
+
+## 2️⃣ Submit Your Proposal on GitHub
+
+ZCG uses **GitHub Issues as the official submission platform**.
+
+### Steps
+
+1. Log in to GitHub  
+   https://github.com  
+
+2. Open the **ZCG GitHub repository**  
+   https://github.com/ZcashCommunityGrants/zcashcommunitygrants  
+
+3. Click **“Issues”**
+
+4. Click **“New Issue”**
+
+5. Select the **Grant Proposal template** (if available)
+
+6. Add:
+   - A clear proposal title  
+     Example: `Grant Proposal: Zcash Education Portal`
+   - Your full proposal in the description field
+  
+   
+
+ **Complete all required checkboxes and provide full project details within the form.**
+
+7. Review and submit the issue
+
+This GitHub Issue becomes your **official grant submission record**.
+
+You may receive questions or feedback — replying promptly helps the review process.
+
+
+## 3️⃣ Share Your Proposal on the Zcash Community Forum
+
+Posting to the Forum is required so the community can review and discuss your proposal.
+
+### Steps
+
+1. Log in or sign up here  
+   https://forum.zcashcommunity.com  
+
+2. Go to the **Grants category**  
+   https://forum.zcashcommunity.com/c/grants/33  
+
+3. Create a **new topic**
+
+4. Include:
+   - your proposal title
+   - a short summary
+   - a link to your GitHub proposal
+
+5. Publish the topic
+
+## 🎥 Tutorial Video
+
+For a visual walkthrough of the submission process:
+
+[How to Submit a ZCG Grant Proposal](https://www.youtube.com/watch?v=ItEwc1lzvzc)
+
+
+## 🔗 Useful Links
+
+- **Zcash Forum — Grants Section**  
+  https://forum.zcashcommunity.com/c/grants/33  
+
+- **ZCG GitHub Repository**  
+  https://github.com/ZcashCommunityGrants/zcashcommunitygrants  
+
+- **ZCG Website**  
+  https://zcashcommunitygrants.org  
+
+
 ## Resources
 
 [Zcash development and governance](https://z.cash/zcash-development-and-governance/)


### PR DESCRIPTION
Added detailed instructions for submitting a Zcash Community Grants proposal, including preparation steps, submission on GitHub, and sharing on the community forum.