### PR TITLE
Add May 2 Zcash ecosystem digest

### DIFF
--- a/newsletter/Digest 05-02-2026.md
+++ b/newsletter/Digest 05-02-2026.md
@@ -1,0 +1,117 @@
+# Zcash Ecosystem Digest | May 2nd
+
+Dive into Zebra 4.4.0 critical security fixes, Zcash Foundation hiring news, Crosslink updates, new ZCG proposals, Zcash Arabia, Brazil, Nigeria, Ghana, India, Mexico, Kenya, Zk Av Club, ZODL, CipherScan, Zafu, BazaarSwap, Zec Map, Zcash Names, and other Zcash community activity from the week.
+
+Curated by [ZecHub contributors](https://github.com/ZecHub/zechub)
+
+## Shielded Labs, Electric Coin Company, Zcash Foundation, and Zcash Updates
+
+[Zebra 4.4.0 critical security fixes - Zcash Foundation](https://zfnd.org/zebra-4-4-0-critical-security-fixes/)
+
+[Zcash Foundation welcomes a new platform engineer - Zcash Foundation](https://zfnd.org/zcash-foundation-welcomes-a-new-platform-engineer/)
+
+[ZF engineering update for April 20 through May 3, 2026 - Zcash Foundation](https://forum.zcashcommunity.com/t/zf-engineering-update-april-20th-may-3rd-2026/55618)
+
+[Shielded Labs Crosslink deployment updates - Shielded Labs](https://forum.zcashcommunity.com/t/shielded-labs-crosslink-deployment-updates/49706)
+
+[Shielded Labs independent organization discussion - Shielded Labs](https://forum.zcashcommunity.com/t/shielded-labs-an-independent-non-us-organization/43855)
+
+[Bending the Bow: ZODL update - ZODL](https://forum.zcashcommunity.com/t/bending-the-bow-zodl-update/55514)
+
+[ZODL is live on Google Play - ZODL](https://forum.zcashcommunity.com/t/zodl-is-live-on-google-play/54859)
+
+---
+
+## Zcash Community Grants
+
+[Zcash Community Grants meeting minutes for April 27, 2026 - ZCG](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-april-27-2026/55555)
+
+[ZCG RFP: Community Note Taker 2025 - ZCG](https://forum.zcashcommunity.com/t/zcg-rfp-community-note-taker-2025/50450)
+
+[Zcash Developer Relations Engineer - ZCG](https://forum.zcashcommunity.com/t/zcash-developer-relations-engineer/48368)
+
+[Zebra coverage-guided fuzzing infrastructure - ZCG application](https://forum.zcashcommunity.com/t/zebra-coverage-guided-fuzzing-infrastructure/54972)
+
+[Grant application for revocable private delegation in token holder voting - ZCG application](https://forum.zcashcommunity.com/t/grant-application-revocable-private-delegation-in-token-holder-voting/55485)
+
+[Quantir privacy-safe risk intelligence for Zcash infrastructure - ZCG application](https://forum.zcashcommunity.com/t/grant-application-quantir-privacy-safe-risk-intelligence-for-zcash-infrastructure/55568)
+
+[Quiet Money for Zcash, Phase 1 - Zush](https://forum.zcashcommunity.com/t/grant-application-zush-quiet-money-for-zcash-phase-1/55458)
+
+[Zafu wallet retroactive grant application - Zafu](https://forum.zcashcommunity.com/t/zafu-wallet-retroactive-grant-application/55551)
+
+[Grassroots marketing team at DWeb Camp - grant application](https://forum.zcashcommunity.com/t/grant-application-grassroots-marketing-team-at-dweb-camp/55472)
+
+[Expanding Zcash in Unstoppable Wallet: liquidity, swaps, and distribution - retroactive grant](https://forum.zcashcommunity.com/t/expanding-zcash-in-unstoppable-wallet-liquidity-swaps-distribution-retroactive-grant/55529)
+
+---
+
+## Community Projects
+
+[CipherScan community update - CipherScan](https://forum.zcashcommunity.com/t/cipherscan-not-another-block-explorer-please-no/53694)
+
+[Zcash Engage server weekly activity - Zcash Engage](https://forum.zcashcommunity.com/t/zcash-engage-server/55358)
+
+[Introducing BazaarSwap: bringing ZEC to Web3 DeFi - BazaarSwap](https://forum.zcashcommunity.com/t/introducing-bazaarswap-bringing-zec-to-web3-defi/55479)
+
+[Zafu client development update - Zafu](https://forum.zcashcommunity.com/t/zafu-client-development/54933)
+
+[Zcash Brazil 2026 community updates - Zcash Brazil](https://forum.zcashcommunity.com/t/zcash-brazil-2026/53702)
+
+[Zcash Nigeria 2026 community updates - Zcash Nigeria](https://forum.zcashcommunity.com/t/zcash-nigeria-2026/53654)
+
+[Zcash Arabia May to September 2026 proposal - Zcash Arabia](https://forum.zcashcommunity.com/t/grant-zcasharabia-may-to-september-2026/55548)
+
+[Zcash Ghana April to June 2026 updates - Zcash Ghana](https://forum.zcashcommunity.com/t/zcash-ghana-april-2026-june-2026/55101)
+
+[Zcash India 2026 update thread - Zcash India](https://forum.zcashcommunity.com/t/zcash-india-2026/54762)
+
+[Zcash university outreach initiative in Mexico - CodeRaiz](https://forum.zcashcommunity.com/t/zcash-university-outreach-initiative-mexico-2026-coderaiz-proposal/55506)
+
+[Zcash gold sponsorship Kenya at KBCC 2026 activation and privacy workshop - Kenya community](https://forum.zcashcommunity.com/t/zcash-gold-sponsorship-kenya-kbcc-2026-activation-privacy-workshop/55520)
+
+[Teenagers in Blockchain Africa privacy and developer education initiative - TIBA](https://forum.zcashcommunity.com/t/teenagers-in-blockchain-africa-tiba-zcash-teenage-and-youth-privacy-developer-education-initiative/55498)
+
+[Zcash CIS educational initiative - Zcash CIS](https://forum.zcashcommunity.com/t/zcash-cis-educational-initiative/55419)
+
+[Spanish-speaking Zcash community now has its own node - Zcash Espanol community](https://forum.zcashcommunity.com/t/the-spanish-speaking-zcash-community-now-has-its-own-node/55530)
+
+[Zcash Community Media Infrastructure and Support 2026 - Zk Av Club](https://forum.zcashcommunity.com/t/zcash-community-media-infrastructure-support-zk-av-club-2026/53913)
+
+[Berlin Blockchain Week and DWeb Camp 2026 - Zk Av Club](https://forum.zcashcommunity.com/t/berlin-blockchain-week-and-dweb-camp-2026-zk-av-club/55047)
+
+[Call for representatives: Zcash at DWeb - community coordination](https://forum.zcashcommunity.com/t/call-for-representatives-zcash-dweb/55231)
+
+[Bountyzcash.org bug bounty infrastructure for the Zcash ecosystem - community collaboration](https://forum.zcashcommunity.com/t/bountyzcash-org-bug-bounty-infrastructure-for-the-zcash-ecosystem/55215)
+
+[ZEC Builders Hub at UNIABUJA - builder education](https://forum.zcashcommunity.com/t/grant-application-zec-builders-hub-uniabuja/55422)
+
+[Using Zcash in an internet freedom crowdfunding campaign - community proposal](https://forum.zcashcommunity.com/t/grant-proposal-using-zcash-in-an-internet-freedom-crowdfunding-campaign/55538)
+
+[Zonp wallet-native commerce on Zcash - project feedback](https://forum.zcashcommunity.com/t/zonp-wallet-native-commerce-on-zcash-zcg-proposal-feedback-requested/55409)
+
+[Seeking ideas and feedback for Zec Map - Zec Map](https://forum.zcashcommunity.com/t/seeking-ideas-and-feedback-for-zec-map/55505)
+
+[ZPrivDEX shielded AMM on Zcash - ZPrivDEX](https://forum.zcashcommunity.com/t/zprivdex-building-a-shielded-amm-on-zcash/55368)
+
+[Zcash Browser Wallet Library - browser wallet work](https://forum.zcashcommunity.com/t/zcash-browser-wallet-library/47897)
+
+[BTCPay Server Zcash plugin for multi-store configuration - BTCPay Zcash plugin](https://forum.zcashcommunity.com/t/grant-application-btcpayserver-zcash-plugin-per-store-zcash-configuration-for-multi-store-btcpay-instances/55335)
+
+[Open-source Orchard-based wallet service for enterprises - wallet infrastructure](https://forum.zcashcommunity.com/t/open-source-orchard-based-wallet-service-for-enterprises-looking-for-users-feedback/54417)
+
+---
+
+## Meme of the week
+
+[ZEC rally community discussion - r/zec](https://www.reddit.com/r/zec/comments/1t10fao/zec_rally_can_anyone_explain_why/)
+
+---
+
+## Jobs in the Ecosystem
+
+[Zcash Developer Relations Engineer - ZCG](https://forum.zcashcommunity.com/t/zcash-developer-relations-engineer/48368)
+
+[ZCG RFP: Community Note Taker 2025 - ZCG](https://forum.zcashcommunity.com/t/zcg-rfp-community-note-taker-2025/50450)
+
+[DeWork tasks posted every Monday - ZecHub](https://app.dework.xyz/zechub-2424)


### PR DESCRIPTION
Summary:
- Add the May 2nd Zcash Ecosystem Digest newsletter entry.
- Include English descriptions and public links across the requested sections.
- Include 26 Community Projects links and 48 total links.

Verification:
- Checked for trailing whitespace.
- Checked the file is ASCII-only.
- Confirmed issue #1573 is open and no existing PR references it.

Closes #1573