### PR TITLE
Add ZODL organization wiki page

### DIFF
--- a/site/Zcash_Organizations/ZODL.md
+++ b/site/Zcash_Organizations/ZODL.md
@@ -1,0 +1,44 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Organizations/ZODL.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZODL
+
+[Official Website](https://zodl.com/)
+
+## Overview
+
+ZODL is a Zcash-powered mobile wallet project focused on private, self-custodial digital payments. The product messaging emphasizes financial sovereignty, strong privacy defaults, and ease of use for people who are new to crypto.
+
+## Mission and Principles
+
+ZODL frames its mission around bringing private money to everyday users through three core principles:
+
+- **Privacy first**: built for shielded Zcash usage
+- **Self-custody**: users keep control of keys and funds
+- **Consent and transparency**: users should understand tradeoffs before acting
+
+## Product Capabilities
+
+Based on publicly shared product information, ZODL highlights:
+
+- **Shielded ZEC payments** for private peer-to-peer transactions
+- **CrossPay** to send shielded ZEC while recipients can receive another asset
+- **Swaps** between shielded ZEC and other crypto assets
+- **Hardware wallet support** (including Keystone for shielded ZEC workflows)
+- **Retail spending integrations** for real-world purchases
+- **1-click shielding** to move transparent ZEC into shielded balances
+- **Shielded notes** for private encrypted messages attached to transactions
+
+## Privacy Position
+
+ZODL states that it does not track wallet activity or collect user behavior analytics, and that only anonymized crash reporting is used for stability and bug fixing.
+
+## Relevance to the Zcash Ecosystem
+
+ZODL contributes to Zcash adoption by making shielded transactions more accessible on mobile, reducing onboarding friction, and extending private-payment UX to broader real-world use cases.
+
+## References
+
+- [ZODL website](https://zodl.com/)
+- [ZODL on X](https://x.com/getzodl)


### PR DESCRIPTION
## Summary
- add new `site/Zcash_Organizations/ZODL.md` page for Zcash Open Development Lab (ZODL)
- include mission/principles, product capabilities, privacy position, and ecosystem relevance
- add references to official website and X profile

## Validation
- verified markdown structure and links in the new page

Closes #1497