### PR TITLE
Update Zcash community wiki pages

### DIFF
--- a/site/Zcash_Community/Arborist_Calls.md
+++ b/site/Zcash_Community/Arborist_Calls.md
@@ -8,13 +8,24 @@
 
 The Zcash Arborist Calls are bi-weekly protocol development meetings focused on tracking upcoming protocol deployment logistics, consensus node implementation issues, and protocol research.
 
-Offical Site: [https://zfnd.org/arborist-calls/](https://zfnd.org/arborist-calls/)
+Official Site: [https://zfnd.org/arborist-calls/](https://zfnd.org/arborist-calls/)
 
 Anyone who wants to contribute to Zcash protocol development and to share news on Zcash node projects. 
 
 Register here: [15:00 UTC](https://us06web.zoom.us/webinar/register/WN_Vk7WMz9sRkiIr_hqH_x3LA) / [22:30 UTC](https://us06web.zoom.us/webinar/register/WN_z0k1ipsnRkS4-DGqDhULdA)
 
 The complete list with full notes & agendas can be found [here](https://github.com/ZcashCommunityGrants/arboretum-notes). 
+
+## Recent Calls and Notes
+
+| Date | Resource | Link |
+|------|----------|------|
+| April 30, 2026 | Zcash Arborist Call recording | [Watch ->](https://x.com/ZcashFoundation/status/2049913064313491476?s=20) |
+| April 30, 2026 | Community note-taker summary update | [Read ->](https://forum.zcashcommunity.com/t/zcg-rfp-community-note-taker-2025/50450/49) |
+| April 16, 2026 | Community call notes and discussion | [Read ->](https://x.com/zcashfoundation/status/2045127715678830628?s=46) |
+| March 19, 2026 | Arborist Call #120 community summary | [Read ->](https://x.com/zcashbrazil/status/2033617310427091218?s=20) |
+
+Typical Arborist Call topics include Zebra, Zaino, Zcashd deprecation, network upgrade planning, wallet infrastructure, protocol research, and open engineering questions from node and wallet teams.
 
 
 ## Playlist
@@ -29,5 +40,4 @@ The complete list with full notes & agendas can be found [here](https://github.c
     loading="lazy"
   />
 </div>
-
 

--- a/site/Zcash_Community/Community_Blogs.md
+++ b/site/Zcash_Community/Community_Blogs.md
@@ -21,4 +21,16 @@ Here are some of the active ones:
 
 ---
 
+## Recent Community Reading
+
+These recurring community publications are useful starting points for following current ecosystem activity:
+
+| Publication | Description | Link |
+|-------------|-------------|------|
+| Zcash Ecosystem Digest | Weekly ZecHub roundup of protocol, grants, project, and community updates | [Latest digest ->](../../newsletter/Digest%2003-05-26.md) |
+| Zcash Shielded News | ZecHub social news series focused on shielded Zcash activity and ecosystem highlights | [Vol. 16 ->](https://x.com/ZecHub/status/2049846703725895815?s=20) |
+| Zcash News and Updates | Community news posts from ZK Radio | [Visit ->](https://x.com/zkradioz/status/2042619973562957840?s=20) |
+| Zcash Z3 Updates | Ongoing forum thread tracking Zcashd deprecation, Zebra, Zaino, and wallet-stack migration work | [Read ->](https://forum.zcashcommunity.com/t/zcash-z3-updates-formerly-zcashd-deprecation/48965/152) |
+| ZODL Updates | Development notes for the ZODL wallet | [Read ->](https://forum.zcashcommunity.com/t/bending-the-bow-zodl-update/55514) |
+
 Here are some community-submitted blogs. If you would like ZecHub to feature one of your blog posts or add your own blog here, please create a Pull Request with the details!

--- a/site/Zcash_Community/Community_Links.md
+++ b/site/Zcash_Community/Community_Links.md
@@ -4,13 +4,13 @@
 
 # <img src="https://i.ibb.co/qYhRbJM/image-2024-02-03-174147713.png" alt="Alt Text" width="400"/> Zcash Community Links
 
-The Zcash community is a vibrant and passion group of people working towards making ZEC one of the most widely used cryptocurrencies in the world. The community is made up of a diverse group of people from all over the world. They come from a variety of different backgrounds and occupations, but they all work together to help achieve Zcash and ZEC's vision.
+The Zcash community is a vibrant and passionate group of people working towards making ZEC one of the most widely used cryptocurrencies in the world. The community is made up of people from many countries, backgrounds, and occupations who work together to advance financial privacy.
 
 ----
 
-## Where you can find community members?
+## Where can you find community members?
 
-The community active in a number of different places:
+The community is active in a number of different places:
 
 ### <img src="https://i.ibb.co/qBrb4qK/image-2024-02-03-173937048.png" alt="Alt Text" width="50"/> <span translate="no" class="notranslate">Telegram</span>
 
@@ -53,6 +53,17 @@ Just like most crypto projects, the Zcash community is extremely active on Twitt
 [@Zcash Brazil](https://x.com/zcashbrazil)
 
 [@zerodartz](https://x.com/Zerodartz) (for the memes!)
+
+### Regional and Project Communities
+
+| Community | Link |
+|-----------|------|
+| Zcash en Espanol | [Visit ->](https://x.com/zcashesp) |
+| Zcash Brazil | [Visit ->](https://x.com/zcashbrazil) |
+| Zcash Nigeria | [Visit ->](https://x.com/ZcashNigeria) |
+| Zcash Global en Espanol forum updates | [Read ->](https://forum.zcashcommunity.com/t/zcash-global-en-espanol-2026/53815/27) |
+| Zcash Nigeria activity reports | [Read ->](https://forum.zcashcommunity.com/t/zcash-nigeria-2026/53654/15) |
+| ZODL Support | [Visit ->](https://x.com/zodl_support/status/2048872443985506434?s=20) |
 
 
 ----

--- a/site/Zcash_Community/Community_Projects.md
+++ b/site/Zcash_Community/Community_Projects.md
@@ -159,6 +159,17 @@ Zecmap is The global map of businesses accepting Zcash. Discover, verify, and co
 
 [Visit Site](https://zecmap.com/)
 
+## Recently Active Projects and Initiatives
+
+| Project | Description | Link |
+|---------|-------------|------|
+| Zafu | Light client development work for Zcash wallets and infrastructure | [Read update](https://forum.zcashcommunity.com/t/zafu-client-development/54933/4) |
+| Rhea Finance Zcash Gateway | Browser wallet and cross-chain DeFi gateway work for Zcash | [Read update](https://forum.zcashcommunity.com/t/rhea-finance-zcash-gateway-browser-wallet-cross-chain-defi/55073/4) |
+| ZecVault | Goal-based savings wallet built on Zcash shielded transactions | [Read update](https://forum.zcashcommunity.com/t/zecvault-a-goal-based-savings-wallet-built-on-zcash-shielded-transactions/55464/3) |
+| ZcashGrantHub | Community-built interface for browsing and tracking Zcash Community Grants | [Read update](https://forum.zcashcommunity.com/t/zcashgranthub-a-better-ui-for-zcg-grants-built-fast-with-ai-tools-seeking-feedback/55267) |
+| Open-source Orchard Wallet Service | Wallet service for enterprises seeking Orchard-based Zcash support | [Read update](https://forum.zcashcommunity.com/t/open-source-orchard-based-wallet-service-for-enterprises-looking-for-users-feedback/54417/10) |
+| Zcash Spanish-speaking node | Community infrastructure work bringing a node to the Spanish-speaking Zcash community | [Read update](https://forum.zcashcommunity.com/t/the-spanish-speaking-zcash-community-now-has-its-own-node/55530) |
+
 
 ___
 

--- a/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -2,11 +2,21 @@
 
 This ecosystem role began as a ZCG grant application by [earthrise](https://forum.zcashcommunity.com/t/zcash-ecosystem-security-lead/42090) to work as a security engineer serving the wider Zcash ecosystem outside of ECC and ZF, with a focus on ZCG grantees. You can learn more about Earthrise's work as the Zcash Ecosystem Security Lead [here](https://zecsec.com). After this grant was completed, ZCG put out an [RFP](https://forum.zcashcommunity.com/t/rfp-zcash-ecosystem-security-lead-2023/45723) to find a replacement. & at the end of March 2024 ZCG selected [Least Authority](https://leastauthority.com) to step into the role through another grant. You can learn more about Least Authority's work as the Zcash Ecosystem Security Lead [here](https://forum.zcashcommunity.com/t/grant-update-zcash-ecosystem-security-lead/47541).
 
+## 2026 Security Work and Updates
+
+| Area | Description | Link |
+|------|-------------|------|
+| ZCG Security Funding | Zcash Community Grants earmarked funding for Zcash security work | [Read ->](https://x.com/ZcashCommGrants/status/2049186366752276765?s=20) |
+| Security and Vulnerability Disclosure Initiative | ZCG initiative focused on security coordination and vulnerability disclosure | [Read ->](https://forum.zcashcommunity.com/t/zcg-security-vulnerability-disclosure-initiative/55545) |
+| Ecosystem Security Lead Reports | Monthly Zcash Ecosystem Security Lead grant updates | [Read ->](https://forum.zcashcommunity.com/t/grant-update-zcash-ecosystem-security-lead/47541/42) |
+| Zebra Security Fixes | Zebra 4.4.0 shipped critical security bug fixes | [Read ->](https://x.com/ZcashFoundation/status/2050391385618997538?s=20) |
+| Zebra Fuzzing Infrastructure | Coverage-guided fuzzing work for Zebra parsing, networking, and cryptographic components | [Read ->](https://forum.zcashcommunity.com/t/zebra-coverage-guided-fuzzing-infrastructure/54972/13) |
+| Privacy-Safe Risk Intelligence | Quantir proposal for risk intelligence around Zcash infrastructure | [Read ->](https://forum.zcashcommunity.com/t/grant-application-quantir-privacy-safe-risk-intelligence-for-zcash-infrastructure/55568) |
+
 
 ## Responsible Disclosure:
 
 The Electric Coin Company & Zcash Foundation both conform to this Responsible Disclosure [standard](https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/d47a5a3dafa5942c8849a93441745fdd186731e6) with the following Deviation: 
 
 >"Zcash is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zcash. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible.The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue. In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable."
-
 

--- a/site/Zcash_Community/Zcash_Global_Ambassadors.md
+++ b/site/Zcash_Community/Zcash_Global_Ambassadors.md
@@ -12,10 +12,20 @@ The Global Ambassador Program is designed to identify community members who make
   * Hosting physical or virtual meetup events
   * Maintaining an active presence on social media, and creating original content related to Zcash.
   * Ambassadors have creative freedom over the activities they plan. 
+
+## Recent Ambassador and Regional Updates
+
+| Update | Link |
+|--------|------|
+| Global Ambassador Elzz April 2026 report | [Read ->](https://forum.zcashcommunity.com/t/global-ambassador-elzz-april-2026-report/55566) |
+| Zcash Global en Espanol 2026 March report | [Read ->](https://forum.zcashcommunity.com/t/zcash-global-en-espanol-2026/53815/27) |
+| Zcash Nigeria monthly activity report | [Read ->](https://forum.zcashcommunity.com/t/zcash-nigeria-2026/53654/15) |
+| Zcash Ghana April-June 2026 report | [Read ->](https://forum.zcashcommunity.com/t/zcash-ghana-april-2026-june-2026/55101/7) |
+| Zcash Brazil 2026 milestone update | [Read ->](https://forum.zcashcommunity.com/t/zcash-brazil-2026/53702/19) |
+| Pesa Ya Siri Tanzania outreach proposal | [Read ->](https://forum.zcashcommunity.com/t/pesa-ya-siri-making-zcash-a-household-name-in-tanzania/55558) |
   
 ## [Global Ambassador Website](https://zcashambassadors.com)
   
 
 
  
-


### PR DESCRIPTION
## Summary

- Updates the six wiki pages requested in #1592:
  - Community Blogs
  - Arborist Calls
  - Community Projects
  - Zcash Ecosystem Security
  - Community Links
  - Global Ambassadors
- Adds recent 2026 links and context from the ZecHub ecosystem digest, Zcash community forum, Zcash Foundation, and Zcash community accounts.
- Fixes a few small wording/typo issues while keeping the existing page structure.

Fixes #1592

## Testing

- `git diff --check`

## Payout

The contribution guide asks for a Zcash unified address for tips. I can provide it in a follow-up comment if this PR is accepted.
