### PR TITLE
Add ZEC gaming ecosystem privacy wiki page

### DIFF
--- a/site/Zcash_Use_Cases/Privacy_in_Play_Zcash_in_the_Global_Gaming_Ecosystem.md
+++ b/site/Zcash_Use_Cases/Privacy_in_Play_Zcash_in_the_Global_Gaming_Ecosystem.md
@@ -1,0 +1,197 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Use_Cases/Privacy_in_Play_Zcash_in_the_Global_Gaming_Ecosystem.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Privacy in Play: Zcash in the Global Gaming Ecosystem
+
+Gaming is one of the largest digital economies in the world. Players buy skins, battle passes, season passes, tournament entries, creator items, collectibles, subscriptions, and small in-game upgrades. These payments often look harmless in isolation, but together they can create a detailed record of a player's habits, identity, spending level, and social connections.
+
+Zcash can help gaming applications protect that financial metadata. Shielded ZEC payments allow a game, marketplace, tournament, or creator platform to accept value without publishing every player's wallet balance and transaction history to a public blockchain.
+
+## TL;DR
+
+- Game payments create sensitive metadata: what a player buys, when they play, which communities they join, and how much they spend.
+- Public blockchains can expose this activity if a player uses the same visible wallet address for repeated purchases.
+- Zcash shielded addresses protect sender, receiver, amount, and encrypted memo data from public observers.
+- Game studios can use ZEC for private microtransactions, creator payouts, tournament prizes, subscriptions, donations, and cross-border community payments.
+- Zcash is most useful when the game keeps identity, order tracking, and gameplay data off-chain while using shielded payments for settlement.
+
+## Why Gaming Payments Need Privacy
+
+Modern games are social and persistent. A single player may make dozens or hundreds of small payments over time:
+
+- Battle passes and season passes.
+- Cosmetic skins and character items.
+- User-generated content purchases.
+- Guild or clan treasury contributions.
+- Tournament entry fees.
+- Esports prizes.
+- Tips to streamers or mod creators.
+- Marketplace trades.
+- Server subscriptions.
+
+If those payments happen on a transparent blockchain, the payment history can become public. Anyone who connects a wallet to a gamer tag, livestream account, tournament roster, Discord identity, or exchange withdrawal can start building a profile.
+
+That profile may reveal:
+
+- How much a player spends.
+- When the player is active.
+- Which games or servers they use.
+- Which creators or teams they support.
+- Which other wallets they interact with.
+- Whether a player is a high-value target for phishing or harassment.
+
+Financial privacy is not only about large transfers. In gaming, small payments can be more revealing because they happen frequently and follow personal behavior.
+
+## The Problem With Transparent Microtransactions
+
+Traditional crypto payments can create a public trail. For example, if a player uses a transparent address to buy a battle pass, then later buys skins, donates to a streamer, joins a tournament, and receives a prize, those events may be linkable.
+
+That creates risks for players and game operators:
+
+- **Player doxing:** A wallet connected to a gamer tag may expose balances and spending history.
+- **Behavior tracking:** Purchase timing can reveal play schedules or time zones.
+- **Targeting whales:** High spenders can be identified and targeted by scammers.
+- **Competitive intelligence:** Rival studios or traders can monitor marketplace flows.
+- **Community pressure:** Players may be judged for what they spend or which creators they support.
+- **Prize exposure:** Tournament winnings can reveal income to anyone watching the chain.
+
+Transparent blockchains are useful for auditability, but most ordinary game purchases do not need global public visibility.
+
+## How Zcash Helps
+
+Zcash supports shielded transactions. When ZEC is sent between shielded receivers, public observers cannot see the sender, receiver, amount, or encrypted memo.
+
+This is useful for gaming because a payment can be verified by the game or payment processor without turning the player's entire spending graph into public data.
+
+Zcash can protect:
+
+- **Player privacy:** Purchases do not expose a reusable public payment trail.
+- **Creator privacy:** Donations and creator payouts can stay confidential.
+- **Tournament privacy:** Prize payments can avoid exposing every winner's full wallet history.
+- **Merchant privacy:** Game studios and servers can avoid revealing total revenue through a public address balance.
+- **Community privacy:** Guilds, clans, and DAOs can fund shared activity without exposing every contribution.
+
+Zcash does not hide information that a game itself collects. A game can still know a user's account, order, or entitlement. The benefit is that this data does not need to be published to the whole internet through a transparent blockchain.
+
+## Gaming Use Cases
+
+### Private In-Game Purchases
+
+A game can accept shielded ZEC for skins, upgrades, battle passes, maps, or season content. The game records the purchase in its own account system, while the public blockchain does not reveal the player's purchase amount or address history.
+
+### Creator Tips and Mod Payments
+
+Players can support streamers, map makers, mod developers, artists, or community hosts with shielded ZEC. This is useful when creators want to receive support without exposing all donor relationships or total income publicly.
+
+### Esports Prizes and Tournament Entry
+
+Tournament organizers can collect entry fees and pay winners in ZEC. Shielded payments reduce the public financial trail around who paid, who won, and how much each participant received.
+
+### Guilds, Clans, and Community Treasuries
+
+Gaming communities often pool money for servers, events, art commissions, prize pools, or shared tools. Zcash can help these groups collect and spend funds while limiting public visibility into individual contributions.
+
+### Cross-Border Player Payments
+
+Gaming communities are global. ZEC can move across borders without relying on a specific national payment app. Shielded payments add privacy for players in regions where public crypto activity can create personal, social, or political risk.
+
+### Player-to-Player Marketplaces
+
+If a game allows user-generated content or marketplace trades, ZEC can be used for private settlement. The marketplace can still enforce rules, fees, refunds, and moderation off-chain while avoiding a public spending graph for every player.
+
+## Example: Buying a Battle Pass
+
+Transparent flow:
+
+1. Player withdraws crypto from an exchange to a public wallet.
+2. Player buys a battle pass from a game wallet.
+3. The same wallet later buys skins and sends funds to a tournament.
+4. Observers can link the activity and estimate the player's spending.
+
+Shielded Zcash flow:
+
+1. Player receives or shields ZEC into a shielded wallet.
+2. Game shows a shielded payment request with amount and optional memo or order code.
+3. Player sends a shielded ZEC payment.
+4. Game verifies the payment and grants the battle pass.
+5. Public observers cannot see the player's address, amount, or memo.
+
+The game still knows the order was paid. The difference is that unrelated observers do not get a permanent public record of the player's spending history.
+
+## Architecture for Game Developers
+
+A game or marketplace does not need to put gameplay data on-chain. A privacy-preserving design can keep most data in the game backend and use Zcash only for payment settlement.
+
+### Basic Payment Flow
+
+1. Player chooses an item, subscription, entry fee, or donation.
+2. Backend creates an invoice with price, expiration time, and order ID.
+3. Backend displays a shielded Zcash payment address or payment URI.
+4. Player pays from a wallet that supports shielded ZEC.
+5. Backend watches for the incoming payment.
+6. Backend matches the payment to the order using amount, memo, or invoice logic.
+7. Game grants the entitlement, prize, or account credit.
+
+### Recommended Design Principles
+
+- Keep player identity and gameplay data off-chain.
+- Use shielded receiving addresses where possible.
+- Use encrypted memos or internal order IDs for reconciliation.
+- Avoid requiring players to post transaction IDs in public chats.
+- Separate treasury, marketplace, creator, and tournament wallets.
+- Give users a clear explanation of what the game can see and what the public chain cannot see.
+
+## What Zcash Does Not Solve
+
+Zcash protects payment metadata on-chain, but it is not a complete privacy system by itself.
+
+Game developers still need to protect:
+
+- Account emails and phone numbers.
+- IP addresses and device fingerprints.
+- Chat logs and social graphs.
+- Anti-cheat telemetry.
+- KYC or tax records when legally required.
+- Marketplace dispute records.
+- Customer support tickets.
+
+If a game links a payment to a public profile, publishes a leaderboard with wallet addresses, or stores sensitive logs insecurely, the privacy benefit is weakened. Zcash should be part of a broader privacy design.
+
+## Best Practices for Players
+
+- Use wallets that support shielded ZEC.
+- Avoid reusing transparent addresses for gaming payments.
+- Do not post payment screenshots, transaction IDs, or wallet addresses in public chats unless necessary.
+- Keep gaming identity separate from exchange accounts and personal social accounts.
+- Use memos carefully; include only what the game needs for order matching.
+- Test with small amounts before using a new game, marketplace, or server.
+- Keep seed phrases and spending keys offline and private.
+
+## Best Practices for Game Studios
+
+- Accept shielded ZEC instead of only transparent addresses.
+- Avoid publishing treasury addresses if privacy is part of the user promise.
+- Do not require players to disclose wallet balances or transaction histories.
+- Keep invoices short-lived to reduce payment confusion.
+- Explain refund and support flows before users pay.
+- Use viewing keys or payment disclosures carefully for accounting, audits, or compliance.
+- Make privacy defaults simple enough for non-technical players.
+
+## Why This Matters for the Gaming Ecosystem
+
+Gaming payments are becoming more global, social, and continuous. Players do not only buy a game once. They subscribe, tip, trade, join servers, fund communities, and participate in creator economies.
+
+That makes privacy more important, not less. A payment network for games should not expose a player's full financial graph just because they bought a skin or entered a tournament.
+
+Zcash gives game developers a way to add private digital payments while preserving user choice. It can support payments that are fast, global, and confidential, while keeping game logic, moderation, inventory, and account systems off-chain where they belong.
+
+## Further Reading
+
+- [Zcash wallets](../Using_Zcash/Wallets.md)
+- [Shielded pools](../Using_Zcash/Shielded_Pools.md)
+- [Transactions](../Using_Zcash/Transactions.md)
+- [Memos](../Using_Zcash/Memos.md)
+- [Payment request URIs](../Using_Zcash/Payment_Request_URIs.md)
+- [Newzoo Global Games Market Report 2025](https://newzoo.com/resources/trend-reports/newzoo-global-games-market-report-2025)
+- [ESA 2025 Essential Facts About the U.S. Video Game Industry](https://www.theesa.com/resources/essential-facts-about-the-us-video-game-industry/2025-data/)


### PR DESCRIPTION
## Summary
- Adds a new Zcash use-case page for the global gaming ecosystem
- Explains how transparent microtransactions can expose player metadata, spending, timing, and social links
- Covers shielded ZEC use cases for in-game purchases, creator tips, esports prizes, community treasuries, and marketplaces
- Adds developer architecture guidance, player/studio best practices, and research links

Fixes #1557

## Testing
- git diff --check

## Payout
- Public Zcash unified address can be provided in a follow-up comment if this bounty is accepted.