### PR TITLE
Improve real-world Zcash use case journey

### DIFF
--- a/site/Zcash_Use_Cases/About.md
+++ b/site/Zcash_Use_Cases/About.md
@@ -1,50 +1,62 @@
 # Use Zcash in the Real World
 
-Zcash is not just about privacy in theory — it's about **practical, everyday financial freedom**.
+Zcash privacy is most useful when it becomes practical. This section turns the basic ideas behind shielded ZEC into step-by-step playbooks for everyday situations.
 
-This section shows you **exactly how to use Zcash in real-life scenarios**, with step-by-step guides and best practices.
+Each guide focuses on a real workflow: what to set up, what to avoid, how to preserve privacy, and what the next step should be.
 
 ## What You'll Learn
 
-- How to protect your financial privacy
-- How to avoid common mistakes that expose your data
-- How to apply Zcash in real-world situations
+- How to receive or send ZEC without exposing unnecessary financial data.
+- How to separate identities, wallets, and use cases.
+- How to use memos and internal records without publishing private information.
+- How to avoid common mistakes that weaken privacy.
+- How to move from simple personal use to advanced operational workflows.
 
-## How to Use These Guides
+## Before You Start
 
-Each playbook is:
-- Short (5-7 minutes)
-- Step-by-step
-- Focused on real-world 
+You should understand three basics:
 
+- **Shielded addresses** protect sender, receiver, amount, and encrypted memo data from public observers.
+- **Transparent addresses** are public and can expose balances, counterparties, and transaction history.
+- **Operational privacy** also depends on behavior: where you post addresses, how you identify yourself, how you store records, and how you handle support or accounting.
 
-If you're new, start here: [What is Zcash](/start-here/what-is-zec-and-zcash)
+If you are new to Zcash, start with [What is Zcash](/start-here/what-is-zec-and-zcash), then return to this journey.
 
+## Recommended Path
 
-##  Recommended Path
+Follow the guides in order. They move from beginner to advanced and build on the habits from the previous page.
 
-Follow this step-by-step journey to master real-world Zcash usage:
+### 1. [Receive Donations Privately](Receive_Donations_Privately.md)
 
-###  [Receive Donations Privately](/zcash-use-cases/receive-donations-privately)
-Learn how to accept funds without exposing your identity or financial history.
+Start here if you want to receive ZEC without exposing your identity, donation history, or wallet balance.
 
+### 2. [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
 
-###  [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity) 
-Avoid exposing your wallet, identity, or transaction graph when sending funds.
+Learn how to send shielded payments while reducing links between your wallet, identity, timing, and recipient.
 
+### 3. [Freelancer Privacy Setup](Freelance_Privacy_Setup.md)
 
-###  [Freelancer Privacy Setup](/zcash-use-cases/freelancer-privacy-setup)  
-Get paid in Zcash while keeping your clients and income private.
+Apply the same privacy habits to client payments, invoices, memos, and income separation.
 
+### 4. [Accept Payments as a Merchant](Accept_Payments_AS_A_Merchant.md)
 
-###  [Accept Payments as a Merchant](/zcash-use-cases/accept-payment-as-a-merchant)  
-Accept payments using a shielded address and avoid exposing customer transaction data
+Turn private receiving into a repeatable business payment flow with order tracking and customer privacy.
 
+### 5. [Run a Private Community Treasury](Private_Community_treasury.md)
 
-###  [Run a Private Community Treasury](/zcash-use-cases/run-a-private-community-treasury)
-Use shielded addresses to hold shared funds and limit visibility of balances and transactions
+Use shielded ZEC for shared funds, roles, internal records, and group spending decisions.
 
-###  [Journalist Privacy Setup](/zcash-use-cases/journalist-privacy-setup)   
-Use shielded addresses for all transactions and protect sources by avoiding traceable payments. Use memos carefully for secure communication
+### 6. [Journalist Privacy Setup](Journalist_privacy_setup.md)
+
+Finish with the most sensitive workflow: protecting sources, payments, memos, and operational metadata.
+
+## Completion Goal
+
+After completing the full path, you should be able to:
+
+- Choose shielded or transparent ZEC intentionally.
+- Receive, send, and track ZEC without unnecessary public exposure.
+- Explain the privacy tradeoffs of each workflow.
+- Build a simple payment process for personal, professional, merchant, community, or source-protection use.
 
 <br/>

--- a/site/Zcash_Use_Cases/Accept_Payments_AS_A_Merchant.md
+++ b/site/Zcash_Use_Cases/Accept_Payments_AS_A_Merchant.md
@@ -120,8 +120,8 @@ You can:
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
 
