### PR TITLE
docs: add ZODL (Zcash Open Development Lab) wiki page

### DIFF
--- a/site/Zcash_Organizations/ZODL.md
+++ b/site/Zcash_Organizations/ZODL.md
@@ -1,0 +1,56 @@
+# <img src="https://github.com/user-attachments/assets/198608b2-9059-4cb7-aeb8-9354971376fd" alt="ZODL Logo" width="50"/> ZODL (Zcash Open Development Lab)
+
+[Official Website](https://zodl.com/) - [App Store](https://apps.apple.com/app/zodl/id6444974742) - [X/Twitter](https://x.com/zodl_app) - [Support](https://forum.zcashcommunity.com)
+
+ZODL (Zcash Open Development Lab) is a team dedicated to building user-friendly privacy-focused cryptocurrency products. Formerly known as Zashi, ZODL continues the mission of making Zcash accessible to everyone while maintaining the highest standards of financial privacy.
+
+## History
+
+ZODL emerged from the Zashi project, which was originally developed by the Electric Coin Company (ECC) team. Following a resolution to the Zashi dispute that led to ECC team members leaving and forming ZODL, the same core team returned to work on making Zcash stronger through the ZODL wallet.
+
+## Products
+
+### ZODL Wallet
+
+ZODL is a fully-featured mobile wallet designed for the modern Zcash user. It offers a seamless experience for both beginners and advanced users.
+
+**Key Features:**
+- **Multi-Pool Support:** Transparent, Sapling, and Orchard pools
+- **Coinbase Integration:** Buy ZEC directly from the wallet using Coinbase
+- **Shielded by Default:** ZEC from Coinbase must be shielded for privacy
+- **Unified Addresses:** Simplified address management
+- **Shielded Memos:** Private communication capabilities
+- **Address Book:** Save frequently used addresses
+- **Payment Requests:** Easy request for payments
+- **TEX Addresses:** Support for transparent addresses
+- **Tor Support:** Enhanced privacy for network traffic
+- **Flexa Payments:** Spend ZEC at participating retailers
+- **DEX Swaps:** In-wallet cryptocurrency swaps
+- **CrossPay:** Cross-chain payment capabilities
+- **MultiSignature:** Additional security for transactions
+
+**Platforms:**
+- iOS (App Store)
+- Coming soon to Android
+
+### Guardian of the Sovereign
+
+ZODL's philosophy centers on the concept of "Guardian of the Sovereign" - empowering users to maintain full control over their financial privacy and sovereignty.
+
+## ZODL and the Zcash Ecosystem
+
+ZODL plays a vital role in the Zcash ecosystem by:
+
+1. **Improving Accessibility:** Making ZEC purchases easy through Coinbase integration
+2. **Privacy Education:** Helping users understand the importance of shielding transactions
+3. **User Experience:** Continuously improving the wallet interface for mainstream adoption
+4. **Innovation:** Contributing to Zcash development through ongoing updates and features
+
+## See Also
+
+- [ZODL Website](https://zodl.com/)
+- [ZODL App Store](https://apps.apple.com/app/zodl/id6444974742)
+- [ZODL Twitter](https://x.com/zodl_app)
+- [Zcash Foundation](../Zcash_Foundation.md)
+- [Electric Coin Company](../Electric_Coin_Company.md)
+- [Zingo Labs](../Zingo_Labs.md)


### PR DESCRIPTION
## Summary

Add Zcash Open Development Lab (ZODL) wiki page to the Zcash Organizations directory per issue #1497.

## Changes

- Created  with:
  - ZODL history and background (formerly Zashi)
  - ZODL wallet features (Coinbase integration, shielded transactions, etc.)
  - Guardian of the Sovereign philosophy
  - Role in Zcash ecosystem

## Bounty Claim

Claiming bounty for issue #1497 - Create wiki page - Zcash Organisations: ZODL (0.17 ZEC)