### PR TITLE
Add May 9 Zcash ecosystem digest

### DIFF
--- a/newsletter/Digest 05-09-2026.md
+++ b/newsletter/Digest 05-09-2026.md
@@ -1,0 +1,60 @@
+# Zcash Ecosystem Digest | May 9th
+
+Zebra 4.4.1 and zcashd 6.12.3 shipped security and reliability updates, Zcash Foundation prepared the Rome Dev Summit, and the forum stayed busy with Zcashd deprecation, Zaino, wallet, community, and grant discussions.
+
+Curated for [ZecHub issue #1586](https://github.com/ZecHub/zechub/issues/1586).
+
+## Shielded Labs, Electric Coin Company, Zcash Foundation Updates
+
+- [Zebra 4.4.1 critical security fix](https://forum.zcashcommunity.com/t/zebra-4-4-1-critical-security-fix/55588) - Zcash Foundation announced the recommended Zebra upgrade and linked the release notes.
+- [Zebra 4.4.1 release](https://github.com/ZcashFoundation/zebra/releases/tag/v4.4.1) - The node release was published on May 4 with the packaged binaries and source archives.
+- [zcashd v6.12.3 release](https://github.com/zcash/zcash/releases/tag/v6.12.3) - The latest zcashd release was published on May 8 for operators still tracking the legacy node.
+- [ZF Engineering Update, April 20-May 3](https://forum.zcashcommunity.com/t/zf-engineering-update-april-20th-may-3rd/55618) - ZF shared current engineering work across Zebra, FROST, Zallet, and related infrastructure.
+- [ZF stewardship of core assets](https://forum.zcashcommunity.com/t/zf-stewardship-of-core-assets/55623) - The Foundation opened a governance discussion about stewardship responsibilities for key Zcash ecosystem assets.
+- [Zcash Z3 updates](https://forum.zcashcommunity.com/t/zcash-z3-updates-formerly-zcashd-deprecation/48965) - The ongoing Z3 thread continues to track the replacement stack for zcashd.
+- [Zcash Dev Summit 2026: Rome](https://forum.zcashcommunity.com/t/save-the-date-three-exciting-events-coming-in-2026/53876) - The community prepared for the May 12-13 developer summit around protocol, wallet, and infrastructure work.
+- [ZIP 316 unified address update](https://forum.zcashcommunity.com/t/zip-316-unified-addresses-and-unified-viewing-key-rev-2-discussion/55515) - The ZIP 316 revision thread focuses on unified addresses and viewing keys.
+
+---
+
+## Zcash Community Grants
+
+- [ZCG security and vulnerability disclosure initiative](https://forum.zcashcommunity.com/t/zcg-security-vulnerability-disclosure-initiative/55545) - The proposal outlines a coordinated path for ecosystem security reporting and response.
+- [ZCG anchor sponsorship for the Cypherpunk Policy Dinner](https://forum.zcashcommunity.com/t/cypherpunk-policy-dinner-cpd-zcg-anchor-sponsorship/55592) - The sponsorship request frames Zcash alongside policy, privacy, and civil-society conversations.
+- [Zcash Network School](https://forum.zcashcommunity.com/t/zcash-network-school/55269) - The education proposal targets structured learning for people entering the Zcash ecosystem.
+- [Zcash Grants Hub](https://forum.zcashcommunity.com/t/zcashgranthub-a-better-ui-for-zcg-grants-built-fast-with-ai-tools-seeking-feedback/55267) - The community reviewed a prototype interface for easier grant discovery and tracking.
+- [Zcash ecosystem onboarding at Women in DeFi Summit 2026](https://forum.zcashcommunity.com/t/zcash-ecosystem-onboarding-proposal-at-women-in-defi-summit-2026/55081) - The proposal aims to introduce Zcash privacy tooling to new users at the summit.
+- [Grant application: ZecShield universal privacy bridge](https://forum.zcashcommunity.com/t/grant-application-zecshield-universal-privacy-bridge-between-solana-and-zcash/55232) - The grant would explore a privacy bridge between Solana activity and Zcash.
+- [Grant application: Zcash CIS Media and Community Growth Program 2026](https://forum.zcashcommunity.com/t/grant-application-zcash-cis-media-community-growth-program-2026/55252) - The application focuses on Russian-language and CIS-region media coverage.
+- [Zcash Community Media Infrastructure Support: ZK AV Club 2026](https://forum.zcashcommunity.com/t/zcash-community-media-infrastructure-support-zk-av-club-2026/53913) - The ZK AV Club thread continues to track media production infrastructure and reports.
+
+---
+
+## Community Projects
+
+- [ZecHub 2026: Education, outreach, and ecosystem coordination](https://forum.zcashcommunity.com/t/zechub-2026/53686) - ZecHub's 2026 thread tracks education, wiki, digest, and coordination work.
+- [CipherScan 2026](https://forum.zcashcommunity.com/t/cipherscan-2026-zcash-indexing-analytics-utility/54151) - CipherScan development is focused on indexing, analytics, and practical Zcash utility.
+- [Rore: high-performance Rust UI engine for Zcash desktop clients](https://forum.zcashcommunity.com/t/rore-high-performance-rust-ui-engine-for-zcash-desktop-clients/55634) - The project explores native Rust UI foundations for desktop Zcash apps.
+- [Zaino 0.3.0 release candidate](https://github.com/ZingoLabs/zaino/releases/tag/0.3.0-rc.1) - Zaino published a May 5 release candidate for the indexer and service stack.
+- [Zaino, the Zallet release](https://forum.zcashcommunity.com/t/zaino-the-zallet-release/52155) - The forum thread continues to document Zaino's path toward wallet infrastructure support.
+- [Zkool, the successor to Ywallet](https://forum.zcashcommunity.com/t/zkool-the-successor-to-ywallet/54247) - Zkool remains an active wallet discussion around the next step after Ywallet.
+- [ZecVault, a goal-based savings wallet](https://forum.zcashcommunity.com/t/zecvault-a-goal-based-savings-wallet-built-on-zcash-shielded-transactions/55464) - The project proposes Zcash savings flows organized around user goals.
+- [Building a Zig foothold in the Zcash ecosystem](https://forum.zcashcommunity.com/t/building-a-zig-foothold-in-the-zcash-ecosystem-talking-to-zebra-over-json-rpc/55243) - The thread shows how Zebra JSON-RPC can be used from Zig.
+- [Zcash block time reduction appears safe for NU7](https://forum.zcashcommunity.com/t/zcash-block-time-reduction-appears-safe-for-nu7-w-zebra-only-devnet/55586) - Community analysis reviews block-time reduction safety assumptions for NU7.
+- [Zcash integration for the Open Wallet Standard](https://forum.zcashcommunity.com/t/zcash-integration-for-the-open-wallet-standard-completed/55425) - The completed integration thread documents Open Wallet Standard work.
+- [Zcash Global en Espanol 2026](https://forum.zcashcommunity.com/t/zcash-global-en-espanol-2026/53815) - The Spanish-language community continues reporting regional education and outreach.
+- [Zcast, the Zcash podcast in Spanish](https://forum.zcashcommunity.com/t/zcast-the-zcash-podcast-in-spanish-a-new-phase/54291) - Zcast outlined its next phase for Spanish-language Zcash audio content.
+- [Club Zcash Barcelona](https://forum.zcashcommunity.com/t/club-zcash-barcelona-the-journey-begins/51247) - The Barcelona group is forming local community events around Zcash.
+- [Zcash Brazil 2026](https://forum.zcashcommunity.com/t/zcash-brazil-2026/53702) - Zcash Brazil is documenting grassroots activity, regional education, and local outreach.
+- [Zcash Nigeria growth report](https://forum.zcashcommunity.com/t/zcash-nigeria-2026/53654) - The Nigeria thread tracks community growth, education, and local ecosystem work.
+- [Introducing Zcash to Kenyan universities and tech communities](https://forum.zcashcommunity.com/t/introducing-zcash-to-kenyan-universities-tech-communities-2026/55088) - The proposal brings Zcash privacy education to Kenyan technical communities.
+- [Zcash Ghana, April-June 2026](https://forum.zcashcommunity.com/t/zcash-ghana-april-2026-june-2026/55101) - Zcash Ghana's thread covers planned community activity for the quarter.
+- [Zcash CIS media and community growth](https://forum.zcashcommunity.com/t/grant-application-zcash-cis-media-community-growth-program-2026/55252) - The CIS proposal supports regional media and outreach, including Russian-language audiences.
+- [Zcash Global Ambassadors](https://zechub.wiki/zcash-community/global-ambassadors) - The ZecHub wiki keeps a reference page for ambassador groups and local community channels.
+- [Community projects on ZecHub](https://zechub.wiki/zcash-community/community-projects) - The community projects page remains a useful index for wallets, tools, media, and regional efforts.
+
+---
+
+## Meme of the Week
+
+- [ZecHub on X](https://x.com/ZecHub) - Check the ZecHub feed for the latest privacy memes, digest posts, and short-form community updates.


### PR DESCRIPTION
## Summary
- add the May 9 Zcash Ecosystem Digest under `newsletter/`
- cover Foundation/core updates, ZCG proposals, regional community updates, wallet/tooling work, and ZecHub resources
- include more than 20 ecosystem links with English descriptions

Fixes #1586

## Testing
- checked all markdown links for non-error HTTP responses
- checked for trailing whitespace