### PR TITLE
Add April 18 Zcash ecosystem digest

### DIFF
--- a/newsletter/Digest 04-18-2026.md
+++ b/newsletter/Digest 04-18-2026.md
@@ -1,0 +1,111 @@
+# Zcash Ecosystem Digest | April 18th
+
+Dive into Zebra 4.3.1, Zcash vulnerability remediation, ZODL migration updates, Coinholder-Directed Retroactive Grants, ZCG meeting notes, Zcash Grants Hub, Zk Av Club, Zonp, Zecboat, Zcash Operators, Zcash Unibadan, Zcash Global Turkish, ruZcash, Zcash Kenya, ZecHub wiki work, Zwap, and other ecosystem activity from the week.
+
+Curated by [ZecHub contributors](https://github.com/ZecHub/zechub)
+
+## Shielded Labs, Electric Coin Company, Zcash Foundation, and Zcash Updates
+
+[Zebra 4.3.1 critical security fixes, Dockerized mining, and CI hardening - Zcash Foundation](https://forum.zcashcommunity.com/t/zebra-4-3-1-critical-security-fixes-dockerized-mining-and-ci-hardening/55389)
+
+[Several Zcash vulnerabilities successfully remediated - ZODL, Shielded Labs, and ZF](https://forum.zcashcommunity.com/t/several-zcash-vulnerabilities-successfully-remediated/55388)
+
+[Advisory: reduce your zcashd attack surface by shielding it behind Zebra - Zcash security](https://forum.zcashcommunity.com/t/advisory-reduce-your-zcashd-attack-surface-by-shielding-it-behind-zebra/55390)
+
+[ZF engineering update for March 23 to April 5, 2026 - Zcash Foundation](https://forum.zcashcommunity.com/t/zf-engineering-update-march-23-to-april-5-2026/55270)
+
+[ZF initiative to champion privacy-preserving humanitarian aid - Zcash Foundation](https://forum.zcashcommunity.com/t/zf-launches-new-initiative-to-champion-privacy-preserving-humanitarian-aid/52026)
+
+[ECC to ZODL migration on Docker Hub - ZODL transition](https://forum.zcashcommunity.com/t/ecc-zodl-migration-on-docker-hub/55327)
+
+[Thinking Big: ZODL update - ZODL](https://forum.zcashcommunity.com/t/thinking-big-zodl-update/55326)
+
+---
+
+## Zcash Community Grants
+
+[Zcash Community Grants meeting minutes for April 13, 2026 - ZCG](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-4-13-2026/55349)
+
+[Coinholder-Directed Retroactive Grants Program Q2 2026 now accepting proposals - ZCG](https://forum.zcashcommunity.com/t/coinholder-directed-retroactive-grants-program-q2-2026-now-accepting-proposals/55328)
+
+[Polling closed for the Coinholder-Directed Grants Program Q1 round - ZCG](https://forum.zcashcommunity.com/t/polling-closed-coinholder-directed-grants-program-q1-round/55048)
+
+[Retroactive grant application for Zcash Grants Hub - community grants](https://forum.zcashcommunity.com/t/retroactive-grant-application-zcash-grants-hub-coinholder-program/55372)
+
+[Hanh maintenance and improvements to coin voting - ZCG application](https://forum.zcashcommunity.com/t/grant-application-hanh-maintenance-and-improvements-to-coin-voting/52350)
+
+[ZecShield universal privacy bridge between Solana and Zcash - ZCG application](https://forum.zcashcommunity.com/t/grant-application-zecshield-universal-privacy-bridge-between-solana-and-zcash/55232)
+
+[ZAP1 protocol hardening and Zaino integration - ZCG application](https://forum.zcashcommunity.com/t/grant-application-zap1-protocol-hardening-and-zaino-integration/55165)
+
+[Bootstrapped and deterministic builds with StageX - ZCG application](https://forum.zcashcommunity.com/t/bootstrapped-and-deterministic-builds-a-la-stagex/53040)
+
+[Marketing at ETHCC and Exxxotica Chicago - ZCG application](https://forum.zcashcommunity.com/t/marketing-at-ethcc-exxxotica-chicago/54832)
+
+[Fair Proof-of-Contribution open research platform - ZCG application](https://forum.zcashcommunity.com/t/f-poc-fair-proof-of-contribution-an-open-research-platform-for-equitable-mining-in-zcash/55179)
+
+---
+
+## Community Projects
+
+[Zonp wallet-native commerce app - Zonp](https://forum.zcashcommunity.com/t/zonp-wallet-native-commerce-app/55260)
+
+[RFF update for Zonp wallet-native commerce - Zonp](https://forum.zcashcommunity.com/t/rff-zonp-wallet-native-commerce-update/55371)
+
+[Zcash Operators uptime rewards discussion - Zcash Operators](https://forum.zcashcommunity.com/t/zcash-operators-earn-zec-for-your-uptime/52090)
+
+[The ZEC offramp problem - community discussion](https://forum.zcashcommunity.com/t/the-zec-offramp-problem/44652)
+
+[Open-source Zcash hardware wallet SDK for embedded devices - wallet tooling](https://forum.zcashcommunity.com/t/building-an-open-source-zcash-hardware-wallet-sdk-for-constrained-embedded-systems/55259)
+
+[Zero-knowledge Audiovisual Club update thread - Zk Av Club](https://forum.zcashcommunity.com/t/zero-knowledge-audiovisual-club-zk-av-club/43733)
+
+[Zecboat FROST-secured wrapped asset bridge - Zecboat](https://forum.zcashcommunity.com/t/zecboat-bridge-frost-secured-wrapped-asset-wsol/55199)
+
+[Trustless bridging for Zcash - bridge research](https://forum.zcashcommunity.com/t/proposal-trustless-bridging-for-zcash/53884)
+
+[ZODL wallet availability update in Russian app stores - ruZcash community](https://forum.zcashcommunity.com/t/zodl/55305)
+
+[Metamask Zcash Snap problem - wallet support](https://forum.zcashcommunity.com/t/metamask-zcash-snap-problem/53824)
+
+[Building a Zig foothold in the Zcash ecosystem - developer tooling](https://forum.zcashcommunity.com/t/building-a-zig-foothold-in-the-zcash-ecosystem-talking-to-zebra-over-json-rpc/55243)
+
+[Foundry institutional-grade Zcash mining pool launch discussion - mining ecosystem](https://forum.zcashcommunity.com/t/foundry-to-launch-institutional-grade-zcash-mining-pool-in-april-2026/54929)
+
+[Sapling withdraw-only discussion kickoff - protocol discussion](https://forum.zcashcommunity.com/t/sapling-withdraw-only-discussion-kickoff/55223)
+
+[Zcash Unibadan campus meetup report - Zcash Nigeria community](https://forum.zcashcommunity.com/t/zcash-unibadan-campus-meetup-report/55239)
+
+[Flatpak support for Zkool2 - Zkool tooling](https://forum.zcashcommunity.com/t/flatpak-support-for-zkool2/54687)
+
+[Wiki search and Answer with AI on zechub.wiki - ZecHub](https://forum.zcashcommunity.com/t/wiki-search-answer-with-ai-on-zechub-wiki/55277)
+
+[Zwap unlinkable cross-chain atomic swaps - Zwap](https://forum.zcashcommunity.com/t/zwap-unlinkable-cross-chain-atomic-swaps/55104)
+
+[Small bridge from the forum to Discord - community coordination](https://forum.zcashcommunity.com/t/feedback-wanted-small-bridge-from-this-forum-to-discord/55262)
+
+[Introducing Zcash to Kenyan universities and tech communities - Zcash East Africa](https://forum.zcashcommunity.com/t/introducing-zcash-to-kenyan-universities-tech-communities-2026/55088)
+
+[Zcash Global Turkish 2026 Q1 and Q2 - Zcash Turkey](https://forum.zcashcommunity.com/t/zcash-global-turkish-2026-q1-2/53945)
+
+[Lowo Life as a ZEC member - community story](https://forum.zcashcommunity.com/t/lowo-life-as-a-zec-member/51453)
+
+[Cypherpunk.com and Zcash support discussion - ecosystem discussion](https://forum.zcashcommunity.com/t/cypherpunk-com-new-winklevoss-company-supporting-zcash/53081)
+
+[ZecHub 2026 project updates - ZecHub](https://forum.zcashcommunity.com/t/zechub-2026/53686)
+
+[Zcash Elastic Subnet Bridge on Avalanche - bridge discussion](https://forum.zcashcommunity.com/t/zcash-elastic-subnet-bridge-on-avalanche/44220)
+
+---
+
+## Meme of the week
+
+[Community ZEC ownership discussion - r/zec](https://www.reddit.com/r/zec/comments/1sbku5r/how_much_zec_do_you_guys_currently_own/)
+
+---
+
+## Jobs in the Ecosystem
+
+[ZCG RFP: Community Note Taker 2025 - ZCG](https://forum.zcashcommunity.com/t/zcg-rfp-community-note-taker-2025/50450)
+
+[DeWork tasks posted every Monday - ZecHub](https://app.dework.xyz/zechub-2424)


### PR DESCRIPTION
Summary:
- Add the April 18th Zcash Ecosystem Digest newsletter entry.
- Include English descriptions and public links across the requested sections.
- Include 24 Community Projects links and 45 total links.

Verification:
- Checked for trailing whitespace.
- Checked the file is ASCII-only.
- Confirmed issue #1553 is open, no existing PR references it, and no matching newsletter file exists on main.

Closes #1553