### PR TITLE
Improve Zimppy wiki page

### DIFF
--- a/site/Using_Zcash/zimppy.md
+++ b/site/Using_Zcash/zimppy.md
@@ -1,271 +1,177 @@
-# [Zimppy.xyz Wiki Page](https://zimppy.xyz/)
+# Zimppy.xyz
 
+[Zimppy.xyz](https://zimppy.xyz/) is a Zcash payment method for the Machine Payments Protocol (MPP). It is designed for software agents, scripts, and API clients that need to pay for online services through HTTP payment flows.
 
-> **Zimppy** is the Machine Payment Protocol (MPP) payment method for Zcash supporting both shielded and transparent payments. Deposit once on-chain, then make unlimited instant bearer requests with no per-request chain interaction.
+Zimppy uses Zcash so machine payments can be made with shielded transactions instead of public payment rails. This is useful when a payment itself may reveal sensitive metadata, such as which API was called, how often it was called, or how much an automated agent spent.
 
----
+## What Zimppy does
 
-## Table of Contents
+Zimppy connects three ideas:
 
-1. [What is Zimppy.xyz?](#what-is-zimppyxyz)
-2. [Why Shielded Payments for AI Agents?](#why-shielded-payments-for-ai-agents)
-3. [Machine Payment Protocol (MPP)](#machine-payment-protocol-mpp)
-4. [How Zimppy Works](#how-zimppy-works)
-   - [Sessions (Recommended)](#sessions-recommended)
-   - [Streaming](#streaming)
-   - [Charge](#charge)
-5. [Use Cases & Examples](#use-cases--examples)
-6. [Installation](#installation)
-7. [Setting Up the Zimppy Wallet](#setting-up-the-zimppy-wallet)
-8. [Integrating Zimppy](#integrating-zimppy--typescript-sdk)
-   - [Server (Shielded)](#typescript-server--shielded)
-   - [Server (Transparent)](#typescript-server--transparent)
-   - [Client](#typescript-client)
-9. [Integrating Zimppy - Rust SDK](#integrating-zimppy--rust-sdk)
-   - [Server (Axum)](#rust-server-axum)
-   - [Client](#rust-client)
-10. [CLI Reference](#cli-reference)
-11. [Key Features](#key-features)
-12. [Architecture](#architecture)
-13. [Examples & Demos](#examples--demos)
+* **HTTP 402 payments**: a server can respond with `402 Payment Required` and a signed payment challenge.
+* **Zcash payments**: the client pays the requested amount using a Zcash payment method.
+* **Automatic retry**: after payment, the client retries the original request with payment proof.
 
----
+The result is a machine-payment flow where an agent can discover a paid endpoint, pay it, and continue without a human manually copying payment details.
 
-## What is Zimppy.xyz?
+## Why Zcash matters for machine payments
 
-**Zimppy.xyz** is a privacy-first payment infrastructure designed specifically for AI agents and automated machine-to-machine (M2M) workflows. It implements the **Machine Payment Protocol (MPP)** using **Zcash** as its underlying currency, enabling both shielded (fully private) and transparent payment modes.
+Public-chain payments can leak usage patterns. If every API call is paid from a visible address, observers may learn which services an agent uses, how often it pays, and how spending changes over time.
 
-Unlike traditional blockchain payment systems, where every transaction is publicly visible on-chain, Zimppy is engineered around a session-based architecture that eliminates per-request latency while preserving cryptographic privacy. This makes it uniquely suited for AI agents that need to pay for APIs, data, compute, or AI tools programmatically, without leaking behavioral metadata.
+Zimppy focuses on Zcash because shielded payments can encrypt payment details such as sender, receiver, amount, and memo data. A server can verify a received shielded payment with an incoming viewing key without exposing the spending key.
 
-### Core Properties
+Zimppy can also support transparent payment flows, but the privacy benefit is strongest when the payment is shielded.
 
-- **Deposit once** on-chain (~75 seconds for Zcash confirmation)
-- **Unlimited instant requests** after session opening, zero per-request chain interaction
-- **Shielded payments** encrypt sender, receiver, amount, and memo using Zcash's Orchard protocol
-- **Transparent payments** use per-challenge T-addresses for replay prevention without full privacy
-- **Spec-compliant**,  HMAC-SHA256 challenges, RFC 9457 errors, `/.well-known/payment` discovery
+## How the payment flow works
 
----
+1. **Agent requests a paid resource**
 
-## Why Shielded Payments for AI Agents?
+   The agent sends a normal HTTP request to an API.
 
-For AI agents handling sensitive workflows, legal research, medical queries, financial analysis, competitive intelligence for **every public payment is a metadata leak**. Zimppy is the only MPP payment method that is **private by default**.
+2. **Server returns a payment challenge**
 
-### Privacy Comparison Table
+   The server responds with `402 Payment Required`, including the payment amount, currency, recipient details, and challenge data.
 
-| Property | Public Chains (USDC, ETH) | Zimppy Shielded | Zimppy Transparent |
-|---|---|---|---|
-| **Sender** | Visible | Encrypted | Visible |
-| **Receiver** | Visible | Encrypted | Per-challenge (unlinkable) |
-| **Amount** | Visible | Encrypted | Visible |
-| **Memo** | Visible | Encrypted | N/A |
-| **Replay Protection** | None | Memo binding | Per-challenge T-address |
-| **Service Usage Pattern** | Linkable | Private | Unlinkable (fresh addr) |
+3. **Agent pays with Zcash**
 
-### The Latency Problem, Solved by Sessions
+   The agent sends the ZEC payment. For shielded flows, the memo can bind the payment to the challenge so it cannot be replayed for another request.
 
-> *"But Zcash has 75-second block times."*
+4. **Agent retries the request**
 
-**Sessions solve this.** The on-chain wait happens exactly **once** at deposit. Every subsequent request is instant.
+   The agent retries the original request with payment proof in the authorization header.
 
-```
-Agent  ->  deposit 100,000 zat           (one on-chain tx, ~75s)
-Agent  ->  open session                  (bearer token issued)
-Agent  ->  request -> response           (0ms - no chain interaction)
-Agent  ->  request -> response           (0ms - no chain interaction)
-Agent  ->  request -> response           (0ms - no chain interaction)
-           ... hundreds of requests ...
-Agent  ->  close session                 (refund unused balance)
-```
+5. **Server verifies and responds**
 
-**Pay once, call instantly, get back the change.** Per-request latency is zero.
+   The server verifies the payment and returns the paid resource with a receipt.
 
----
-
-## Machine Payment Protocol (MPP)
-
-The **Machine Payment Protocol (MPP)** is a standardized protocol that enables autonomous software agents (AI agents, bots, scripts) to discover, negotiate, and fulfill payment requirements for API access all without human intervention.
-
-### How MPP Integrates with APIs
-
-MPP follows the HTTP **402 Payment Required** flow:
-
-1. **Agent requests** a resource from a paid API endpoint.
-2. **Server responds** with `402 Payment Required` + a signed challenge (amount, recipient, memo).
-3. **Agent pays** using a compatible payment method (e.g., Zimppy shielded Zcash).
-4. **Agent retries** the request with `Authorization: Payment {txid}`.
-5. **Server verifies** the payment cryptographically (Orchard IVK decryption, amount + memo check).
-6. **Server responds** with `200 OK` + a `Payment-Receipt` header.
-
-### Spec Compliance
-
-- **HMAC-SHA256** challenge signing
-- **RFC 9457** structured error responses
-- **`/.well-known/payment`** endpoint for automatic payment method discovery
-- **Orchard IVK** (Incoming Viewing Key) for server-side payment verification without exposing spending keys
-
----
-
-## How Zimppy Works
-
-### Sessions (Recommended)
-
-Sessions are the primary interaction pattern. The agent deposits a balance on-chain once, receives a bearer token, and uses it for all subsequent requests at zero latency.
-
-```
-Agent  ->  deposit 100,000 zat           (on-chain, ~75s one-time)
-Agent  ->  open session                  (bearer token issued)
-Agent  ->  GET /api/query + bearer       (instant, balance deducted)
-Agent  ->  GET /api/query + bearer       (instant, balance deducted)
-Agent  ->  close session                 (refund unused balance on-chain)
-```
-
-**Best for:** High-frequency API calls, LLM inference, repeated data queries.
-
----
-
-### Streaming
-
-Pay-per-token metered content delivered over **Server-Sent Events (SSE)**. The server deducts from the session balance per word or token streamed.
-
-```
-Agent  ->  open session with deposit
-Agent  ->  GET /api/stream (SSE)
-Server ->  stream word by word, deducting per token
-Agent  ->  close session, refund remaining
-```
-
-**Best for:** LLM streaming responses, real-time data feeds, pay-per-token AI tools.
-
----
-
-### Charge
-
-A single shielded payment per request. The full HTTP 402 flow is executed per call. Suitable when requests are infrequent or high-value.
-
-```
+```text
 Agent  ->  GET /api/resource
-Server ->  402 + challenge (amount, recipient, memo)
-Agent  ->  shielded ZEC with memo "zimppy:{challenge_id}"
-Agent  ->  GET /api/resource + Authorization: Payment {txid}
-Server ->  decrypt with Orchard IVK, verify amount + memo
-Server ->  200 OK + Payment-Receipt
+Server ->  402 Payment Required + challenge
+Agent  ->  Send ZEC payment
+Agent  ->  GET /api/resource + payment proof
+Server ->  200 OK + receipt
 ```
 
-**Best for:** High-value one-off requests, infrequent API calls, premium data endpoints.
+## Sessions and streaming
 
----
+For high-frequency API calls, paying on-chain for every request is slow and inefficient. Zimppy supports session-style flows where an agent deposits once, receives a bearer token, and then makes repeated instant requests against the prepaid balance.
 
-## Use Cases & Examples
+This pattern is useful for:
 
-### 1. AI Agent
+* LLM inference calls
+* pay-per-token streaming
+* data APIs with many small requests
+* agent workflows that need repeated tool calls
 
-A legal AI agent queries a paid case-law database. Using Zimppy shielded sessions, neither the law firm's identity nor the specific queries are visible on-chain - protecting attorney-client privilege at the infrastructure level.
-
+```text
+Agent  ->  Open session with ZEC deposit
+Agent  ->  Request data with bearer token
+Agent  ->  Stream or repeat requests
+Agent  ->  Close session and refund unused balance
 ```
-Agent opens session (100,000 zat deposit)
--> GET /api/cases?q=patent+infringement+2024     (instant)
--> GET /api/cases?q=prior+art+semiconductor      (instant)
--> GET /api/document/US11234567B2                (instant)
-Session closed, unused balance refunded
-```
 
-### 2. AI Agent for Medical Query Pipeline
+## Use cases
 
-A medical diagnostic agent queries multiple clinical databases. Shielded payments ensure patient query patterns are not linkable across providers.
+### AI agents
 
-### 3. Financial Analysis Agent
+An autonomous agent can pay for tools, data, or inference without a human in the loop. Shielded payments help avoid linking the agent's full service-usage pattern to a public payment address.
 
-An algorithmic trading agent pays for real-time market data APIs. Transparent payments use fresh T-addresses per challenge, preventing usage pattern correlation across data vendors.
+### Private research workflows
 
-### 4. MCP Tool Server, Paid AI Tools
+A legal, medical, or financial research assistant may need to query paid databases. Shielded payment flows can reduce the amount of payment metadata exposed while still letting the provider verify payment.
 
-An MCP (Model Context Protocol) server exposes paid AI tools. Each tool invocation triggers a Zimppy charge, enabling a marketplace of monetized AI capabilities.
+### Paid API services
 
-### 5. LLM Summarizer, Pay-Per-Token
+API providers can use MPP-style challenges to charge for individual requests, sessions, or streaming responses. Zimppy gives those services a Zcash payment method.
 
-An LLM summarization service charges agents per output token via SSE streaming, with automatic balance deduction and refund of unused prepaid balance.
+### Multi-agent systems
 
----
+Different agents can use separate wallet identities or accounts so usage and balances can be managed independently.
 
-## Installation
+## Quick start: wallet and shielded payments
 
-### Node.js / TypeScript
+The public Zimppy docs show the CLI package as:
 
 ```bash
-npm install zimppy          # CLI + wallet
-npm install zimppy-ts       # TypeScript SDK
+npm install zimppy
+npx zimppy
 ```
 
-### Rust
+Use this basic setup path before integrating an API:
 
-```toml
-[dependencies]
-zimppy-core = "0.5"         # Rust verification engine
-zimppy-rs = "0.5"           # Rust SDK (charge, session, axum)
-```
+1. **Install the CLI**
 
----
+   ```bash
+   npm install zimppy
+   ```
 
-## Setting Up the Zimppy Wallet
+2. **Create or select a wallet identity**
 
-The Zimppy CLI provides a full wallet interface. All commands are available via `npx zimppy`.
+   ```bash
+   npx zimppy wallet create
+   npx zimppy wallet use work
+   ```
 
-### Step 1 : Create a Wallet
+   Store any seed phrase or wallet backup securely. Treat an automated agent wallet as a hot wallet unless you have stronger key isolation.
 
-```bash
-npx zimppy wallet create
-```
+3. **Check the wallet address and network**
 
-Generates cryptographic keys and displays your **seed phrase**. Store this securely - it cannot be recovered if lost.
+   ```bash
+   npx zimppy wallet whoami
+   ```
 
-### Step 2 : Check Your Address and Balance
+   Confirm the displayed address, balance, and network before sending funds.
+
+4. **Fund the wallet**
+
+   Send testnet ZEC first when possible. For real payments, send only the amount needed for the agent workflow you are testing.
+
+5. **Send a shielded payment**
+
+   ```bash
+   npx zimppy wallet send <address> <amount-in-zat>
+   ```
+
+6. **Call a paid MPP endpoint**
+
+   ```bash
+   npx zimppy request <url>
+   ```
+
+   The request command handles the `402 -> pay -> retry` flow for compatible endpoints.
+
+Other useful wallet commands:
 
 ```bash
 npx zimppy wallet whoami
-```
-
-Displays your **Unified Address (UA)**, **T-address**, current balance, and active network.
-
-```bash
 npx zimppy wallet balance --all
-```
-
-Shows a per-account balance breakdown across all ZIP-32 accounts.
-
-### Step 3 : Fund Your Wallet
-
-Send ZEC to your Unified Address from any Zcash-compatible wallet or exchange. Shielded deposits go directly to your Orchard account.
-
-### Step 4 : Send and Shield Funds
-
-```bash
-# Send ZEC to any address (shielded or transparent)
-npx zimppy wallet send <addr> 42000
-
-# Move transparent funds into Orchard (shielded)
+npx zimppy wallet send <address> <amount-in-zat>
 npx zimppy wallet shield
-
-# Transfer between your own accounts
-npx zimppy wallet transfer 0 1 50000
-
-# Switch active wallet identity
-npx zimppy wallet use work
-```
-
-### Step 5 : Make an Auto-Pay Request
-
-```bash
+npx zimppy wallet use <name>
 npx zimppy request <url>
 ```
 
-Automatically handles the full 402 -> pay -> retry flow. Sessions are opened and managed transparently.
+Before using Zimppy with real funds:
 
----
+* start on testnet if available
+* keep seed phrases and wallet files private
+* confirm the recipient and amount before funding a wallet
+* understand whether a flow is shielded or transparent
+* treat automated agents as hot-wallet software unless you have stronger key isolation
 
-## Integrating Zimppy - TypeScript SDK
+## Step-by-step TypeScript integration
 
-### TypeScript Server - Shielded
+Zimppy's public examples show a TypeScript server using `mppx` and `zimppy-ts` to add a Zcash payment method to an HTTP endpoint.
+
+1. **Install the packages**
+
+   ```bash
+   npm install zimppy zimppy-ts mppx
+   ```
+
+2. **Configure the server payment method**
+
+   Load the server wallet and register the Zcash payment method with MPP.
 
 ```typescript
 import { Mppx } from 'mppx/server'
@@ -273,71 +179,103 @@ import { zcash } from 'zimppy-ts/server'
 
 const mppx = Mppx.create({
   methods: [await zcash({ wallet: 'server' })],
-  realm: 'my-api',
-  secretKey: process.env.MPP_SECRET_KEY,
 })
+```
 
+3. **Wrap the paid endpoint**
+
+   The charge wrapper returns a challenge when payment is needed and a receipt wrapper after payment is verified.
+
+```typescript
 const result = await mppx.charge({
   amount: '42000',
   currency: 'zec',
 })(request)
 
-if (result.status === 402) return result.challenge
+if (result.status === 402) {
+  return result.challenge
+}
 
 return result.withReceipt(Response.json({ data }))
 ```
 
-**Key points:**
-- `zcash({ wallet: 'server' })` loads the server's shielded wallet
-- `mppx.charge()` handles the full 402 challenge/verify lifecycle
-- `result.withReceipt()` attaches the cryptographic payment receipt to the response
-
----
-
-### TypeScript Server - Transparent
-
-```typescript
-import { Mppx } from 'mppx/server'
-import { zcashTransparent } from 'zimppy-ts/server'
-
-const mppx = Mppx.create({
-  methods: [await zcashTransparent({ wallet: 'server' })],
-  // per-challenge T-address generated automatically (replay-safe)
-})
-```
-
-Each challenge generates a **fresh T-address**, making payment requests unlinkable across sessions.
-
----
-
-### TypeScript Client
+4. **Configure the client wallet**
 
 ```typescript
 import { Mppx } from 'mppx/client'
 import { zcash } from 'zimppy-ts/client'
 
-const mppx = Mppx.create({ methods: [zcash({ wallet: 'default' })] })
-
-// Session opened automatically; 402 is handled transparently
-const res = await mppx.fetch('https://api.example.com/resource')
+const mppx = Mppx.create({
+  methods: [zcash({ wallet: 'default' })],
+})
 ```
 
-The client intercepts `402` responses, opens a session automatically, and retries the request - the calling code requires no payment-specific logic.
+5. **Call the paid endpoint**
 
----
+   The client handles the `402 -> pay -> retry` loop.
 
-## Integrating Zimppy - Rust SDK
+```typescript
+const response = await mppx.fetch('<paid-api-url>')
+```
 
-### Rust Server (Axum)
+6. **Verify receipts and errors**
+
+   In production, log payment receipts carefully, set clear prices, and handle insufficient funds, expired challenges, and failed payment verification.
+
+## Step-by-step Rust integration
+
+Zimppy also exposes Rust integration patterns for servers and clients.
+
+1. **Add dependencies**
+
+   Check the current Zimppy repository for the latest versions, then add the Rust crates used by your service.
+
+```toml
+[dependencies]
+zimppy-rs = "0.5"
+# Add the MPP crate/version used by the current Zimppy repository.
+```
+
+2. **Create the Zcash charge method**
+
+   A server needs Zcash RPC access, a recipient address, and an Orchard incoming viewing key for shielded payment verification.
 
 ```rust
-use mpp::server::axum::*;
-use zimppy_rs::ZcashChallenger;
+use mpp::server::Mpp;
+use zimppy_rs::ZcashChargeMethod;
 
+let mpp = Mpp::create(ZcashChargeMethod::new(
+    &rpc,
+    &address,
+    &orchard_ivk,
+))?;
+```
+
+3. **Attach MPP state to the web app**
+
+   Public examples use Axum-style state and extractors.
+
+```rust
+use std::sync::Arc;
+use axum::{routing::get, Router};
+use mpp::server::axum::*;
+
+let state: Arc<dyn ChargeChallenger> = Arc::new(mpp);
+
+let app = Router::new()
+    .route("/api/resource", get(handler))
+    .with_state(state);
+```
+
+4. **Protect a handler with a payment extractor**
+
+```rust
 struct Price;
 
 impl ChargeConfig for Price {
-    fn amount() -> &'static str { "42000" }
+    fn amount() -> &'static str {
+        "42000"
+    }
 }
 
 async fn handler(charge: MppCharge<Price>) -> WithReceipt<Json<Value>> {
@@ -348,130 +286,133 @@ async fn handler(charge: MppCharge<Price>) -> WithReceipt<Json<Value>> {
 }
 ```
 
-**Key points:**
-- `MppCharge<Price>` is an Axum extractor that verifies payment before the handler runs
-- `WithReceipt` wraps the response with a cryptographic payment receipt
-- `ChargeConfig` defines the pricing logic - can be dynamic based on request parameters
-
----
-
-### Rust Client
+5. **Configure the Rust client**
 
 ```rust
 use mpp::client::Fetch;
 use zimppy_rs::ZcashPaymentProvider;
 
-let provider = ZcashPaymentProvider::new(wallet_config, &rpc);
+let provider = ZcashPaymentProvider::new(wallet_config, &rpc_endpoint);
 
-let resp = client
-    .get("https://api.example.com/resource")
+let response = client
+    .get("<paid-api-url>")
     .send_with_payment(&provider)
     .await?;
 ```
 
-`send_with_payment` extends any HTTP client with automatic 402 handling, session management, and Zcash payment fulfillment.
+6. **Test before mainnet**
 
----
+   Test challenge creation, payment verification, replay protection, receipt handling, and session refund behavior before connecting an agent to real funds.
 
-## CLI Reference
+## Reference snippets
 
-| Command | Description |
-|---|---|
-| `npx zimppy wallet create` | Generate keys and display seed phrase |
-| `npx zimppy wallet whoami` | Show address (UA + T-addr), balance, network |
-| `npx zimppy wallet balance --all` | Per-account balance breakdown |
-| `npx zimppy wallet send <addr> <zat>` | Send shielded or transparent ZEC |
-| `npx zimppy wallet transfer <from> <to> <zat>` | Cross-account internal transfer |
-| `npx zimppy wallet shield` | Move transparent funds to Orchard (shielded) |
-| `npx zimppy wallet use <name>` | Switch active wallet identity |
-| `npx zimppy request <url>` | Auto 402 -> pay -> retry request |
+The compact examples below mirror the public Zimppy docs.
 
----
+### TypeScript server
 
-## Key Features
+```typescript
+import { Mppx } from 'mppx/server'
+import { zcash } from 'zimppy-ts/server'
 
-### Agent-Native Wallets
+const mppx = Mppx.create({
+  methods: [await zcash({ wallet: 'server' })],
+})
 
-Zimppy wallets are designed for programmatic use by AI agents - not human-managed browser extensions. Keys are managed via the CLI or SDKs, accounts can be rotated via **ZIP-32 account derivation**, and the wallet supports fully automated payment flows without human approval per transaction.
+const result = await mppx.charge({
+  amount: '42000',
+  currency: 'zec',
+})(request)
 
-### Multi-Agent Support
+if (result.status === 402) {
+  return result.challenge
+}
 
-Multiple agents can operate from the same wallet using **ZIP-32 account rotation** - each agent gets its own account with isolated balance tracking, cross-account transfer capability, and per-account balance reporting. This enables fleet management of many agents from a single wallet infrastructure.
-
-### Fully Shielded Zcash Transactions (Orchard)
-
-Shielded payments use Zcash's **Orchard protocol** - the latest and most secure shielded pool. The server verifies payments using an **Incoming Viewing Key (IVK)**, which can decrypt received notes without exposing the spending key. Replay attacks are prevented via **memo binding** - each challenge embeds a unique `zimppy:{challenge_id}` memo that is cryptographically verified.
-
-### Sessions , Zero Per-Request Latency
-
-The session architecture decouples the on-chain confirmation wait from per-request latency. After a single deposit (~75 seconds), all subsequent bearer-token requests are served instantly with no blockchain interaction until session close.
-
-### Streaming , Pay-Per-Token
-
-Native **SSE (Server-Sent Events)** support enables pay-per-token metered content. Ideal for LLM inference APIs where output length is variable and billing should reflect actual consumption.
-
-### Spec Compliance
-
-- **HMAC-SHA256** signed challenges prevent forgery
-- **RFC 9457** structured error format for interoperable error handling
-- **`/.well-known/payment`** for automatic payment method discovery by any MPP-compliant agent
-
----
-
-## Architecture
-
-```
-crates/
-  zimppy-core/       Zcash verification engine (Orchard decryption, replay protection)
-  zimppy-wallet/     Native Zcash wallet (zingolib)
-  zimppy-rs/         Rust SDK (ChargeMethod, SessionMethod, PaymentProvider, axum extractors)
-  zimppy-napi/       Node.js native bindings (NAPI-RS)
-
-packages/
-  zimppy-ts/         TypeScript SDK (charge, session, SSE)
-  zimppy-cli/        CLI with auto-pay and session management
+return result.withReceipt(Response.json({ data }))
 ```
 
-### Component Responsibilities
+### TypeScript client
 
-**`zimppy-core`** - The cryptographic core. Handles Orchard note decryption using the server's IVK, memo parsing, replay protection logic, and challenge verification. Written in Rust for performance and correctness.
+```typescript
+import { Mppx } from 'mppx/client'
+import { zcash } from 'zimppy-ts/client'
 
-**`zimppy-wallet`** - A native Zcash wallet powered by `zingolib`. Manages keys, accounts, shielded/transparent balances, and transaction submission.
+const mppx = Mppx.create({
+  methods: [zcash({ wallet: 'default' })],
+})
 
-**`zimppy-rs`** - The Rust SDK. Provides `ChargeMethod`, `SessionMethod`, and `PaymentProvider` traits, plus Axum extractors (`MppCharge`, `WithReceipt`) for ergonomic server integration.
+const response = await mppx.fetch('<paid-api-url>')
+```
 
-**`zimppy-napi`** - NAPI-RS bindings that expose the Rust core to Node.js, enabling the TypeScript SDK to use the same cryptographic engine without reimplementing Zcash primitives in JavaScript.
+### Rust server
 
-**`zimppy-ts`** - The TypeScript SDK. Wraps NAPI bindings with idiomatic async/await APIs for charge, session, and SSE streaming flows.
+```rust
+use mpp::server::axum::*;
+use zimppy_rs::ZcashChargeMethod;
 
-**`zimppy-cli`** - The command-line wallet and request tool. Supports auto-pay (402 -> pay -> retry), session management, and all wallet operations.
+struct Price;
 
----
+impl ChargeConfig for Price {
+    fn amount() -> &'static str {
+        "42000"
+    }
+}
 
-## Examples & Demos
+async fn handler(charge: MppCharge<Price>) -> WithReceipt<Json<Value>> {
+    WithReceipt {
+        receipt: charge.receipt,
+        body: Json(data),
+    }
+}
+```
 
-| Example | Description |
-|---|---|
-| `examples/fortune-teller/` | Charge, session, and streaming demos - Rust server + client |
-| `examples/llm-summarizer/` | Pay-per-token LLM streaming demo |
-| `examples/mcp-server/` | MCP tool server with paid AI tools |
-| `examples/ts-server/` | TypeScript MPP server reference implementation |
+### Rust client
 
----
+```rust
+use mpp::client::Fetch;
+use zimppy_rs::ZcashPaymentProvider;
 
-## What's Included - Feature Summary
+let provider = ZcashPaymentProvider::new(wallet_config, &rpc_endpoint);
 
-| Feature | Description |
-|---|---|
-| **Sessions** | Deposit once, instant bearer requests, refund on close |
-| **Streaming** | Pay-per-token metered content over SSE |
-| **Charge** | Shielded or transparent payment per HTTP request (402 flow) |
-| **Transparent Payments** | T-addresses with per-challenge replay prevention + shield command |
-| **Multi-Account** | ZIP-32 account rotation, cross-account transfers, per-account balances |
-| **CLI Wallet** | Send, shield, transfer, balance --all, whoami, auto-pay |
-| **Dual SDK** | TypeScript and Rust |
-| **Spec-Compliant** | HMAC-SHA256 challenges, RFC 9457 errors, `/.well-known/payment` discovery |
+let response = client
+    .get("<paid-api-url>")
+    .send_with_payment(&provider)
+    .await?;
+```
 
----
+Check the current Zimppy docs and package versions before copying snippets into production code.
 
-*For more information, visit [zimppy.xyz](https://zimppy.xyz)*
+## Key features
+
+* **Agent-native wallets**: use CLI and SDK workflows intended for automated agents rather than only browser-based human wallets.
+* **Multi-agent support**: separate wallet identities or accounts can isolate balances and usage for different agents or environments.
+* **Fully shielded Zcash transactions**: use Zcash shielded payments to reduce payment metadata leakage.
+* **HTTP 402 support**: respond to payment challenges and retry requests automatically.
+* **Session payments**: deposit once and make repeated low-latency requests.
+* **Streaming support**: support pay-as-you-go streaming patterns.
+* **CLI wallet**: manage wallet identity and make paid requests from the command line.
+* **TypeScript and Rust examples**: integrate with web services and agent tooling.
+
+## Privacy and safety notes
+
+Zimppy can reduce payment metadata leakage, but it does not make every part of an application private. API servers may still log IP addresses, account identifiers, request bodies, timing, and bearer-token usage. Agents should combine shielded payments with normal operational privacy practices.
+
+For production deployments, review:
+
+* wallet key storage
+* testnet coverage
+* replay protection
+* challenge expiration
+* server logging policy
+* rate limits and abuse handling
+* refund behavior for sessions
+
+## Contributing
+
+Zimppy is maintained by BetterClever. Developers can start from the public site and linked GitHub resources:
+
+* [Zimppy.xyz](https://zimppy.xyz/)
+* [Zimppy GitHub repository](https://github.com/betterclever/zimppy)
+* [Zimppy on docs.rs](https://docs.rs/zimppy)
+* [Machine Payments Protocol overview](https://mpp.dev/)
+
+Useful contribution areas include documentation, examples, SDK ergonomics, wallet safety, test coverage, and integrations with agent frameworks.


### PR DESCRIPTION
Submission for #1567. Also addresses duplicate issue #1566 without assuming a separate payout for the same work.

Summary:
- rewrites the existing `site/Using_Zcash/zimppy.md` page into a clearer Zimppy wiki guide
- covers Zimppy functionality, Zcash privacy use cases for AI agents, MPP/HTTP 402 payment flow, sessions, wallet setup, TypeScript integration, Rust integration, key features, and safety notes
- adds current public resource links for Zimppy, the GitHub repo, docs.rs, and MPP

Verification before submission:
- independent content review subagent: APPROVE
- independent verification subagent: PASS
- `git diff --check -- site/Using_Zcash/zimppy.md`
- external links returned HTTP 200: `zimppy.xyz`, `github.com/betterclever/zimppy`, `docs.rs/zimppy`, `mpp.dev`
- no open PR overlap found for `site/Using_Zcash/zimppy.md`, #1567, or #1566

Closes #1567