### PR TITLE
Update ZecHub Wiki with custodial exchange

### DIFF
--- a/newsletter/Update Custodial Exchanges – ZecHub Wiki .md
+++ b/newsletter/Update Custodial Exchanges – ZecHub Wiki .md
@@ -1,0 +1,148 @@
+# Custodial Wallets & Exchanges Supporting Zcash (ZEC)
+
+The following custodial wallets and exchanges support **Zcash (ZEC)**.  
+Custodial services hold users’ private keys and manage deposits and withdrawals on their behalf.
+
+> ⚠️ **Privacy Notice**  
+> Most custodial services support **transparent (t-address) ZEC only**.  
+> **Gemini** is currently the only major custodial provider that supports **shielded ZEC withdrawals**.
+
+
+### Binance
+![Binance Logo](../assets/img/exchanges/binance.png)
+
+**Website:** https://www.binance.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent (t-address)
+- **Deposit Time:** ~20 minutes
+
+
+### Bitfinex
+![Bitfinex Logo](../assets/img/exchanges/bitfinex.png)
+
+**Website:** https://www.bitfinex.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~25 minutes
+
+
+### Coinbase
+![Coinbase Logo](../assets/img/exchanges/coinbase.png)
+
+**Website:** https://www.coinbase.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent (withdrawals only)
+- **Deposit Time:** ~150 minutes
+
+
+### Gemini
+![Gemini Logo](../assets/img/exchanges/gemini.png)
+
+**Website:** https://www.gemini.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent deposits, **Shielded withdrawals**
+- **Deposit Time:** ~50 minutes
+
+
+### HTX (Huobi)
+![HTX Logo](../assets/img/exchanges/htx.png)
+
+**Website:** https://www.htx.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~35 minutes
+
+
+### Kraken
+![Kraken Logo](../assets/img/exchanges/kraken.png)
+
+**Website:** https://www.kraken.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~60 minutes
+
+
+### KuCoin
+![KuCoin Logo](../assets/img/exchanges/kucoin.png)
+
+**Website:** https://www.kucoin.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~20 minutes
+
+
+### OKX
+![OKX Logo](../assets/img/exchanges/okx.png)
+
+**Website:** https://www.okx.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~25 minutes
+
+
+### CoinEx
+![CoinEx Logo](../assets/img/exchanges/coinex.png)
+
+**Website:** https://www.coinex.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~15 minutes
+
+
+### WhiteBIT
+![WhiteBIT Logo](../assets/img/exchanges/whitebit.png)
+
+**Website:** https://whitebit.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~20 minutes
+
+
+### MEXC
+![MEXC Logo](../assets/img/exchanges/mexc.png)
+
+**Website:** https://www.mexc.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~30 minutes
+
+
+### Poloniex
+![Poloniex Logo](../assets/img/exchanges/poloniex.png)
+
+**Website:** https://poloniex.com/
+
+- **Pairs:** ALL / ZEC
+- **Supports:** Transparent
+- **Deposit Time:** ~20 minutes
+
+
+## Notes
+
+- **Shielded ZEC withdrawals** are currently supported **only by Gemini**.
+-  **Shielded ZEC** refers to withdrawals sent directly to **z-addresses or Unified Addresses**, preserving on-chain privacy.
+- All other custodial exchanges listed support **transparent ZEC only**.
+- **Transparent ZEC** uses legacy transparent addresses and does **not** provide transaction privacy.
+- Deposit times are approximate and may vary depending on network conditions.
+- Custodial services may change ZEC support policies due to regulatory or compliance requirements.
+
+
+## Recommendation
+
+For maximum privacy, users are encouraged to withdraw ZEC to a **self-custodial wallet** and shield funds using wallets that support **Unified Addresses**.
+
+
+## Related Pages
+
+- [Custodial Wallets Supporting Zcash](https://zechub.wiki/using-zcash/custodial-exchanges)


### PR DESCRIPTION
Added details for various custodial exchanges supporting ZEC, including deposit times and withdrawal types.