### PR TITLE
Add Use Zcash in the Real World wiki page

### DIFF
--- a/site/zcash-use-case/Accept_Payments_as_a_Merchant.md
+++ b/site/zcash-use-case/Accept_Payments_as_a_Merchant.md
@@ -1,0 +1,345 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zcash-use-case/Accept_Payments_as_a_Merchant.md" target="_blank"><img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/></a>
+
+
+# Accept Payments as a Merchant with Zcash
+
+Running a business that accepts Zcash gives you and your customers financial privacy that traditional payment processors simply cannot match. No chargebacks from payment processors, no frozen accounts, no 3% processing fees, and no customer data stored on third-party servers.
+
+This guide covers everything a merchant needs to know — from setting up a Zcash wallet for business use to integrating payments into your website or physical store.
+
+---
+
+## Why Merchants Should Consider Zcash
+
+### Advantages Over Traditional Payment Processors
+
+| Feature | Credit Cards | PayPal | Zcash |
+|---------|-------------|--------|-------|
+| Transaction Fee | 2.9% + $0.30 | 2.9% + $0.30 | < $0.01 |
+| Chargeback Risk | High | High | None |
+| Account Freezes | Possible | Common | Impossible |
+| Customer Privacy | Limited | Limited | Strong |
+| Settlement Time | 2-7 days | Instant (to PayPal) | ~2.5 minutes |
+| Cross-Border Fees | 1-4% extra | 4-5% extra | None |
+| Self-Custody | No | No | Yes |
+
+### Why Customer Privacy Matters to Merchants
+
+- **Competitive advantage** — Privacy-conscious customers actively seek merchants who accept Zcash
+- **Reduced liability** — You don't store customer financial data, so there's nothing to leak in a breach
+- **Global reach** — Accept payments from anyone with internet access, regardless of their banking situation
+- **No discrimination** — You can't discriminate based on a customer's financial history because you don't see it
+- **Lower costs** — Near-zero transaction fees mean better margins or lower prices for customers
+
+### Who Should Use This Guide
+
+- Online store owners
+- Service providers (consultants, designers, developers)
+- Physical retailers wanting to accept crypto
+- Digital product sellers
+- Subscription service operators
+- Anyone selling goods or services online
+
+---
+
+## Step 1: Set Up Your Merchant Wallet
+
+### Choose Your Wallet Strategy
+
+As a merchant, you need a wallet solution that balances convenience, security, and privacy.
+
+### Option A: Ywallet (Small to Medium Volume)
+
+For merchants processing a moderate number of transactions:
+
+1. **Install Ywallet** on a dedicated device — [ywallet.app](https://ywallet.app/)
+2. **Create a new merchant wallet** — Don't mix personal and business funds
+3. **Back up the recovery phrase** — Store it in a secure location (safe, bank deposit box)
+4. **Generate your primary receiving address** — This is your main business shielded address
+
+### Option B: ZecWallet Lite + Full Node (Medium to High Volume)
+
+For higher-volume merchants:
+
+1. **Install ZecWallet Lite** on your business computer — [zecwallet.co](https://www.zecwallet.co/)
+2. **Run a Zcash full node** (zcashd or zebrad) for maximum independence
+   - Full node: [Zcashd](https://github.com/zcash/zcash) — Requires ~100GB storage
+   - Lighter alternative: [Zebrad](https://github.com/ZcashFoundation/zebra) — Written in Rust
+3. **Connect ZecWallet Lite to your node** for direct, trustless transaction verification
+
+### Option C: BTCPay Server (Professional Setup)
+
+For merchants who want a complete payment processing solution:
+
+1. **Set up BTCPay Server** — [btcpayserver.org](https://btcpayserver.org/)
+2. BTCPay Server supports Zcash and provides:
+   - Professional invoicing system
+   - Payment buttons for your website
+   - Point-of-sale interface for physical stores
+   - Automatic payment detection
+   - Multi-user access for staff
+   - Integration with accounting software
+3. **Self-hosted** — You control everything, no third party
+
+### Best Practices for Merchant Wallets
+
+- **Use a dedicated device** for your merchant wallet when possible
+- **Enable all security features** — PIN, biometrics, encryption
+- **Keep the wallet software updated** — Security patches are critical
+- **Maintain a cold storage strategy** — Move excess profits to cold storage regularly
+- **Separate addresses** — Use different addresses for different products or services
+
+---
+
+## Step 2: Generate Payment Requests
+
+### Basic Payment Request
+
+For simple, one-off transactions:
+
+1. **Determine the amount** — In ZEC or in fiat with real-time conversion
+2. **Generate a new shielded address** for this payment
+3. **Share the address and amount** with the customer
+4. **Wait for confirmation** (~2.5 minutes)
+5. **Confirm receipt** and fulfill the order
+
+### Creating Payment Requests with Specific Amounts
+
+**In Ywallet:**
+1. Go to **Receive**
+2. Enter the **amount** you're requesting
+3. The wallet generates a QR code containing both the address and amount
+4. Share the QR code or the address with the customer
+
+**In BTCPay Server:**
+1. Create a **new invoice** in the dashboard
+2. Enter the amount (in fiat or ZEC)
+3. BTCPay generates a payment page with QR code
+4. Send the payment link to the customer or embed it on your website
+
+### Handling Fiat-Priced Products
+
+If your products are priced in fiat currency:
+
+1. Use a **live price feed** to convert fiat to ZEC at the current exchange rate
+2. **BTCPay Server** handles this automatically with configurable rate sources
+3. For manual conversion, check [CoinGecko](https://www.coingecko.com/en/coins/zcash) or [CoinMarketCap](https://coinmarketcap.com/currencies/zcash/)
+4. Consider **adding a small buffer** (1-2%) to account for price volatility during the payment window
+5. Set a **payment window** (e.g., 15 minutes) during which the rate is locked
+
+---
+
+## Step 3: Integrate Zcash Payments into Your Website or Store
+
+### Online Store Integration
+
+#### Option A: BTCPay Server (Recommended)
+
+BTCPay Server is the gold standard for self-hosted crypto payment processing:
+
+1. **Install BTCPay Server** on a VPS or local server
+   - [Docker deployment](https://docs.btcpayserver.org/Docker/) — Recommended
+   - [LunaNode deployment](https://docs.btcpayserver.org/LunaNodeWebDeployment/) — One-click
+   - [Raspberry Pi deployment](https://docs.btcpayserver.org/RaspberryPi/) — Low cost
+2. **Add Zcash as a payment method** in BTCPay Server settings
+3. **Connect your Zcash wallet** to BTCPay Server
+4. **Create payment buttons** or embed the checkout on your site
+5. **Configure webhooks** for automatic order fulfillment
+
+BTCPay Server works with:
+- **WooCommerce** (WordPress)
+- **Shopify** (via manual integration)
+- **PrestaShop**
+- **Custom websites** (via API)
+- **Lightning Network** and other cryptocurrencies alongside Zcash
+
+#### Option B: Manual Integration
+
+For simple websites or landing pages:
+
+1. **Add a payment section** to your website:
+   ```html
+   <h3>Pay with Zcash</h3>
+   <p>Send ZEC to the address below:</p>
+   <div id="zcash-address">
+     <img src="your-qr-code.png" alt="Zcash Payment QR Code">
+     <code>zs1yourshieldedaddress...</code>
+   </div>
+   <p>Amount: <span id="amount">0.1 ZEC</span></p>
+   <p>Transaction confirms in ~2.5 minutes</p>
+   ```
+
+2. **Monitor your wallet** for incoming payments
+3. **Manually confirm** and fulfill orders
+
+#### Option C: Payment Link Service
+
+Some services generate payment links without requiring self-hosting:
+
+- Share a payment link via email or messaging
+- Customer clicks the link, sees the amount and address
+- Customer pays from their wallet
+
+### Physical Store (Point of Sale)
+
+#### Using Ywallet Mobile
+
+1. Open Ywallet on your phone
+2. Enter the sale amount
+3. Show the QR code to the customer
+4. Customer scans and pays from their wallet
+5. Confirm receipt on your device
+
+#### Using BTCPay Server POS
+
+1. Set up BTCPay Server with a tablet or dedicated device
+2. Use the **Point of Sale app** built into BTCPay Server
+3. Enter items or total amount
+4. Customer sees the payment QR code on screen
+5. Payment is confirmed automatically
+
+### Subscription and Recurring Payments
+
+For subscription-based businesses:
+
+1. **Manual approach** — Generate a new invoice each billing period and send it to subscribers
+2. **BTCPay Server** — Supports recurring payment plans and subscription management
+3. **Customer responsibility** — Unlike credit card auto-charging, the customer must initiate each payment. Clear communication about payment deadlines is essential
+
+---
+
+## Step 4: Handling Refunds
+
+Refunds with Zcash work differently than with traditional payment processors. There are no chargebacks, but you can voluntarily refund customers when appropriate.
+
+### Refund Process
+
+1. **Verify the original transaction** in your wallet history
+2. **Get the customer's shielded address** for the refund
+   - Important: Ask the customer to provide their **current** shielded address
+   - Don't assume the sending address is their receiving address (in shielded transactions, these are separate)
+3. **Send the refund amount** from your wallet to the customer's shielded address
+4. **Notify the customer** that the refund has been sent
+5. **Record the refund** in your accounting
+
+### Refund Best Practices
+
+- **Establish a clear refund policy** — Publish it on your website
+- **Set time limits** — e.g., "Refunds available within 30 days of purchase"
+- **Document everything** — Keep records of original transactions and refunds
+- **Communicate clearly** — Let customers know refunds go to their Zcash wallet, not back to their original payment method
+
+### Handling Disputes
+
+Without chargebacks, disputes must be resolved directly:
+
+- **Maintain good customer communication** — Most disputes are resolved through dialogue
+- **Document all interactions** — Keep records of customer communications
+- **Offer partial refunds** when appropriate
+- **Use escrow for high-value transactions** — Consider a trusted third party to hold funds until both parties are satisfied
+
+---
+
+## Step 5: Accounting and Record-Keeping
+
+### Essential Records to Maintain
+
+For every transaction, record:
+
+1. **Date and time** of the transaction
+2. **Transaction ID** (txid) for blockchain reference
+3. **Amount in ZEC** received
+4. **Fiat equivalent** at time of transaction
+5. **Customer identifier** (order number, invoice number)
+6. **Product or service** sold
+7. **Payment status** (confirmed, pending, refunded)
+
+### Accounting Tools
+
+#### Spreadsheets
+
+A well-organized spreadsheet works for most small merchants:
+
+| Date | TxID | ZEC Amount | USD Value | Customer | Product | Status |
+|------|------|------------|-----------|----------|---------|--------|
+| 2025-01-15 | abc123... | 0.5 | $158.50 | Order #1001 | Consulting | Confirmed |
+
+#### Cryptocurrency Accounting Software
+
+- **[Koinly](https://koinly.io/)** — Import wallet data and generate tax reports
+- **[CoinTracker](https://www.cointracker.io/)** — Portfolio tracking and tax calculations
+- **[Cryptio](https://cryptio.co/)** — Enterprise-grade crypto accounting
+
+#### BTCPay Server Reporting
+
+If using BTCPay Server:
+- Built-in reporting dashboard
+- Export data as CSV
+- Integration with accounting software via plugins
+
+### Tax Considerations
+
+**⚠️ Consult a tax professional for advice specific to your jurisdiction.**
+
+General considerations for merchants accepting Zcash:
+
+- **Sales tax** — May apply depending on your jurisdiction and what you're selling
+- **Income tax** — ZEC received is income at its fair market value when received
+- **Capital gains/losses** — If ZEC changes in value between receipt and conversion to fiat
+- **Record-keeping requirements** — Most jurisdictions require detailed transaction records
+- **Reporting thresholds** — Some jurisdictions have specific thresholds for cryptocurrency reporting
+
+### Privacy and Accounting
+
+Your shielded transactions are private on the blockchain, but **you still need to maintain accurate records for your own accounting and tax purposes**:
+
+- Export your wallet's transaction history regularly
+- Keep your records secure and backed up
+- Consider encrypting your accounting data
+- Use privacy-respecting accounting tools when available
+
+---
+
+## Step 6: Customer Education
+
+Many customers won't know how to use Zcash. Providing clear instructions can significantly increase adoption.
+
+### What to Include on Your Payment Page
+
+1. **What is Zcash?** — Brief explanation:
+   > "Zcash is a privacy-focused digital currency. Transactions are fast, cheap, and private."
+
+2. **How to Get ZEC:**
+   - Link to [exchanges where ZEC can be purchased](https://coinmarketcap.com/currencies/zcash/#Markets)
+   - Mention that many people already hold ZEC in their crypto portfolios
+
+3. **How to Pay:**
+   - "1. Get a Zcash wallet (try [Ywallet](https://ywallet.app/))"
+   - "2. Send ZEC to the address shown below"
+   - "3. Payment confirms in ~2.5 minutes"
+
+4. **Why Use Zcash?**
+   - Lower fees for both you and the customer
+   - No need to share credit card information
+   - Private transactions
+   - Works globally without banking restrictions
+
+---
+
+## External Resources
+
+- [BTCPay Server](https://btcpayserver.org/) — Self-hosted payment processor with Zcash support
+- [Ywallet](https://ywallet.app/) — Mobile and desktop wallet
+- [ZecWallet Lite](https://www.zecwallet.co/) — Desktop light wallet
+- [Zcashd Full Node](https://github.com/zcash/zcash) — Run your own node
+- [Zebrad](https://github.com/ZcashFoundation/zebra) — Rust-based Zcash node
+- [CoinGecko ZEC](https://www.coingecko.com/en/coins/zcash) — Price tracking
+- [Zcash Merchant Resources](https://z.cash/business/) — Official Zcash business guide
+
+---
+
+## What's Next?
+
+Now that you can accept payments privately as a merchant, the next level of Zcash mastery involves **managing community funds** with privacy. The next guide covers setting up a private treasury for DAOs, community groups, and organizations.
+
+→ **[Step 5: Run a Private Community Treasury](Run_a_Private_Community_Treasury.md)**

--- a/site/zcash-use-case/Freelancer_Privacy_Setup.md
+++ b/site/zcash-use-case/Freelancer_Privacy_Setup.md
@@ -1,0 +1,292 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zcash-use-case/Freelancer_Privacy_Setup.md" target="_blank"><img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/></a>
+
+
+# Freelancer Privacy Setup with Zcash
+
+As a freelancer, your financial data is one of your most sensitive assets. Every client payment reveals information about who you work for, how much you charge, and your income patterns. Traditional payment systems — bank transfers, PayPal, Stripe — create permanent records that can be accessed by governments, hackers, competitors, and even the platforms themselves.
+
+Zcash offers freelancers a way to receive payments while keeping your client list, rates, and income private. This guide walks you through setting up a complete privacy-preserving financial workflow for freelance work.
+
+---
+
+## Why Freelancers Need Financial Privacy
+
+### The Problem with Traditional Payments
+
+When you accept payment through conventional channels:
+
+- **Your clients can see your total account balance** and transaction history through bank statements
+- **Payment processors build profiles** of your income, clients, and spending habits
+- **Tax authorities receive reports** from payment processors (e.g., 1099-K in the US for transactions over $600)
+- **Competitors can estimate your income** if they know your client list and typical rates
+- **Data breaches** can expose your financial information to criminals
+
+### How Zcash Helps
+
+- **Client privacy:** Clients pay you without their payment being publicly linked to you
+- **Income privacy:** Your total earnings are invisible to anyone except you
+- **Client list privacy:** Nobody can see who has paid you
+- **Rate privacy:** Your per-project rates are not visible on any public ledger
+- **Global payments:** No need for international wire fees or currency conversion through banks
+- **Self-custody:** You control your funds — no bank can freeze or seize them
+
+### Who Benefits Most
+
+- Freelancers in countries with unstable currencies or restrictive banking
+- Privacy-conscious professionals who don't want their income public
+- Contractors working with multiple clients who prefer discretion
+- Open-source developers receiving sponsorships
+- Consultants handling sensitive projects for competing companies
+- Anyone who believes financial privacy is a fundamental right
+
+---
+
+## Step 1: Set Up a Dedicated Freelance Wallet
+
+Using a separate wallet for freelance income — distinct from your personal spending wallet — is a fundamental best practice.
+
+### Why a Separate Wallet?
+
+- **Clean accounting** — Easy to track freelance income separately
+- **Privacy isolation** — If one address is linked to your identity, it doesn't reveal your personal finances
+- **Tax preparation** — Simplifies calculating income for tax reporting
+- **Risk management** — If one wallet is compromised, the other remains safe
+
+### Setting Up Ywallet for Freelance Use
+
+1. **Install Ywallet** on your device (if not already installed) — see [Step 1](Receive_Donations_Privately.md) for installation instructions
+2. **Create a new wallet** specifically for freelance income
+   - Open Ywallet → Create New Wallet
+   - Write down the recovery phrase and store it securely
+   - Give this wallet a clear label (e.g., "Freelance Income")
+3. **Generate your first shielded address**
+   - Go to Receive → Copy your shielded address (starts with `zs1` or `u1`)
+   - This is your primary freelance receiving address
+
+### Alternative: Multiple Wallets for Multiple Income Streams
+
+If you have different types of freelance work (e.g., consulting, writing, development), consider creating separate wallets or at least separate addresses for each stream:
+
+- **Wallet A** — Consulting clients
+- **Wallet B** — Writing/content clients
+- **Wallet C** — Development projects
+
+This makes it trivially easy to track income by category without needing additional accounting software.
+
+---
+
+## Step 2: Create Unique Addresses for Each Client
+
+For maximum privacy and accounting clarity, generate a **unique receiving address for each client**.
+
+### Why Client-Specific Addresses?
+
+- **Instant income tracking** — You immediately know which client paid by which address received funds
+- **Reduced linkability** — If one address is somehow linked to your identity, it doesn't connect all your clients together
+- **Professional appearance** — Providing a dedicated address per client looks more organized
+- **Dispute resolution** — If a client claims they didn't pay, you can check the specific address assigned to them
+
+### How to Generate New Addresses
+
+**In Ywallet:**
+1. Go to the **Receive** section
+2. Tap **New Address** or similar option
+3. Ywallet generates a fresh shielded address
+4. Label this address with the client's name or project code (privately, in your records)
+5. Share this address with the client
+
+**In ZecWallet Lite:**
+1. Go to **Receive**
+2. Click **New Address**
+3. The wallet generates a new shielded address
+4. Record the address-to-client mapping in your private records
+
+### Best Practices for Address Management
+
+- **Keep a private mapping** — Maintain a spreadsheet or notebook linking addresses to clients
+- **One address per project** — For larger projects with milestone payments, consider one address per milestone
+- **Don't reuse addresses** for different clients
+- **Archive old addresses** — Once a client relationship ends, note the final payment and archive the address
+
+---
+
+## Step 3: Invoicing and Payment Workflow
+
+### Creating Professional Invoices
+
+Your invoice should include:
+
+1. **Your freelance business name** (or pseudonym, if you prefer)
+2. **Project description** and deliverables
+3. **Payment amount** in ZEC (or your local currency equivalent)
+4. **Your shielded Zcash address** — the client-specific address you generated
+5. **Payment deadline**
+6. **Optional: QR code** for the address (makes mobile payment easier)
+
+### Invoice Template
+
+```
+INVOICE #001
+─────────────────────────────────────
+From: [Your Name/Pseudonym]
+To: [Client Name]
+Date: [Date]
+Due: [Payment Deadline]
+
+Description: [Project/Service Description]
+Amount: [X.XXXXX ZEC] (≈ $[USD equivalent])
+
+Payment Method: Zcash (ZEC)
+Shielded Address: zs1...[your address]
+[QR Code]
+
+Please send payment to the above Zcash shielded address.
+Transaction will confirm within ~2.5 minutes.
+─────────────────────────────────────
+```
+
+### Communicating Payment Details to Clients
+
+When sending the invoice:
+
+1. **Explain Zcash briefly** — Many clients won't know what Zcash is. A simple explanation:
+   > "I accept payment via Zcash (ZEC), a privacy-focused cryptocurrency. It works like a bank transfer but with stronger privacy protections and lower fees. If you don't have ZEC, you can purchase it on any major exchange."
+
+2. **Provide exchange recommendations** — Suggest reputable exchanges where clients can buy ZEC:
+   - [Kraken](https://www.kraken.com/)
+   - [Binance](https://www.binance.com/)
+   - [Gate.io](https://www.gate.io/)
+   - [Huobi](https://www.huobi.com/)
+
+3. **Include a brief guide** — Point clients to [How to Buy ZEC](https://z.cash/get-zcash/) guides
+
+4. **Offer to help** — Some clients may need guidance on acquiring and sending ZEC. Being helpful here can be a competitive advantage.
+
+### Handling Fiat-to-ZEC Conversion
+
+If a client insists on paying in fiat currency:
+
+1. **Use a peer-to-peer exchange** to convert fiat to ZEC privately
+2. **Receive fiat** through your preferred method (bank transfer, etc.)
+3. **Purchase ZEC** on an exchange
+4. **Immediately shield** the ZEC by sending it to your shielded address
+5. **Note:** This creates a link between your fiat payment and your Zcash address on the exchange side. For full privacy, encourage clients to pay in ZEC directly.
+
+---
+
+## Step 4: Receiving and Confirming Payments
+
+### Payment Confirmation Workflow
+
+1. **Monitor your wallet** — Check for incoming transactions on the addresses you've shared
+2. **Verify the amount** — Confirm the received amount matches the invoice
+3. **Wait for confirmation** — Zcash transactions typically confirm within 2.5 minutes
+4. **Send a receipt** — Once confirmed, send the client a brief confirmation:
+   > "Payment received and confirmed. Thank you!"
+5. **Record the transaction** — Log it in your private accounting system
+
+### Handling Partial Payments
+
+- If a client sends less than the invoiced amount, follow up professionally
+- Zcash's precision (8 decimal places) means they can send the exact amount
+- For milestone-based projects, invoice per milestone rather than one lump sum
+
+### Dealing with Volatility
+
+ZEC's price fluctuates like any cryptocurrency. Consider these approaches:
+
+- **Price in ZEC** — Set your rates in ZEC and accept the volatility (good for long-term holders)
+- **Price in fiat, pay in ZEC** — Quote in your local currency and convert at the current rate at time of invoice. Use a service like [CoinGecko](https://www.coingecko.com/) for live rates
+- **Convert to stablecoin** — If you need stable value, convert received ZEC to a stablecoin through a non-KYC exchange (see [atomic swaps](https://atomic.finance/) or [Trocador](https://trocador.app/))
+
+---
+
+## Step 5: Tax Considerations
+
+**⚠️ Disclaimer: I am not a tax professional. Consult a qualified tax advisor for guidance specific to your jurisdiction.**
+
+### General Principles
+
+In most jurisdictions, cryptocurrency income is treated similarly to fiat income:
+
+- **Income tax** — ZEC received for freelance work is taxable income at its fair market value when received
+- **Capital gains tax** — If ZEC's value increases after you receive it, the gain may be taxable when you sell or spend it
+- **Self-employment tax** — Freelance income may be subject to additional taxes
+
+### Record-Keeping Best Practices
+
+1. **Document every transaction:**
+   - Date and time received
+   - Amount in ZEC
+   - USD (or local currency) value at time of receipt
+   - Client name or identifier
+   - Purpose (project description)
+
+2. **Use accounting tools:**
+   - [Koinly](https://koinly.io/) — Cryptocurrency tax software
+   - [CoinTracker](https://www.cointracker.io/) — Portfolio tracking and tax
+   - A well-organized spreadsheet works for simple setups
+
+3. **Keep records of:**
+   - All invoices sent
+   - All payments received (with ZEC-to-fiat conversion rates)
+   - All expenses related to your freelance work
+   - Any ZEC-to-fiat conversions you make
+
+### Privacy and Tax Reporting
+
+Using Zcash for privacy **does not exempt you from tax obligations**. The goal of this guide is to protect your privacy from unauthorized access — not to evade legal tax requirements.
+
+- Shielded transactions are private on the blockchain, but you still know your own income
+- Report your income honestly based on your own records
+- The privacy Zcash provides protects you from data breaches, corporate surveillance, and unauthorized access — not from legitimate tax obligations
+
+---
+
+## Step 6: Scaling Your Freelance Setup
+
+As your freelance business grows, consider these enhancements:
+
+### Multi-Device Wallet Access
+
+- Ywallet supports multiple devices — install on both your phone and desktop
+- Use the same recovery phrase to access the same wallet from different devices
+- Ensure both devices are equally secure
+
+### Automated Accounting
+
+- Export your wallet's transaction history regularly
+- Use scripts or tools to convert ZEC amounts to fiat values at historical rates
+- Consider integrating with accounting software that supports cryptocurrency
+
+### Accepting Zcash on Your Website
+
+If you have a freelance website or portfolio:
+- Add a "Hire Me" or "Services" page with Zcash as a payment option
+- Include your shielded address or a payment request form
+- Consider integrating with [BTCPay Server](https://btcpayserver.org/) which supports Zcash for automated invoicing
+
+### Building a Reputation
+
+- Privacy doesn't mean anonymity in your professional relationships
+- Build trust through quality work, clear communication, and reliable delivery
+- Your financial privacy and your professional reputation are separate — you can have both
+
+---
+
+## External Resources
+
+- [BTCPay Server with Zcash](https://docs.btcpayserver.org/) — Self-hosted payment processor
+- [Ywallet](https://ywallet.app/) — Recommended freelance wallet
+- [CoinGecko ZEC Price](https://www.coingecko.com/en/coins/zcash) — Live price tracking
+- [Koinly](https://koinly.io/) — Crypto tax reporting
+- [Zcash Community Grants](https://zcashcommunitygrants.org/) — Funding opportunities
+- [Privacy Guides — Freelancer Resources](https://www.privacyguides.org/)
+
+---
+
+## What's Next?
+
+Ready to take your Zcash privacy skills to the next level? The next guide covers how to **accept payments as a merchant** — perfect for online store owners, service providers, and anyone running a business that needs private payment processing.
+
+→ **[Step 4: Accept Payments as a Merchant](Accept_Payments_as_a_Merchant.md)**

--- a/site/zcash-use-case/Journalist_Privacy_Setup.md
+++ b/site/zcash-use-case/Journalist_Privacy_Setup.md
@@ -1,0 +1,358 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zcash-use-case/Journalist_Privacy_Setup.md" target="_blank"><img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/></a>
+
+
+# Journalist Privacy Setup with Zcash
+
+Journalists face some of the highest-stakes financial privacy challenges of any profession. The ability to receive funds from sources, pay confidential informants, and manage operational finances without exposing financial trails can be a matter of source safety — and sometimes, a matter of life and death.
+
+This guide covers the most comprehensive Zcash privacy setup, designed for journalists, whistleblowers, human rights workers, and anyone whose financial privacy is critical to their safety.
+
+**⚠️ Warning: If you are in immediate danger, seek professional security assistance. This guide provides technical guidance but cannot replace personalized security consulting.**
+
+---
+
+## Why Journalists Need Financial Privacy
+
+### The Threat Landscape
+
+Journalists face unique financial surveillance risks:
+
+- **Source protection** — If a government or adversary can trace payments to your sources, those sources are in danger
+- **Operational security** — Financial patterns can reveal your activities, contacts, and locations
+- **Asset protection** — In hostile jurisdictions, journalists' assets may be frozen or seized
+- **Cross-border payments** — International sources and collaborators need payment methods that don't require traditional banking
+- **Legal protection** — In some jurisdictions, journalists can be compelled to reveal financial records
+
+### How Traditional Systems Fail Journalists
+
+- **Bank records** can be subpoenaed, revealing all transactions
+- **Payment processors** (PayPal, Venmo, etc.) share data with governments and advertisers
+- **Credit card transactions** create permanent, searchable records
+- **Wire transfers** expose sender, receiver, and amount to multiple intermediaries
+- **Cash** is increasingly impractical for remote sources and international transactions
+
+### How Zcash Protects Journalists
+
+- **Shielded transactions** hide sender, receiver, and amount from all observers
+- **Self-custody** means no third party can freeze, seize, or report your funds
+- **No KYC required** — You can use Zcash without providing personal information
+- **Global accessibility** — Anyone with internet access can send or receive ZEC
+- **Cryptographic privacy** — Privacy is guaranteed by mathematics, not by corporate policy
+
+---
+
+## Step 1: Secure Wallet Setup
+
+For journalists, wallet security goes beyond the basics. This section covers the most secure setup options.
+
+### Threat Assessment
+
+Before setting up your wallet, assess your threat model:
+
+| Threat Level | Description | Recommended Setup |
+|-------------|-------------|-------------------|
+| **Low** | General privacy concerns, no specific threats | Ywallet on personal device |
+| **Medium** | Government surveillance, hostile employer | Dedicated device + Ywallet + Tor |
+| **High** | Active targeting by state actors | Air-gapped setup + hardware wallet |
+| **Critical** | Life-threatening situation | Full operational security protocol (see Step 5) |
+
+### Standard Secure Setup (Low to Medium Threat)
+
+1. **Use a dedicated device** — A separate phone or laptop used only for Zcash operations
+   - Factory reset the device before setup
+   - Install only essential apps (wallet, Tor browser, secure messaging)
+   - Keep the OS updated with security patches
+   - Enable full-disk encryption
+
+2. **Install Ywallet** — [ywallet.app](https://ywallet.app/)
+   - Download only from the official source
+   - Verify the download signature/hash if available
+   - Install and create a new wallet
+
+3. **Generate and secure your recovery phrase**
+   - Write the 24-word phrase on paper
+   - Never store it digitally
+   - Consider splitting it using [Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing)
+   - Store shares in separate physical locations
+
+4. **Enable Tor routing**
+   - Install [Orbot](https://guardianproject.info/apps/orbot/) (Android) or use [Tor Browser](https://www.torproject.org/)
+   - Configure your wallet to route through Tor
+   - This hides your IP address from Zcash nodes
+
+### Air-Gapped Setup (High Threat)
+
+An air-gapped setup means your wallet device never connects to the internet. This is the gold standard for security.
+
+1. **Requirements:**
+   - Two devices: one online (for viewing balances, checking transactions), one offline (for signing transactions)
+   - USB drive or QR code transfer mechanism
+   - [ZecWallet Offline Signer](https://www.zecwallet.co/) or similar tool
+
+2. **Setup Process:**
+   - **Offline device:** Install wallet, create wallet, generate addresses
+   - **Online device:** Monitor blockchain for incoming transactions
+   - **To receive:** Share your shielded address (can be done via QR code on the offline device, photographed and shared)
+   - **To send:**
+     1. Create an unsigned transaction on the online device
+     2. Transfer the unsigned transaction to the offline device (via USB or QR code)
+     3. Sign the transaction on the offline device
+     4. Transfer the signed transaction back to the online device
+     5. Broadcast the signed transaction from the online device
+
+3. **Hardware Wallet Integration:**
+   - **Trezor Model T** supports Zcash and provides hardware-level security
+   - **Ledger Nano X** also supports Zcash
+   - Hardware wallets keep your private keys on a separate device that never exposes them to your computer
+   - Combine hardware wallet with Tor for maximum security
+
+### Wallet Selection Criteria for Journalists
+
+When choosing a wallet, prioritize:
+
+- **Open source** — Code can be audited by security experts
+- **Active development** — Regular updates and security patches
+- **Shielded-by-default** — Uses shielded addresses automatically
+- **Tor support** — Built-in or easy Tor integration
+- **No telemetry** — Doesn't send usage data to developers
+- **Reproducible builds** — Can verify the binary matches the source code
+
+**Recommended wallets:**
+- [Ywallet](https://ywallet.app/) — Modern, actively developed, open source
+- [ZecWallet Lite](https://www.zecwallet.co/) — Established, well-audited
+- [zcash4win](https://github.com/zechub/zcash4win) — Windows-specific wallet
+
+---
+
+## Step 2: Securely Receiving Funds from Sources
+
+Receiving funds from sources is one of the most sensitive operations a journalist performs. Here's how to do it safely.
+
+### Setting Up Source-Specific Addresses
+
+1. **Generate a unique shielded address for each source**
+   - Never reuse addresses between sources
+   - If one address is compromised, it doesn't expose other sources
+   - Label addresses securely in your private records (use code names, not real names)
+
+2. **Sharing the address with your source**
+   - **In person:** Show the QR code on your device, let them photograph it
+   - **Encrypted messaging:** Use [Signal](https://signal.org/) or [Session](https://getsession.org/) to send the address
+   - **Dead drop:** Leave the address at a physical location (written on paper)
+   - **Never** send addresses via email, SMS, or unencrypted channels
+
+3. **Source education**
+   - Many sources won't know how to use Zcash
+   - Provide clear, simple instructions
+   - Consider setting up a wallet for them if meeting in person
+   - Recommend they use Tor when acquiring and sending ZEC
+
+### Protecting Source Identity
+
+Even with shielded transactions, there are ways a source's identity could be compromised:
+
+1. **Exchange KYC** — If your source buys ZEC on a KYC exchange and sends it directly, the exchange knows the source bought ZEC and when. To mitigate:
+   - Recommend the source use a **non-KYC exchange** or peer-to-peer platform
+   - Suggest the source **shield the funds** (send to their own shielded address) before sending to you
+   - Consider recommending **mining ZEC** directly to a shielded address
+
+2. **Network surveillance** — If a source's internet is monitored:
+   - Recommend they use **Tor** when accessing their wallet
+   - Suggest they use a **public Wi-Fi network** (with Tor) for transactions
+   - For high-risk sources, recommend an **in-person meeting** to transfer funds
+
+3. **Device forensics** — If a source's device is seized:
+   - Recommend they use a **dedicated device** for Zcash operations
+   - Suggest they **delete wallet data** after sending funds
+   - Recommend **full-disk encryption** on all devices
+
+---
+
+## Step 3: Operational Security (OPSEC)
+
+OPSEC is the practice of keeping your operational details secret. For journalists using Zcash, this is critical.
+
+### Communication Security
+
+1. **Use encrypted messaging** for all Zcash-related communications:
+   - [Signal](https://signal.org/) — Best overall, but requires phone number
+   - [Session](https://getsession.org/) — No phone number required, routes through Onion routing
+   - [Briar](https://briarproject.org/) — Peer-to-peer, works offline via Bluetooth/Wi-Fi
+   - [Matrix](https://matrix.org/) — Decentralized, supports E2E encryption
+
+2. **Never discuss Zcash operations on unencrypted channels:**
+   - No email about wallet addresses or transactions
+   - No SMS about financial operations
+   - No social media posts about your Zcash activities
+
+3. **Compartmentalize your communications:**
+   - Use separate accounts/apps for different aspects of your work
+   - Don't mix personal and operational communications
+
+### Device Security
+
+1. **Use separate devices for separate purposes:**
+   - Device A: Personal use (social media, email, etc.)
+   - Device B: Zcash operations (wallet only)
+   - Device C: Source communications (secure messaging only)
+
+2. **Keep devices updated:**
+   - Install security patches promptly
+   - Use automatic updates when possible
+   - Verify updates come from legitimate sources
+
+3. **Physical security:**
+   - Keep devices with you or in a secure location
+   - Use strong passcodes (not simple PINs)
+   - Enable remote wipe capabilities
+   - Consider tamper-evident storage for devices
+
+### Financial OpSec
+
+1. **Don't mix Zcash with identifiable income:**
+   - Keep your Zcash operations separate from your regular banking
+   - Don't deposit Zcash proceeds directly into your personal bank account without considering the implications
+   - If you need to convert to fiat, use methods that preserve privacy
+
+2. **Timing considerations:**
+   - Don't receive funds immediately before or after identifiable events
+   - Vary the timing of transactions to avoid pattern detection
+   - Consider that transaction timing alone can reveal information
+
+3. **Amount considerations:**
+   - Unusual amounts can be identifying (e.g., receiving exactly $5,000.00 worth of ZEC)
+   - Consider receiving round ZEC amounts rather than exact fiat equivalents
+
+---
+
+## Step 4: Emergency Procedures
+
+Things can go wrong. Here's how to prepare for emergencies.
+
+### Wallet Compromise
+
+If you believe your wallet has been compromised:
+
+1. **Immediately move funds** to a new wallet
+   - Create a new wallet on a clean device
+   - Send all funds from the compromised wallet to the new wallet's shielded address
+   - This breaks the link between the old and new addresses
+
+2. **Assume all previous addresses are compromised**
+   - Generate entirely new addresses for all ongoing operations
+   - Notify trusted contacts of your new address through secure channels
+
+3. **Investigate the compromise**
+   - Check for malware on your device
+   - Review your operational security practices
+   - Consider what information may have been exposed
+
+### Device Seizure
+
+If your device is seized or at risk of seizure:
+
+1. **Wipe the device remotely** (if you've set this up in advance)
+2. **Destroy physical backup materials** (paper seed phrases) if safe to do so
+3. **Alert trusted contacts** that your address has changed
+4. **Access funds from a backup** — This is why you should maintain a separate backup wallet with emergency funds
+
+### Source Compromise
+
+If you believe a source has been compromised:
+
+1. **Stop all communications** through potentially compromised channels
+2. **Move any pending funds** — If the source was about to send you ZEC, provide a new address through a secure channel
+3. **Assess what information may have been exposed**
+4. **Consider the safety of the source** and take appropriate action
+
+### Duress Scenario
+
+If you are being coerced to reveal wallet access:
+
+1. **Maintain a decoy wallet** with a small amount of funds
+   - If coerced, reveal the decoy wallet's seed phrase
+   - Your real funds remain in the hidden wallet
+2. **Use plausible deniability features** if your wallet supports them
+3. **Know your legal rights** regarding compelled decryption in your jurisdiction
+
+---
+
+## Step 5: Converting to Fiat (When Necessary)
+
+Sometimes you need to convert ZEC to fiat currency. Here's how to do it while preserving as much privacy as possible.
+
+### Options for Converting ZEC to Fiat
+
+1. **Peer-to-peer exchanges** — [HodlHodl](https://hodlhodl.com/), [Bisq](https://bisq.network/)
+   - No KYC required
+   - Trade directly with other individuals
+   - Payment via bank transfer, cash, or other methods
+
+2. **Non-KYC exchanges** — Some exchanges don't require identity verification
+   - Research current options as they change frequently
+   - Use Tor when accessing these services
+   - Be aware of legal implications in your jurisdiction
+
+3. **Bitcoin ATMs** — Some accept ZEC or can be used after converting ZEC to BTC
+   - Pay in cash
+   - No identity verification (below certain limits)
+   - Higher fees but good for small amounts
+
+4. **Direct ZEC-to-fiat trades** — Find trusted individuals in your community
+   - Meet in person
+   - Exchange ZEC for cash
+   - Build trusted relationships over time
+
+### Best Practices for Fiat Conversion
+
+- **Convert small amounts regularly** rather than large amounts at once
+- **Use different methods** for different conversions to avoid pattern detection
+- **Don't convert immediately** after receiving funds — wait a variable period
+- **Keep records** of conversions for your own accounting (securely)
+
+---
+
+## External Resources
+
+- [Freedom of the Press Foundation](https://freedom.press/) — Journalist security resources
+- [Committee to Protect Journalists](https://cpj.org/) — Press freedom and safety
+- [Security in a Box](https://securityinabox.org/) — Digital security guide for activists
+- [EFF Surveillance Self-Defense](https://ssd.eff.org/) — Privacy and security guides
+- [Signal](https://signal.org/) — Encrypted messaging
+- [Tor Project](https://www.torproject.org/) — Anonymous network access
+- [Ywallet](https://ywallet.app/) — Recommended secure wallet
+- [Trezor](https://trezor.io/) — Hardware wallet with Zcash support
+- [Zcash Foundation](https://zfnd.org/) — Non-profit supporting Zcash development
+
+---
+
+## Journey Complete
+
+You've reached the end of the **Use Zcash in the Real World** journey. From receiving your first private donation to running a journalist-level secure financial operation, you now have the knowledge to use Zcash for real-world privacy needs.
+
+### What You've Learned
+
+1. ✅ **Receive donations privately** — Set up a wallet and receive shielded payments
+2. ✅ **Send money without linking identity** — Understand and use shielded transactions
+3. ✅ **Freelancer privacy setup** — Manage client payments with financial privacy
+4. ✅ **Merchant payment acceptance** — Accept Zcash in your business or store
+5. ✅ **Private community treasury** — Manage shared funds with governance
+6. ✅ **Journalist security setup** — Maximum privacy for high-stakes situations
+
+### Continuing Your Zcash Journey
+
+- Join the [Zcash Community Forum](https://forum.zcashcommunity.com/)
+- Explore more guides on [ZecHub](https://zechub.global/)
+- Contribute to Zcash development and documentation
+- Help others learn to use Zcash privately
+- Stay updated on Zcash protocol improvements
+
+### Remember
+
+Privacy is not about hiding wrongdoing — it's about protecting your right to live freely. Financial privacy is a fundamental aspect of personal autonomy, and Zcash provides the technology to exercise that right.
+
+**Stay private. Stay safe.**
+
+---
+
+← [Back to Use Zcash in the Real World](README.md)

--- a/site/zcash-use-case/README.md
+++ b/site/zcash-use-case/README.md
@@ -1,0 +1,65 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zcash-use-case/README.md" target="_blank"><img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/></a>
+
+
+# Use Zcash in the Real World
+
+Privacy isn't an abstract concept — it's a practical need. Whether you're a freelancer protecting your income, a merchant serving customers, a journalist safeguarding sources, or simply someone who values financial autonomy, Zcash provides the tools to transact without exposing your personal data to the world.
+
+This guide is structured as a **single linear journey** — from beginner fundamentals to advanced privacy setups. Each step builds on the last, so we recommend reading them in order. But if you already have Zcash experience, feel free to jump to the section that matches your needs.
+
+---
+
+## Your Journey
+
+| Step | Topic | Difficulty | For Whom |
+|------|-------|------------|----------|
+| 1 | [Receive Donations Privately](Receive_Donations_Privately.md) | 🟢 Beginner | Anyone new to Zcash |
+| 2 | [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md) | 🟢 Beginner | Basic users |
+| 3 | [Freelancer Privacy Setup](Freelancer_Privacy_Setup.md) | 🟡 Intermediate | Freelancers & contractors |
+| 4 | [Accept Payments as a Merchant](Accept_Payments_as_a_Merchant.md) | 🟡 Intermediate | Business owners & online sellers |
+| 5 | [Run a Private Community Treasury](Run_a_Private_Community_Treasury.md) | 🟠 Advanced | DAOs & community groups |
+| 6 | [Journalist Privacy Setup](Journalist_Privacy_Setup.md) | 🔴 Expert | Journalists & high-risk individuals |
+
+---
+
+## Why Zcash?
+
+Zcash is one of the few cryptocurrencies that offers **strong, default-available transaction privacy** through its shielded (zk-SNARK) protocol. Unlike transparent blockchains where every transaction is publicly visible, Zcash shielded transactions hide:
+
+- **Sender** — who sent the funds
+- **Receiver** — who received the funds
+- **Amount** — how much was transferred
+
+This isn't obfuscation or mixing — it's **cryptographic proof** that a transaction is valid without revealing its contents. The technology behind it, zk-SNARKs, is the same foundation used by zero-knowledge rollups and modern privacy-preserving systems.
+
+### Key Resources
+
+- [Zcash Official Site](https://z.cash/)
+- [Zcash Wikipedia](https://en.wikipedia.org/wiki/Zcash)
+- [Electric Coin Company](https://electriccoin.co/) — Core development
+- [Zcash Foundation](https://zfnd.org/) — Non-profit stewardship
+- [zcash4win](https://github.com/zechub/zcash4win) — Windows wallet
+- [Ywallet](https://ywallet.app/) — Modern mobile & desktop wallet
+- [ZecWallet Lite](https://www.zecwallet.co/) — Lightweight full-node wallet
+
+---
+
+## Getting Started
+
+Before beginning this journey, you'll need:
+
+1. **A Zcash wallet** — We recommend [Ywallet](https://ywallet.app/) for mobile and desktop, or [ZecWallet Lite](https://www.zecwallet.co/) for desktop users who want light node functionality.
+2. **Some ZEC** — You can acquire ZEC from [major exchanges](https://coinmarketcap.com/currencies/zcash/#Markets) or [peer-to-peer platforms](https://localmonero.co/?rc=8y9n).
+3. **Basic understanding** of cryptocurrency concepts — if you're totally new, start with the [Zcash Start Here guide](../Start_Here/).
+
+---
+
+## Important Notes
+
+- **Shielded addresses (z-addresses)** start with `z` and provide full privacy. **Transparent addresses (t-addresses)** start with `t` and work like Bitcoin — all transaction details are public.
+- Always use **shielded addresses** when privacy matters. This guide assumes shielded usage throughout.
+- For the latest Zcash ecosystem tools and wallets, visit [ZecHub Global](https://zechub.global/).
+
+---
+
+**Ready to begin?** → [Step 1: Receive Donations Privately](Receive_Donations_Privately.md)

--- a/site/zcash-use-case/Receive_Donations_Privately.md
+++ b/site/zcash-use-case/Receive_Donations_Privately.md
@@ -1,0 +1,240 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zcash-use-case/Receive_Donations_Privately.md" target="_blank"><img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/></a>
+
+
+# Receive Donations Privately with Zcash
+
+Whether you run a blog, create open-source software, stream content, or support a community cause — receiving donations shouldn't require exposing your financial history to the world. With Zcash, you can accept donations privately, keeping your balance, transaction history, and personal information shielded from public view.
+
+This guide walks you through the complete process of setting up a Zcash wallet, creating a shielded address, and receiving donations — all without linking your identity to your financial activity.
+
+---
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+- A computer or smartphone with internet access
+- A secure device (free of malware, with up-to-date OS)
+- A reliable internet connection
+- About 15-20 minutes for initial setup
+
+---
+
+## Step 1: Install a Zcash Wallet
+
+Choose one of the following wallets based on your device and needs:
+
+### Option A: Ywallet (Recommended — Mobile & Desktop)
+
+[Ywallet](https://ywallet.app/) is a modern, user-friendly Zcash wallet available for Android, iOS, Windows, macOS, and Linux.
+
+**On Android:**
+1. Open the [Google Play Store](https://play.google.com/store/apps/details?id=app.ywallet) or download the APK from [ywallet.app](https://ywallet.app/)
+2. Search for "Ywallet" and tap **Install**
+3. Open the app once installation completes
+
+**On iOS:**
+1. Open the [App Store](https://apps.apple.com/app/ywallet)
+2. Search for "Ywallet" and tap **Get**
+3. Open the app after installation
+
+**On Desktop (Windows/macOS/Linux):**
+1. Visit [ywallet.app](https://ywallet.app/) and download the version for your OS
+2. Install the application following the installer prompts
+3. Launch Ywallet
+
+### Option B: ZecWallet Lite (Desktop)
+
+[ZecWallet Lite](https://www.zecwallet.co/) is a lightweight wallet that connects to full nodes without downloading the entire blockchain (~500MB download).
+
+1. Visit [zecwallet.co](https://www.zecwallet.co/)
+2. Download the latest release for your operating system
+3. Verify the download signature (instructions on the download page)
+4. Install and launch ZecWallet Lite
+
+### Option C: Full Node Wallet (Advanced)
+
+For maximum privacy and network support, running a full node is ideal. See the [Zcashd documentation](https://zcash.readthedocs.io/en/latest/) for setup instructions.
+
+---
+
+## Step 2: Create Your Zcash Shielded Address
+
+This is the most critical step. Understanding the difference between address types is essential for your privacy.
+
+### Understanding Zcash Address Types
+
+| Type | Prefix | Privacy Level | Description |
+|------|--------|---------------|-------------|
+| Transparent | `t1...` | ❌ None | Like Bitcoin — all details are public |
+| Shielded (Sapling) | `zs1...` | ✅ Full | Sender, receiver, and amount are hidden |
+| Shielded (Unified) | `u1...` | ✅ Full | Latest address format with full shielding |
+
+**⚠️ Critical: Always use shielded addresses (starting with `z`) when privacy matters.**
+
+### Creating Your Address in Ywallet
+
+1. **Open Ywallet** after installation
+2. On first launch, you'll be prompted to **Create a New Wallet** or **Restore Existing Wallet**
+3. Select **Create a New Wallet**
+4. **Write down your recovery phrase** (seed phrase) — this is typically 24 words
+   - Write it on paper, not digitally
+   - Store it in a secure, offline location
+   - Never share it with anyone
+   - This phrase is the ONLY way to recover your funds if you lose your device
+5. Confirm the recovery phrase by entering it when prompted
+6. Your wallet will generate your addresses automatically
+7. **Find your shielded address:**
+   - Tap the **Receive** button
+   - Your default address should be a shielded address (starting with `zs1` or `u1`)
+   - If you see multiple addresses, always choose the one starting with `z` or `u`
+8. **Copy the address** — you'll share this with donors
+
+### Creating Your Address in ZecWallet Lite
+
+1. Open ZecWallet Lite
+2. Go to **Receive** tab
+3. Your shielded address (starting with `zs1`) will be displayed
+4. Click **Copy** to copy the address to clipboard
+
+---
+
+## Step 3: Share Your Donation Address
+
+Now that you have your shielded address, you need to share it with potential donors. Here's how to do it effectively while maintaining privacy:
+
+### Best Practices for Sharing Your Address
+
+1. **Share only the shielded address** — Never share your transparent address publicly
+2. **Use a QR code** — Most wallets can generate a QR code for your address. This reduces the chance of typos and makes it easy for donors to send funds.
+3. **Consider address rotation** — While shielded addresses provide strong privacy, generating a new address periodically adds an extra layer. Ywallet supports this natively.
+4. **Don't link your address to your real identity publicly** — If you publish your address on a website, consider whether the website itself reveals your identity.
+
+### Where to Publish Your Address
+
+- **Your website or blog** — Add a "Support Me" or "Donate" section with your QR code and address
+- **GitHub README** — For open-source projects, add a sponsorship section
+- **Social media** — Share in your bio or pinned posts (note: this links your social identity to the address, though shielded transactions hide the amounts and flow)
+- **Content platforms** — Patreon alternatives like [Liberapay](https://liberapay.com/) can display your crypto address
+- **Email signature** — Add a subtle donation link to your professional email
+
+### Important Privacy Warning
+
+Even though shielded transactions hide the transaction details, **the act of publishing your address publicly does create a link between your public identity and that address**. Observers won't see your balance or transaction amounts, but they'll know that address belongs to you.
+
+For maximum privacy:
+- Generate a fresh address for each donation campaign
+- Use a pseudonym when publishing the address
+- Consider using a [unified address](https://z.cash/ua/) which provides the strongest privacy guarantees
+
+---
+
+## Step 4: Receive and Confirm Donations
+
+Once donors start sending ZEC to your shielded address, here's how to confirm receipt:
+
+### Checking Your Balance
+
+**In Ywallet:**
+1. Open the app
+2. Your **shielded balance** will be displayed on the main screen
+3. Incoming transactions will appear in the transaction history
+4. Shielded transactions may take a few minutes to confirm — this is normal
+
+**In ZecWallet Lite:**
+1. Open the wallet
+2. The **Shielded Balance** is shown on the dashboard
+3. Wait for the wallet to sync (indicated by the sync progress bar)
+4. Transactions appear in the history once confirmed
+
+### Understanding Confirmation Times
+
+Zcash transactions typically confirm within **~2.5 minutes** (one block). However, shielded transactions may take slightly longer to appear in your wallet due to the additional cryptographic verification required.
+
+- **1 confirmation** (~2.5 min) — Transaction is on the blockchain
+- **10 confirmations** (~25 min) — Considered very secure
+- Most wallets show incoming funds after 1-2 confirmations
+
+### Handling Different Donation Amounts
+
+ZEC is divisible to 8 decimal places, so you can receive any amount — from fractions of a cent to large donations. Your wallet handles all amounts automatically.
+
+---
+
+## Step 5: Security Best Practices
+
+Protecting your donated funds is just as important as receiving them.
+
+### Protect Your Recovery Phrase
+
+- **Write it on paper** — Never store it digitally (no screenshots, no cloud storage, no email)
+- **Make multiple copies** — Store in separate secure locations (safe, bank deposit box, trusted family member)
+- **Consider a metal backup** — Products like [Cryptosteel](https://cryptosteel.com/) or [Billfodl](https://billfodl.com/) protect against fire and water damage
+- **Never share it** — No legitimate service will ever ask for your seed phrase
+
+### Device Security
+
+- **Keep your OS updated** — Security patches protect against known vulnerabilities
+- **Use a dedicated device** if handling significant amounts
+- **Install antivirus/anti-malware** software
+- **Enable full-disk encryption** on your device
+- **Use a strong device password** or biometric lock
+
+### Wallet Security
+
+- **Set a strong wallet password** or PIN
+- **Enable biometric authentication** if your device supports it (Ywallet offers this)
+- **Keep your wallet software updated** — Updates often include security improvements
+- **Never enter your seed phrase** on any website or app other than your wallet
+
+### Operational Security
+
+- **Don't discuss your holdings** publicly or with strangers
+- **Use a VPN** (such as [Tor](https://www.torproject.org/) or a trusted VPN service) when accessing your wallet on public networks
+- **Be cautious of phishing** — Scammers may impersonate wallet developers or exchanges
+- **Verify addresses carefully** — Always double-check addresses before sending (when you eventually spend)
+
+### For Large Donations
+
+If you receive a significant amount of ZEC:
+- Consider moving funds to a **cold storage** solution
+- Look into hardware wallets like [Trezor](https://trezor.io/) or [Ledger](https://www.ledger.com/) which support Zcash
+- Consider splitting large amounts across multiple wallets (not all at once, to avoid linking)
+- Consult a financial advisor familiar with cryptocurrency
+
+---
+
+## Step 6: Managing Ongoing Donations
+
+### Tracking Donations Without Compromising Privacy
+
+Since shielded transactions hide amounts from the public, you'll need your own system for tracking:
+
+- **Keep a private spreadsheet** — Record date, approximate amount, and purpose for tax purposes
+- **Use wallet notes** — Some wallets allow you to add memos to transactions
+- **Export transaction history** — Most wallets let you export your private transaction history for accounting
+
+### Communicating with Donors
+
+- Thank donors personally when possible
+- Consider publishing a **transparency report** (without revealing amounts or transaction details) showing how donations are used
+- For recurring donations, consider setting up a dedicated address per donor
+
+---
+
+## External Resources
+
+- [Ywallet Documentation](https://ywallet.app/)
+- [ZecWallet Lite Guide](https://www.zecwallet.co/)
+- [Zcash Shielded Addresses Explained](https://z.cash/support/addresses/)
+- [zcash4win — Windows Wallet Guide](https://github.com/zechub/zcash4win)
+- [Hardware Wallet Support for Zcash](https://trezor.io/learn/a/what-coins-does-trezor-support)
+- [Privacy Guides — Wallet Security](https://www.privacyguides.org/en/cryptocurrency/)
+
+---
+
+## What's Next?
+
+Now that you can receive donations privately, the next logical step is learning how to **send Zcash without linking your identity** to the recipient or the transaction.
+
+→ **[Step 2: Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)**

--- a/site/zcash-use-case/Run_a_Private_Community_Treasury.md
+++ b/site/zcash-use-case/Run_a_Private_Community_Treasury.md
@@ -1,0 +1,304 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zcash-use-case/Run_a_Private_Community_Treasury.md" target="_blank"><img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/></a>
+
+
+# Run a Private Community Treasury with Zcash
+
+Community treasuries — funds managed collectively by a group for shared goals — are a cornerstone of decentralized organizations, DAOs, open-source projects, and grassroots movements. But managing a treasury on a transparent blockchain exposes every decision, every payment, and every participant's financial activity to the world.
+
+Zcash enables communities to manage their treasury privately while maintaining the accountability and transparency that members need. This guide shows you how to set up and operate a private community treasury using Zcash's shielded transaction capabilities.
+
+---
+
+## Why Communities Need Private Treasuries
+
+### The Problem with Transparent Treasuries
+
+When a community treasury operates on a transparent blockchain (like Ethereum or Bitcoin):
+
+- **Every expenditure is public** — Anyone can see exactly how much was paid, to whom, and when
+- **Contributors are exposed** — Donors' identities and contribution amounts are visible
+- **Negotiation disadvantage** — Vendors and partners can see your total budget and spending patterns
+- **Targeting risk** — Large treasury balances on public blockchains make communities targets for attacks
+- **Member privacy** — Individual members' financial relationships with the treasury are exposed
+
+### How Zcash Solves These Problems
+
+- **Shielded treasury balance** — Total funds are invisible to outsiders
+- **Private expenditures** — Payments to vendors, contributors, and grantees are not publicly traceable
+- **Private contributions** — Donations to the treasury are shielded
+- **Internal accountability** — Treasury managers and members with access can see all transactions
+- **Protection from targeting** — No one can see how much the treasury holds
+
+### Use Cases
+
+- **DAO treasuries** — Decentralized autonomous organizations managing community funds
+- **Open-source project funding** — Grants and bounties for developers
+- **Community grants programs** — Distributing funds to members for projects
+- **Mutual aid networks** — Pooling and distributing resources within a community
+- **Political organizations** — Fundraising and spending in jurisdictions where financial privacy is important
+- **Cooperative businesses** — Shared financial management among members
+
+---
+
+## Step 1: Multi-Signature Setup
+
+A community treasury should never be controlled by a single person. Multi-signature (multisig) arrangements ensure that no individual can unilaterally move funds.
+
+### Understanding Multisig for Zcash
+
+Unlike Bitcoin's native multisig, Zcash doesn't have a built-in multisig protocol for shielded addresses. However, there are several approaches to achieve multisig-like security:
+
+### Approach A: Shared Wallet with Policy (Recommended for Small Groups)
+
+1. **Create a dedicated treasury wallet** — Use Ywallet or ZecWallet Lite
+2. **Share the recovery phrase** among trusted members (e.g., 3-of-5 arrangement)
+   - Split the 24-word seed phrase into shares using [Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing)
+   - Tools like [SLIP-39](https://slips.livecoin.net/slip-0039) support this natively
+   - Each member holds a portion; a threshold (e.g., 3 of 5) is needed to reconstruct
+3. **Establish governance rules** — Document how many signatures/approvals are needed for different transaction sizes
+4. **Designate a transaction initiator** — One person prepares transactions; others review and approve before the seed phrase is reconstructed for signing
+
+### Approach B: Hardware Wallet Multisig
+
+For larger treasuries:
+
+1. **Use multiple hardware wallets** — Each core member holds one hardware wallet (Trezor or Ledger) that supports Zcash
+2. **Set up a policy** requiring multiple hardware wallet approvals for any outgoing transaction
+3. **Trezor Model T** and **Ledger Nano X** both support Zcash
+4. Transactions require physical access to multiple devices, providing strong security
+
+### Approach C: Smart Contract Treasury (Advanced)
+
+For communities building on Zcash's ecosystem:
+
+1. **Use a smart contract platform** that supports Zcash (when available)
+2. **Deploy a multisig contract** with defined governance rules
+3. **Automate approval workflows** through on-chain voting
+
+### Implementing Shamir's Secret Sharing
+
+1. Choose a tool that implements SLIP-39:
+   - [Trezor Suite](https://trezor.io/trezor-suite/) — Built-in support
+   - [Ian Coleman's SLIP-39 tool](https://iancoleman.io/slip39/) — Online (use offline for security)
+2. Generate shares with your desired threshold (e.g., 3-of-5)
+3. Distribute shares to trusted members
+4. Store each share securely
+5. To access funds, the required number of members must combine their shares
+
+---
+
+## Step 2: Proposal and Voting Process
+
+A private treasury needs a transparent (to members) governance process for deciding how to spend funds.
+
+### Creating a Proposal
+
+A standard treasury proposal should include:
+
+1. **Proposal title** — Clear and descriptive
+2. **Requestor** — Who is requesting the funds
+3. **Amount** — How much ZEC is requested
+4. **Purpose** — What the funds will be used for
+5. **Timeline** — When the funds are needed
+6. **Deliverables** — What the community gets in return
+7. **Budget breakdown** — Detailed cost breakdown
+
+### Proposal Template
+
+```
+PROPOSAL: [Title]
+─────────────────────────────────────
+Requestor: [Name/Pseudonym]
+Amount Requested: [X.XX ZEC] (≈ $[USD])
+Purpose: [Description]
+Timeline: [Start date] to [End date]
+Deliverables:
+  - [Deliverable 1]
+  - [Deliverable 2]
+  - [Deliverable 3]
+
+Budget Breakdown:
+  - Item 1: [Amount]
+  - Item 2: [Amount]
+  - Total: [Total Amount]
+
+Wallet Address: [zs1...] (shielded)
+─────────────────────────────────────
+```
+
+### Voting Mechanisms
+
+#### Option A: Simple Majority Vote
+
+- Each member gets one vote
+- Simple majority (>50%) approves the proposal
+- Use a secure voting platform:
+  - [Snapshot](https://snapshot.org/) — Off-chain voting (public but cheap)
+  - Encrypted messaging polls (Signal, Matrix)
+  - Dedicated governance platforms
+
+#### Option B: Quadratic Voting
+
+- Members receive voting credits
+- Cost of additional votes increases quadratically
+- Prevents whale dominance while allowing strong opinions to carry more weight
+
+#### Option C: Delegation
+
+- Members delegate voting power to trusted representatives
+- Representatives vote on behalf of their delegators
+- Delegators can reclaim their voting power at any time
+
+### Voting Workflow
+
+1. **Proposal submission** — Requestor submits proposal to the community forum
+2. **Discussion period** — Community discusses for a set period (e.g., 7 days)
+3. **Voting period** — Members vote for a set period (e.g., 3 days)
+4. **Result announcement** — Results are published to the community
+5. **Execution** — If approved, treasury managers process the payment
+
+---
+
+## Step 3: Fund Distribution
+
+Once a proposal is approved, the treasury managers need to distribute funds privately.
+
+### Payment Process
+
+1. **Verify approval** — Confirm the proposal passed the vote
+2. **Request the recipient's shielded address** — Must be a z-address (zs1 or u1)
+3. **Verify the address** — Cross-check with the proposal and confirm with the recipient
+4. **Reconstruct the wallet** (if using Shamir's Secret Sharing):
+   - Gather the required number of seed phrase shares
+   - Reconstruct the full seed phrase in a secure environment
+   - Perform the transaction
+   - Securely delete the reconstructed phrase
+5. **Send the payment** — Use your wallet to send the approved amount
+6. **Record the transaction** — Log the txid, amount, and purpose in the community's private records
+7. **Notify the community** — Announce that the payment was processed (without necessarily revealing amounts publicly)
+
+### Batch Payments
+
+For efficiency when multiple proposals are approved:
+
+1. **Batch all approved payments** into a single session
+2. **Reconstruct the wallet once** (if using Shamir's Secret Sharing)
+3. **Send all payments** in sequence
+4. **Securely destroy** the reconstructed seed phrase
+5. **Record all transactions** in the private ledger
+
+### Milestone-Based Payments
+
+For larger grants or contracts:
+
+1. **Split the total amount** into milestone payments
+2. **Define clear deliverables** for each milestone
+3. **Release each payment** only after the previous milestone is verified
+4. **Use unique addresses** for each milestone payment
+
+---
+
+## Step 4: Balancing Transparency and Privacy
+
+A community treasury needs internal transparency (members can see what's happening) while maintaining external privacy (outsiders cannot).
+
+### Internal Transparency Tools
+
+1. **Shared private ledger** — A document (encrypted) that all members can access, recording:
+   - All incoming contributions
+   - All outgoing payments
+   - Current balance
+   - Proposal outcomes
+
+2. **Regular financial reports** — Monthly or quarterly summaries shared with members:
+   - Total income during the period
+   - Total expenditures
+   - Category breakdown of spending
+   - Current treasury balance
+
+3. **Audit process** — Periodic audits by a trusted member or external auditor:
+   - Verify that the wallet balance matches the ledger
+   - Confirm all payments were properly authorized
+   - Report findings to the community
+
+### External Privacy
+
+What the public sees:
+- ❌ Treasury balance
+- ❌ Individual transactions
+- ❌ Contributor identities
+- ❌ Recipient identities
+- ❌ Payment amounts
+
+What community members see:
+- ✅ Full transaction history
+- ✅ Current balance
+- ✅ All proposal details
+- ✅ All voting results
+
+### Publishing Transparency Reports
+
+Consider publishing a **transparency report** that shows:
+- Number of proposals received
+- Number of proposals approved/rejected
+- Total funds distributed (without individual breakdowns)
+- Categories of spending
+- Impact metrics (projects funded, people helped, etc.)
+
+This demonstrates accountability without compromising privacy.
+
+---
+
+## Step 5: Security for Community Treasuries
+
+Treasury security is paramount — you're protecting not just your own funds, but the community's collective resources.
+
+### Operational Security
+
+1. **Use dedicated devices** for treasury management
+2. **Enable full-disk encryption** on all devices that access the wallet
+3. **Use strong, unique passwords** for all accounts
+4. **Enable two-factor authentication** on all related accounts
+5. **Regular security audits** — Periodically review access controls and procedures
+
+### Access Control
+
+- **Define roles clearly** — Who can propose, who can vote, who can execute transactions
+- **Rotate access periodically** — Don't let the same people hold access indefinitely
+- **Have an emergency procedure** — What happens if a key member becomes unavailable?
+- **Document everything** — Clear procedures prevent disputes and confusion
+
+### Emergency Procedures
+
+1. **Member departure** — Process for redistributing seed phrase shares when a member leaves
+2. **Compromised wallet** — Procedure for moving funds to a new wallet if security is breached
+3. **Disputed transaction** — Process for handling disagreements about authorized spending
+4. **Legal compliance** — Understanding your jurisdiction's requirements for community funds
+
+### Insurance and Recovery
+
+For large treasuries:
+- Consider **crypto insurance** options if available in your jurisdiction
+- Maintain **offline backups** of all critical information
+- Have a **succession plan** for key roles
+- Consider **professional custody** services for very large amounts
+
+---
+
+## External Resources
+
+- [Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing) — Secret sharing scheme
+- [SLIP-39 Specification](https://slips.livecoin.net/slip-0039) — Shamir backup standard
+- [Trezor Suite](https://trezor.io/trezor-suite/) — Hardware wallet with SLIP-39 support
+- [Snapshot](https://snapshot.org/) — Governance voting platform
+- [BTCPay Server](https://btcpayserver.org/) — Can be adapted for treasury payments
+- [Zcash Foundation Grants](https://grants.zfnd.org/) — Example of community grant program
+- [Ywallet](https://ywallet.app/) — Recommended wallet for treasury management
+
+---
+
+## What's Next?
+
+The final guide in this journey covers the most demanding privacy setup: **journalists and high-risk individuals** who need the strongest possible financial privacy to protect their sources and their safety.
+
+→ **[Step 6: Journalist Privacy Setup](Journalist_Privacy_Setup.md)**

--- a/site/zcash-use-case/Send_Money_Without_Linking_Identity.md
+++ b/site/zcash-use-case/Send_Money_Without_Linking_Identity.md
@@ -1,0 +1,243 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zcash-use-case/Send_Money_Without_Linking_Identity.md" target="_blank"><img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/></a>
+
+
+# Send Money Without Linking Identity
+
+One of the most powerful features of Zcash is the ability to send money to anyone, anywhere in the world, without either party's identity, balance, or transaction amount being exposed on the public blockchain. This guide teaches you how to leverage Zcash's shielded transactions for private, untraceable payments.
+
+Whether you're paying a freelancer, sending money to family, supporting a cause, or simply exercising your right to financial privacy — this guide covers everything you need to know about sending Zcash privately.
+
+---
+
+## Prerequisites
+
+Before proceeding, ensure you have:
+
+- A Zcash wallet set up (Ywallet, ZecWallet Lite, or similar) — see [Step 1](Receive_Donations_Privately.md) if you haven't set one up yet
+- A shielded wallet with a positive ZEC balance
+- The recipient's Zcash shielded address (starting with `zs1` or `u1`)
+- About 10-15 minutes
+
+---
+
+## Step 1: Understanding Transparent vs Shielded Transactions
+
+Before sending anything, it's crucial to understand the fundamental difference between Zcash's two transaction types. This knowledge directly impacts your privacy.
+
+### Transparent Transactions (t-addresses)
+
+Transparent transactions work exactly like Bitcoin:
+
+- **Sender address is public** — Anyone can see who sent the funds
+- **Receiver address is public** — Anyone can see who received the funds
+- **Amount is public** — The exact ZEC amount is visible to everyone
+- **All history is traceable** — Anyone can trace the complete flow of funds
+
+If you send ZEC from a transparent address, **blockchain analysts can potentially link your identity** to the transaction through exchange KYC data, IP address tracking, or other metadata.
+
+### Shielded Transactions (z-addresses)
+
+Shielded transactions use zk-SNARK technology:
+
+- **Sender is hidden** — The blockchain doesn't reveal who sent the funds
+- **Receiver is hidden** — The recipient's identity is cryptographically concealed
+- **Amount is hidden** — The transaction amount is encrypted
+- **History is untraceable** — There is no way to trace the flow of shielded funds
+
+The only thing visible on the blockchain for a fully shielded transaction is that **a transaction occurred** — nothing more.
+
+### The Privacy Spectrum
+
+| Transaction Type | Sender Visible? | Receiver Visible? | Amount Visible? |
+|-----------------|-----------------|-------------------|-----------------|
+| t → t | ✅ Yes | ✅ Yes | ✅ Yes |
+| t → z | ✅ Yes | ❌ No | ❌ No |
+| z → t | ❌ No | ✅ Yes | ✅ Yes |
+| **z → z** | **❌ No** | **❌ No** | **❌ No** |
+
+**For complete privacy, always send from a shielded address to a shielded address (z → z).**
+
+---
+
+## Step 2: Prepare Your Wallet for Sending
+
+### Ensure Your Wallet Is Synced
+
+Before sending any transaction, your wallet must be fully synced with the Zcash blockchain:
+
+**In Ywallet:**
+1. Open the app
+2. Check the sync status — it should say "Synced" or show 100%
+3. If syncing, wait for it to complete before proceeding
+4. Your available balance should reflect your actual shielded balance
+
+**In ZecWallet Lite:**
+1. Open the wallet
+2. Check the sync indicator (usually at the bottom of the window)
+3. Wait for the sync to reach the latest block
+4. The sync process downloads only the relevant shielded data, not the full blockchain
+
+### Verify Your Balance
+
+- Check that your **shielded balance** (not transparent) has sufficient funds
+- Remember to account for the small transaction fee (typically a fraction of a ZEC)
+- If your funds are in a transparent address, you'll need to shield them first
+
+### Shielding Your Funds (If Needed)
+
+If you received ZEC at a transparent address (t-address) or bought it on an exchange and withdrew to a t-address:
+
+1. In your wallet, look for a **Shield** or **Shield Funds** button
+2. This creates a shielded transaction that moves your funds from t-address to z-address
+3. Wait for the shielding transaction to confirm (~2.5 minutes)
+4. Your funds are now in your shielded balance and ready for private sending
+
+**In Ywallet:** Shielding is typically automatic for incoming shielded funds. For transparent funds, use the shield function in the settings.
+
+**In ZecWallet Lite:** Go to **Send** → Enter your own shielded address as the recipient → Send. This "self-shields" your transparent funds.
+
+---
+
+## Step 3: Sending a Shielded Transaction
+
+### Getting the Recipient's Shielded Address
+
+Before you can send privately, the recipient must provide you with their **shielded address**:
+
+- Shielded addresses start with `zs1` (Sapling) or `u1` (Unified)
+- Ask the recipient to share their shielded address, not their transparent address
+- The address can be shared as text or as a QR code
+- **Never send to a transparent address** if privacy is your goal
+
+### Verifying the Address
+
+Always double-check the recipient's address before sending:
+
+1. **Compare the first 5 and last 5 characters** of the address
+2. If using a QR code, verify the decoded text matches what the recipient provided
+3. For large amounts, consider sending a small test transaction first
+4. Use secure communication channels to receive the address (encrypted messaging, in person, etc.)
+
+### Sending in Ywallet
+
+1. Open Ywallet and ensure it's synced
+2. Tap the **Send** button
+3. **Enter or paste the recipient's shielded address**
+   - You can also scan a QR code using the camera icon
+4. **Enter the amount** of ZEC to send
+   - You can enter the amount in ZEC or in your local currency equivalent
+5. **Add a memo (optional)** — Shielded memos are encrypted and only visible to sender and receiver
+   - Useful for payment references or personal messages
+   - Keep memos brief and avoid sensitive information
+6. **Review the transaction details:**
+   - Recipient address (verify again!)
+   - Amount
+   - Transaction fee
+   - Total to be deducted
+7. **Confirm the transaction** — Enter your PIN/password/biometric
+8. Wait for confirmation — the transaction should confirm within ~2.5 minutes
+
+### Sending in ZecWallet Lite
+
+1. Open ZecWallet Lite and wait for sync to complete
+2. Click the **Send** tab
+3. **ZEC Address:** Paste the recipient's shielded address
+4. **Amount:** Enter the ZEC amount
+5. **Memo (optional):** Add an encrypted memo if needed
+6. Click **Send**
+7. Review the confirmation dialog and click **Confirm**
+8. The transaction will appear in your history once confirmed
+
+### Transaction Fees
+
+Zcash transaction fees are very low — typically fractions of a cent. The fee is automatically calculated by your wallet. Even during network congestion, fees remain minimal compared to Bitcoin or Ethereum.
+
+---
+
+## Step 4: Verifying Transaction Privacy
+
+After sending a shielded transaction, you may want to verify that it was indeed private. Here's how:
+
+### Checking on a Block Explorer
+
+1. Visit a Zcash block explorer like [blockchair.com/zcash](https://blockchair.com/zcash) or [explorer.zcha.in](https://explorer.zcha.in/)
+2. Search for your transaction ID (txid) — your wallet should display this after sending
+3. What you'll see for a fully shielded (z → z) transaction:
+   - **Input addresses:** Hidden (shown as shielded pool)
+   - **Output addresses:** Hidden (shown as shielded pool)
+   - **Amount:** Hidden
+   - The only visible information is the transaction ID and block number
+
+### What Others Cannot See
+
+After your shielded transaction:
+- ❌ The recipient cannot see your wallet balance
+- ❌ The recipient cannot see your other transactions
+- ❌ Third parties cannot see who sent the funds
+- ❌ Third parties cannot see who received the funds
+- ❌ Third parties cannot see the transaction amount
+- ✅ The recipient receives the funds and can see the memo (if any)
+- ✅ You can see the transaction in your own wallet history
+
+### Important: Receiving Side Privacy
+
+Remember that if you receive ZEC from a transparent address (t → z), the sender's address IS visible on the blockchain. For both parties to maintain privacy, **both sides must use shielded addresses**.
+
+---
+
+## Step 5: Security and Safety Considerations
+
+### Protecting Transaction Privacy
+
+1. **Use Tor or a VPN** when sending transactions
+   - Your wallet software connects to Zcash nodes over the internet
+   - Your IP address could potentially be linked to your wallet activity
+   - Ywallet supports Tor integration on mobile
+   - On desktop, route your wallet through Tor or use a trusted VPN
+
+2. **Don't reuse addresses unnecessarily**
+   - While shielded addresses provide strong privacy, using fresh addresses for different purposes adds defense in depth
+   - Most modern wallets generate new addresses automatically
+
+3. **Be careful with memos**
+   - Shielded memos are encrypted, but both parties can see them
+   - Don't include personally identifying information in memos
+   - Avoid memos that could link the transaction to your real identity
+
+4. **Timing analysis**
+   - If you always send transactions at the same time, patterns could emerge
+   - Vary your sending times when possible
+   - Consider using your wallet's "send later" feature if available
+
+### Avoiding Common Mistakes
+
+1. **Don't send to a transparent address** — This breaks the privacy chain
+2. **Don't use exchange withdrawals directly** — Exchanges typically send from their transparent addresses, linking the transaction to their known addresses. If you must receive from an exchange, immediately shield the funds before sending them onward
+3. **Don't link your exchange account to your personal wallet in a traceable way** — When withdrawing from exchanges, the withdrawal goes to your address. This creates a link between your exchange identity and that address
+4. **Don't share your transaction ID publicly** — While shielded, the txid can still be used to correlate information
+
+### For High-Value Transactions
+
+- Consider using a **fresh wallet** that has never been linked to your identity
+- Send a **small test amount first** to confirm everything works
+- Wait for full confirmation before considering the transaction complete
+- Consider splitting large amounts across multiple transactions over time (though this is generally unnecessary with Zcash's strong shielded privacy)
+
+---
+
+## External Resources
+
+- [Zcash Shielded Transactions Explained](https://z.cash/technology/zk-snarks/)
+- [Zerocash Protocol Paper](https://zerocash-project.org/paper)
+- [Ywallet](https://ywallet.app/) — Recommended wallet for private sending
+- [ZecWallet Lite](https://www.zecwallet.co/) — Desktop alternative
+- [Tor Project](https://www.torproject.org/) — For anonymous network access
+- [Orbot for Android](https://guardianproject.info/apps/orbot/) — Tor for mobile wallets
+
+---
+
+## What's Next?
+
+Now that you can send money privately, you might want to apply these skills to a real-world scenario. The next guide shows **freelancers** how to set up a complete privacy-preserving financial workflow for client work.
+
+→ **[Step 3: Freelancer Privacy Setup](Freelancer_Privacy_Setup.md)**


### PR DESCRIPTION
Create comprehensive guide with 7 markdown files covering real-world Zcash use cases:

- **README.md**: Navigation page with single linear journey from beginner to advanced
- **Receive Donations Privately**: Wallet setup, shielded addresses, receiving donations
- **Send Money Without Linking Identity**: Transparent vs shielded, private transactions
- **Freelancer Privacy Setup**: Dedicated wallets, client addresses, invoicing, taxes
- **Accept Payments as a Merchant**: Merchant wallets, payment integration, refunds, accounting
- **Run a Private Community Treasury**: Multisig, governance, fund distribution
- **Journalist Privacy Setup**: Air-gapped wallets, source protection, OPSEC, emergency procedures

Each file follows the site/Privacy_Tools format with edit badges and external resource links.

Fixes #1555