-- [Wallets](/wallets)
-- [Privacy - Best Practices](/privacy/best-practices)
+- [Wallets](../Using_Zcash/Wallets.md)
+- [Payment Processors](../Using_Zcash/Payment_Processors.md)
 
 <br/>
 
@@ -135,5 +135,5 @@ You can now run private payment flows for business.
 
 ## Next Step
 
-- [Run a Private Community Treasury](/use-cases/private-community-treasury)
+- [Run a Private Community Treasury](Private_Community_treasury.md)
 <br/>

--- a/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md
+++ b/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md
@@ -110,7 +110,7 @@ You can:
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
-- [Wallets](/wallets)
+- [Wallets](../Using_Zcash/Wallets.md)
 
 <br/>
 
@@ -124,5 +124,5 @@ You now understand how to receive income privately.
 
 ## Next Step
 
-- [Accept Payments as a Merchant](/use-cases/accept-payments-as-a-merchant)
+- [Accept Payments as a Merchant](Accept_Payments_AS_A_Merchant.md)
 <br/>

--- a/site/Zcash_Use_Cases/Journalist_privacy_setup.md
+++ b/site/Zcash_Use_Cases/Journalist_privacy_setup.md
@@ -113,8 +113,8 @@ You can:
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
-- [Privacy - Best practices](/privacy/best-practices)
-- [Send money without linking identity](/use-cases/send-money-without-linking-identity)
+- [Shielded Pools](../Using_Zcash/Shielded_Pools.md)
+- [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
 
  <br/>
 
@@ -133,8 +133,8 @@ You now understand:
 
 ## What Next?
 
-- [Go to home page](/)
-- [Explore developer paths](/developers)
-- [Contribute to ZecHub](/contribute/help-build-zechub)
+- [Review Wallets](../Using_Zcash/Wallets.md)
+- [Learn about Shielded Pools](../Using_Zcash/Shielded_Pools.md)
+- [Return to the Real World Use Cases index](About.md)
 
 <br/> 

--- a/site/Zcash_Use_Cases/Private_Community_treasury.md
+++ b/site/Zcash_Use_Cases/Private_Community_treasury.md
@@ -121,8 +121,8 @@ Your community can:
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
-- [Privacy - Best practices](/privacy/best-practices)
-- [Send money without linking identity](/use-cases/send-money-without-linking-identity)
+- [Shielded Pools](../Using_Zcash/Shielded_Pools.md)
+- [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
  
 
 <br/>
@@ -137,4 +137,4 @@ You understand how to manage shared funds privately.
 
 ## Next Step
 
-- [Journalist Privacy Setup](/use-cases/journalist-privacy-setup)
+- [Journalist Privacy Setup](Journalist_privacy_setup.md)

--- a/site/Zcash_Use_Cases/Receive_Donations_Privately.md
+++ b/site/Zcash_Use_Cases/Receive_Donations_Privately.md
@@ -106,8 +106,8 @@ You can:
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
-- [Privacy - Shielded vs Transparent](/privacy/shielded-vs-transparent)
-- [Wallets](/wallets)
+- [Shielded Pools](../Using_Zcash/Shielded_Pools.md)
+- [Wallets](../Using_Zcash/Wallets.md)
 
 <br/>
 
@@ -123,6 +123,6 @@ You have learned how to receive funds privately.
 
 Continue your journey:
 
-- [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity)
+- [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
   
 <br/>

--- a/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md
+++ b/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md
@@ -96,7 +96,7 @@ You can:
 <br/>
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
-- [Privacy - Shielded vs Transparent](/privacy/shielded-vs-transparent)
+- [Shielded Pools](../Using_Zcash/Shielded_Pools.md)
 
 <br/>
 
@@ -110,4 +110,4 @@ You can now send funds privately without exposing identity.
 
 ## Next Step
 
-- [Freelancer Privacy Setup](/use-cases/freelancer-privacy-setup)
+- [Freelancer Privacy Setup](Freelance_Privacy_Setup.md)


### PR DESCRIPTION
## Summary
- Reworks the Use Zcash in the Real World index into a clear beginner-to-advanced journey
- Preserves and links the six requested playbooks: donations, sending, freelancer setup, merchant payments, community treasury, and journalist privacy
- Fixes next-step chaining and related links across all six playbooks
- Adds clearer completion goals, operational privacy context, and practical progression

Fixes #1555

## Testing
- git diff --check

## Payout
- Public Zcash unified address can be provided in a follow-up comment if this bounty is accepted.