### PR TITLE
Update Zcash community wiki pages

### DIFF
--- a/site/Zcash_Community/Arborist_Calls.md
+++ b/site/Zcash_Community/Arborist_Calls.md
@@ -8,13 +8,20 @@
 
 The Zcash Arborist Calls are bi-weekly protocol development meetings focused on tracking upcoming protocol deployment logistics, consensus node implementation issues, and protocol research.
 
-Offical Site: [https://zfnd.org/arborist-calls/](https://zfnd.org/arborist-calls/)
+Official site: [https://zfnd.org/arborist-calls/](https://zfnd.org/arborist-calls/)
 
-Anyone who wants to contribute to Zcash protocol development and to share news on Zcash node projects. 
+The calls alternate between two time slots so contributors in different regions can participate. Anyone interested in Zcash protocol development, node implementation work, network upgrades, research, Zebra, Zaino, lightwallet infrastructure, or related ecosystem engineering is welcome to follow along.
 
-Register here: [15:00 UTC](https://us06web.zoom.us/webinar/register/WN_Vk7WMz9sRkiIr_hqH_x3LA) / [22:30 UTC](https://us06web.zoom.us/webinar/register/WN_z0k1ipsnRkS4-DGqDhULdA)
+Join links, current time slots, and calendar files are maintained by the Zcash Foundation on the [official Arborist Calls page](https://zfnd.org/arborist-calls/).
 
-The complete list with full notes & agendas can be found [here](https://github.com/ZcashCommunityGrants/arboretum-notes). 
+The complete list of notes, agendas, and minutes can be found in the [arboretum-notes repository](https://github.com/ZcashCommunityGrants/arboretum-notes).
+
+## Resources
+
+- [Official Arborist Calls page](https://zfnd.org/arborist-calls/)
+- [Arborist Call recordings](https://www.youtube.com/playlist?list=PL40dyJ0UYTLJqD_3PE9qiJTxse-iHnn1G)
+- [Zcash R&D Discord](https://discord.com/invite/xpzPR53xtU)
+- [Zcash Community Forum](https://forum.zcashcommunity.com/)
 
 
 ## Playlist
@@ -29,5 +36,3 @@ The complete list with full notes & agendas can be found [here](https://github.c
     loading="lazy"
   />
 </div>
-
-

--- a/site/Zcash_Community/Community_Blogs.md
+++ b/site/Zcash_Community/Community_Blogs.md
@@ -2,23 +2,34 @@
 
 # Community Blogs
 
-Community members run many excellent blogs covering Zcash, privacy, cryptocurrency, and related topics.
+Community members and ecosystem teams publish regular updates about Zcash, privacy, wallets, grants, research, and community projects.
 
-Here are some of the active ones:
+Last reviewed: May 2026
 
-| Blog / Author              | Description                                              | Link |
-|----------------------------|----------------------------------------------------------|------|
-| James Katz                 | Personal writings and thoughts on Zcash and privacy      | [Visit ->](https://free2z.cash/James_Katz/) |
-| Thumbs' Update             | Regular ecosystem updates and insights                   | [Visit ->](https://thumbsup.substack.com) |
-| roomatemusing              | Musings and community content                            | [Visit ->](https://free2z.cash/roommatemusing) |
-| NerdBank Blog              | Technical blog focused on Zcash development and tools    | [Visit ->](https://blog.nerdbank.net/) |
-| Thor Likes                 | News, opinions, and commentary on Zcash                  | [Visit ->](https://www.thorlikes.com/) |
-| ZecMec                     | Zcash-focused articles on Medium                         | [Visit ->](https://zecmec21.medium.com/) |
-| Ian Sagstetter             | In-depth articles and newsletter                         | [Visit ->](https://iansagstetter.substack.com/) |
-| Naomi Brockwell (NBTV)     | High-profile interviews and content                      | [Visit ->](https://naomibrockwell.com/highprofileinterviews) |
-| Sqribbles                  | Creative and community-driven Zcash content              | [Visit ->](https://free2z.cash/sqribbles) |
-| Str4d                      | Technical writings from Zcash core developer             | [Visit ->](https://words.str4d.xyz/) |
+## Ecosystem updates
+
+| Blog / Feed | Description | Link |
+|-------------|-------------|------|
+| ZecHub Substack | Weekly Zcash ecosystem digest and community updates | [Visit ->](https://zechub.substack.com/) |
+| Zcash Community | Community hub with Zcash news, blog feeds, project links, and onboarding resources | [Visit ->](https://www.zcashcommunity.com/) |
+| Zcash Foundation Blog | Foundation updates, Zebra releases, governance, events, and protocol stewardship | [Visit ->](https://zfnd.org/blog/) |
+| Electric Coin Company Blog | Wallet, protocol, privacy, and product updates from ECC | [Visit ->](https://electriccoin.co/blog/) |
+
+## Community writers
+
+| Blog / Author | Description | Link |
+|---------------|-------------|------|
+| James Katz | Personal writings and thoughts on Zcash and privacy | [Visit ->](https://free2z.cash/James_Katz/) |
+| Thumbs' Update | Regular ecosystem updates and insights | [Visit ->](https://thumbsup.substack.com) |
+| roomatemusing | Musings and community content | [Visit ->](https://free2z.cash/roommatemusing) |
+| NerdBank Blog | Technical blog focused on Zcash development and tools | [Visit ->](https://blog.nerdbank.net/) |
+| Thor Likes | News, opinions, and commentary on Zcash | [Visit ->](https://www.thorlikes.com/) |
+| ZecMec | Zcash-focused articles on Medium | [Visit ->](https://zecmec21.medium.com/) |
+| Ian Sagstetter | In-depth articles and newsletter | [Visit ->](https://iansagstetter.substack.com/) |
+| Naomi Brockwell (NBTV) | Privacy education, interviews, and video content | [Visit ->](https://naomibrockwell.com/highprofileinterviews) |
+| Sqribbles | Creative and community-driven Zcash content | [Visit ->](https://free2z.cash/sqribbles) |
+| Str4d | Technical writings from a Zcash core developer | [Visit ->](https://words.str4d.xyz/) |
 
 ---
 
-Here are some community-submitted blogs. If you would like ZecHub to feature one of your blog posts or add your own blog here, please create a Pull Request with the details!
+If you would like ZecHub to feature one of your blog posts or add your own blog here, please create a Pull Request with the details.

--- a/site/Zcash_Community/Community_Links.md
+++ b/site/Zcash_Community/Community_Links.md
@@ -4,17 +4,25 @@
 
 # <img src="https://i.ibb.co/qYhRbJM/image-2024-02-03-174147713.png" alt="Alt Text" width="400"/> Zcash Community Links
 
-The Zcash community is a vibrant and passion group of people working towards making ZEC one of the most widely used cryptocurrencies in the world. The community is made up of a diverse group of people from all over the world. They come from a variety of different backgrounds and occupations, but they all work together to help achieve Zcash and ZEC's vision.
+The Zcash community is a global group of developers, educators, researchers, artists, advocates, merchants, and users working to make private digital cash practical and widely available.
+
+Last reviewed: May 2026
 
 ----
 
-## Where you can find community members?
+## Start here
 
-The community active in a number of different places:
+- [Zcash Community](https://www.zcashcommunity.com/) - community hub with projects, news, resources, and onboarding links.
+- [ZecHub Wiki](https://zechub.wiki/) - community-maintained Zcash education hub.
+- [Zcash Community Forum](https://forum.zcashcommunity.com/) - long-form community discussion, grants, governance, ecosystem updates, and technical threads.
+
+## Where can you find community members?
+
+The community is active in a number of different places:
 
 ### <img src="https://i.ibb.co/qBrb4qK/image-2024-02-03-173937048.png" alt="Alt Text" width="50"/> <span translate="no" class="notranslate">Telegram</span>
 
-The Zcash community is very active in its community <span translate="no" class="notranslate">Telegram</span>. This is a channel where zcashers talk about the day-to-day, discuss news and updates, and is also a good place for community members to get acquainted with each other. The link to join is [here](https://t.me/Zcash_Community).
+The Zcash community is active in its community <span translate="no" class="notranslate">Telegram</span>. This is a channel where zcashers talk day-to-day, discuss news and updates, and help new community members get acquainted. The link to join is [here](https://t.me/Zcash_Community).
 
 ### <img src="https://i.ibb.co/kxVwQxM/image-2024-02-03-174056252.png" alt="Alt Text" width="50"/> <span translate="no" class="notranslate">Discord</span>
 
@@ -34,10 +42,6 @@ The Zcash community is very active in its community <span translate="no" class="
 
 These places are great options for new community members to join in discussions.
 
-### Zcash Community Forum
-
-The [Zcash community forum](https://forum.zcashcommunity.com/) is a place where long form discussions related to Zcash take place. It's where members voice their support for various proposals in the community, debate specific topics, and also a place where projects seeking grants funding can go to announce their intention for applying to the Zcash Community Grants program. These are not the only topics for discussion, but they are some of the most common.
-
 ### <img src="https://i.ibb.co/mqKfr62/image-2024-02-03-174240928.png" alt="Alt Text" width="50"/>   <span translate="no" class="notranslate">Twitter / X</span>
 
 Just like most crypto projects, the Zcash community is extremely active on Twitter. The conversations are lively, debates are plentiful, and of course, there are memes. Here are some interesting accounts to follow
@@ -54,6 +58,17 @@ Just like most crypto projects, the Zcash community is extremely active on Twitt
 
 [@zerodartz](https://x.com/Zerodartz) (for the memes!)
 
+### Project and grant links
+
+[Zcash Community Grants](https://zcashcommunitygrants.org/)
+
+[Zcash Foundation](https://zfnd.org/)
+
+[Electric Coin Company](https://electriccoin.co/)
+
+[Zcash Foundation Arborist Calls](https://zfnd.org/arborist-calls/)
+
+[Zcash Community Grants Forum Category](https://forum.zcashcommunity.com/c/zcash-community-grants/13)
 
 ----
 

--- a/site/Zcash_Community/Community_Projects.md
+++ b/site/Zcash_Community/Community_Projects.md
@@ -4,6 +4,18 @@
 
 ## Zcash Community Projects
 
+Zcash community projects include wallets, explorers, developer tooling, education, events, merchant adoption, media, and public-good infrastructure.
+
+Last reviewed: May 2026
+
+[Zcash Community](https://www.zcashcommunity.com/)
+
+The Zcash Community hub collects ecosystem news, social links, community projects, blog feeds, wallets, grants, and onboarding resources.
+
+[ZecHub Wiki](https://zechub.wiki/)
+
+ZecHub is the community-driven education hub for Zcash, with guides, visualizers, tutorials, global resources, and contribution pathways for new and experienced community members.
+
 [ZECping](https://github.com/emersonian/zecping)
 
 See the gRPC response times of Zcash [Lightwalletd](https://github.com/zcash/lightwalletd) nodes.
@@ -14,7 +26,7 @@ Ziggurat is network test suite that provides zcashd and zebra devs with this rel
 
 [Exblo](https://testnet.exblo.app/#/)
 
-A block explorer specially design for apps testing transactions over the Zcash Testnet. Currently in active development
+A block explorer designed for testing apps that transact over the Zcash testnet. Currently in active development.
 
 The Zcash Block Explorer provides information such as transaction data / block information / Addresses / Mempool Blocks etc. Also allows for Transaction Payment Disclosure Viewing Key to be used.
 
@@ -32,7 +44,7 @@ Free2z is a tool for anonymous content and private donations.
 
 [Ezcash](https://blog.nerdbank.net/ezcash-app)
 
-An easy to use and fully-feature Zcash wallet multiplatform Zcash Wallet with autoshielding support.
+An easy to use, fully featured, multi-platform Zcash wallet with autoshielding support.
 
 [My First Zcash](https://github.com/massadoptionorg/My-First-Zcash)
 
@@ -57,6 +69,10 @@ ZGo is a Zcash Register. Enabling vendors and merchants to accept Zcash. Current
 [Zlink](https://zlink.click)
 
 Zlink is the simplest way to find any link, tool, information you need about Zcash's ecosystem.
+
+[Pay With Zcash](https://paywithz.cash/)
+
+Pay With Zcash is a community directory for discovering businesses, services, and tools that accept ZEC.
 
 [ZK Radio](https://zcashesp.com/zk-radio/)
 
@@ -155,7 +171,7 @@ Zectastic.com is Launch the Zcash rocket, Play the memory game, and Follow the l
 
 ## Zecmap
 
-Zecmap is The global map of businesses accepting Zcash. Discover, verify, and contribute to places that support privacy-focused payments.
+Zecmap is the global map of businesses accepting Zcash. Discover, verify, and contribute places that support privacy-focused payments.
 
 [Visit Site](https://zecmap.com/)
 

--- a/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -1,12 +1,25 @@
-## Zcash Ecosystem Security Lead:
+## Zcash Ecosystem Security
 
-This ecosystem role began as a ZCG grant application by [earthrise](https://forum.zcashcommunity.com/t/zcash-ecosystem-security-lead/42090) to work as a security engineer serving the wider Zcash ecosystem outside of ECC and ZF, with a focus on ZCG grantees. You can learn more about Earthrise's work as the Zcash Ecosystem Security Lead [here](https://zecsec.com). After this grant was completed, ZCG put out an [RFP](https://forum.zcashcommunity.com/t/rfp-zcash-ecosystem-security-lead-2023/45723) to find a replacement. & at the end of March 2024 ZCG selected [Least Authority](https://leastauthority.com) to step into the role through another grant. You can learn more about Least Authority's work as the Zcash Ecosystem Security Lead [here](https://forum.zcashcommunity.com/t/grant-update-zcash-ecosystem-security-lead/47541).
+Security work in the Zcash ecosystem spans protocol engineering, wallet safety, Zebra and lightwallet infrastructure, grants review, responsible disclosure, and audits for community projects.
 
+Last reviewed: May 2026
 
-## Responsible Disclosure:
+## Ecosystem Security Lead
 
-The Electric Coin Company & Zcash Foundation both conform to this Responsible Disclosure [standard](https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/d47a5a3dafa5942c8849a93441745fdd186731e6) with the following Deviation: 
+This ecosystem role began as a ZCG grant application by [earthrise](https://forum.zcashcommunity.com/t/zcash-ecosystem-security-lead/42090) to work as a security engineer serving the wider Zcash ecosystem outside of ECC and ZF, with a focus on ZCG grantees.
 
->"Zcash is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zcash. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible.The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue. In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable."
+You can learn more about earthrise's ZecSec work at [zecsec.com](https://zecsec.com), including past audits of Zcash ecosystem projects such as ZGo, zecwallet-lite-cli, the Zcash Ledger app, Free2Z, and YWallet.
 
+After that grant was completed, ZCG put out an [RFP](https://forum.zcashcommunity.com/t/rfp-zcash-ecosystem-security-lead-2023/45723) to find a replacement. At the end of March 2024, ZCG selected [Least Authority](https://leastauthority.com) to step into the role through another grant. You can learn more about Least Authority's work as the Zcash Ecosystem Security Lead [here](https://forum.zcashcommunity.com/t/grant-update-zcash-ecosystem-security-lead/47541).
 
+## Core Infrastructure Stewardship
+
+In May 2026, the Zcash Foundation announced stewardship of core community-facing Zcash assets, including the Zcash GitHub organization, the z.cash website and domain, and the @Zcash X account. This helps centralize accountability for repository governance and long-term protocol infrastructure maintenance.
+
+Read more: [Zcash Foundation Assumes Stewardship of Core Zcash Community Assets](https://zfnd.org/zcash-foundation-assumes-stewardship-of-core-zcash-community-assets/)
+
+## Responsible Disclosure
+
+The Electric Coin Company and Zcash Foundation both conform to this Responsible Disclosure [standard](https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/d47a5a3dafa5942c8849a93441745fdd186731e6), with the following deviation:
+
+>"Zcash is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zcash. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible. The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue. In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable."

--- a/site/Zcash_Community/Zcash_Global_Ambassadors.md
+++ b/site/Zcash_Community/Zcash_Global_Ambassadors.md
@@ -4,18 +4,43 @@
 
 # Zcash Global Ambassadors
 
+Zcash Global Ambassadors are community leaders dedicated to promoting privacy-focused cryptocurrency adoption and education worldwide. Ambassador projects focus on awareness, onboarding, local-language education, events, and regional community building.
 
-The Global Ambassador Program is designed to identify community members who make high-quality contributions to the Zcash community and empower them to become leaders. Ambassadors lead activities that grow the Zcash community, drive user adoption, and advance awareness of Zcash’s privacy-preserving technology.
+Last reviewed: May 2026
+
+## Program overview
+
+The Global Ambassador Program was created to identify community members who make high-quality contributions to the Zcash community and empower them to become leaders. Ambassadors lead activities that grow the Zcash community, drive user adoption, and advance awareness of Zcash's privacy-preserving technology.
 
 ## What does an Ambassador do?
 
-  * Hosting physical or virtual meetup events
-  * Maintaining an active presence on social media, and creating original content related to Zcash.
-  * Ambassadors have creative freedom over the activities they plan. 
-  
-## [Global Ambassador Website](https://zcashambassadors.com)
-  
+- Host physical or virtual meetup events
+- Maintain an active presence on social media
+- Create original Zcash-related content
+- Translate educational material for local communities
+- Help new users understand wallets, shielded payments, privacy, and ecosystem resources
+- Coordinate with other regional community projects
 
+Ambassadors have creative freedom over the activities they plan while contributing to the broader Zcash ecosystem.
 
- 
+## Active Global Ambassador Projects
 
+The current ZecHub ambassador page lists regional projects including:
+
+- Zcash Korea
+- Zcash Russia
+- Zcash Arabia
+- Zcash Brazil
+- Zcash Ghana
+- Zcash Espanol
+- Zcash Nigeria
+- Zcash Ukraine
+- Zcash Turkey
+- Zcash Kenya
+- Zcash India
+
+## Links
+
+- [ZecHub Global Ambassadors page](https://zechub.wiki/zcash-global-ambassadors)
+- [Original ZCG Global Ambassador Program announcement](https://zcashcommunitygrants.org/news/2022/02/24/the-global-ambassador-program/)
+- [Global Ambassador forum thread](https://forum.zcashcommunity.com/t/the-global-ambassador-program/41070)


### PR DESCRIPTION
Fixes #1592

Updates all six requested ZecHub wiki pages:
- Community Blogs
- Arborist Calls
- Community Projects
- Zcash Ecosystem Security
- Community Links
- Global Ambassadors

Changes include refreshed links, clearer page structure, May 2026 review notes, typo fixes, and updated descriptions for community resources/projects.

Verification:
- Reviewed markdown diff locally
- Ran `git diff --check`
- Checked targeted files for stale wording/typos