### PR TITLE
Update six Zcash community wiki pages

### DIFF
--- a/site/Zcash_Community/Arborist_Calls.md
+++ b/site/Zcash_Community/Arborist_Calls.md
@@ -4,30 +4,35 @@
 
 # Arborist Calls
 
-[](https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F0d708fde-0a74-440d-8cf0-e782d984415d_831x468.webp)
+Last reviewed: May 2026.
 
-The Zcash Arborist Calls are bi-weekly protocol development meetings focused on tracking upcoming protocol deployment logistics, consensus node implementation issues, and protocol research.
+Zcash Arborist Calls are recurring protocol development meetings focused on network upgrade planning, consensus node implementation work, wallet and infrastructure dependencies, and protocol research.
 
-Offical Site: [https://zfnd.org/arborist-calls/](https://zfnd.org/arborist-calls/)
+The official Arborist Calls page is maintained by the Zcash Foundation:
 
-Anyone who wants to contribute to Zcash protocol development and to share news on Zcash node projects. 
+[https://zfnd.org/arborist-calls/](https://zfnd.org/arborist-calls/)
 
-Register here: [15:00 UTC](https://us06web.zoom.us/webinar/register/WN_Vk7WMz9sRkiIr_hqH_x3LA) / [22:30 UTC](https://us06web.zoom.us/webinar/register/WN_z0k1ipsnRkS4-DGqDhULdA)
+## How to Join
 
-The complete list with full notes & agendas can be found [here](https://github.com/ZcashCommunityGrants/arboretum-notes). 
+The calls alternate between two recurring time slots so that contributors in different regions can participate. Use the official Zcash Foundation page for the current calendar files and Zoom links:
 
+- 15:00 UTC timeslot
+- 21:00 UTC timeslot
 
-## Playlist
+The Foundation page should be treated as the source of truth for registration links, calendar files, and meeting access because meeting links can change.
 
-<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
-  <iframe
-    className="w-full h-full"
-    src="https://www.youtube.com/embed/videoseries?si=lFFtNRmUsdmSQ1qM&list=PL40dyJ0UYTLJqD_3PE9qiJTxse-iHnn1G"
-    title="Zcash Arborist Call Playlist"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    allowFullScreen
-    loading="lazy"
-  />
-</div>
+## Notes, Agendas, and Recordings
 
+- Full agendas and minutes: [arboretum-notes](https://github.com/ZcashCommunityGrants/arboretum-notes)
+- Recent recordings: [Zcash Arborist Call playlist](https://www.youtube.com/playlist?list=PL40dyJ0UYTLJqD_3PE9qiJTxse-iHnn1G)
+- Zcash R&D discussion: [Zcash R&D Discord](https://discord.gg/xpzPR53xtU)
+- Long-form discussion: [Zcash Community Forum](https://forum.zcashcommunity.com/)
 
+## Who Should Attend
+
+Arborist Calls are useful for:
+
+- protocol engineers and researchers;
+- node, wallet, SDK, and lightwallet infrastructure developers;
+- grant recipients whose work touches consensus, network upgrades, or protocol dependencies;
+- community members who want to follow technical decision-making in public.

--- a/site/Zcash_Community/Community_Blogs.md
+++ b/site/Zcash_Community/Community_Blogs.md
@@ -2,23 +2,41 @@
 
 # Community Blogs
 
-Community members run many excellent blogs covering Zcash, privacy, cryptocurrency, and related topics.
+Last reviewed: May 2026.
 
-Here are some of the active ones:
+Community members publish regular updates, technical notes, privacy commentary, and creative work across the Zcash ecosystem. The links below are useful starting points for following independent voices and recurring community coverage.
 
-| Blog / Author              | Description                                              | Link |
-|----------------------------|----------------------------------------------------------|------|
-| James Katz                 | Personal writings and thoughts on Zcash and privacy      | [Visit ->](https://free2z.cash/James_Katz/) |
-| Thumbs' Update             | Regular ecosystem updates and insights                   | [Visit ->](https://thumbsup.substack.com) |
-| roomatemusing              | Musings and community content                            | [Visit ->](https://free2z.cash/roommatemusing) |
-| NerdBank Blog              | Technical blog focused on Zcash development and tools    | [Visit ->](https://blog.nerdbank.net/) |
-| Thor Likes                 | News, opinions, and commentary on Zcash                  | [Visit ->](https://www.thorlikes.com/) |
-| ZecMec                     | Zcash-focused articles on Medium                         | [Visit ->](https://zecmec21.medium.com/) |
-| Ian Sagstetter             | In-depth articles and newsletter                         | [Visit ->](https://iansagstetter.substack.com/) |
-| Naomi Brockwell (NBTV)     | High-profile interviews and content                      | [Visit ->](https://naomibrockwell.com/highprofileinterviews) |
-| Sqribbles                  | Creative and community-driven Zcash content              | [Visit ->](https://free2z.cash/sqribbles) |
-| Str4d                      | Technical writings from Zcash core developer             | [Visit ->](https://words.str4d.xyz/) |
+## Active Blogs and Newsletters
 
----
+| Blog / Author | Focus | Link |
+| --- | --- | --- |
+| James Katz | Personal writing about Zcash, privacy, and community topics | [Visit](https://free2z.cash/James_Katz/) |
+| Thumbs' Update | Recurring ecosystem updates and commentary | [Visit](https://thumbsup.substack.com) |
+| roomatemusing | Community essays and Zcash-related posts | [Visit](https://free2z.cash/roommatemusing) |
+| NerdBank Blog | Technical notes on Zcash wallets, payments, and developer tools | [Visit](https://blog.nerdbank.net/) |
+| Thor Likes | Zcash news, opinion, and market commentary | [Visit](https://www.thorlikes.com/) |
+| ZecMec | Zcash-focused articles and community writing | [Visit](https://zecmec21.medium.com/) |
+| Ian Sagstetter | Long-form articles, research notes, and newsletter posts | [Visit](https://iansagstetter.substack.com/) |
+| Sqribbles | Creative and community-driven Zcash content | [Visit](https://free2z.cash/sqribbles) |
+| Str4d | Technical writing from a Zcash core developer | [Visit](https://words.str4d.xyz/) |
 
-Here are some community-submitted blogs. If you would like ZecHub to feature one of your blog posts or add your own blog here, please create a Pull Request with the details!
+## Video, Interviews, and Media
+
+| Creator / Channel | Focus | Link |
+| --- | --- | --- |
+| Naomi Brockwell / NBTV | Privacy interviews and educational media | [Visit](https://naomibrockwell.com/highprofileinterviews) |
+| Zcash en Espanol | Spanish-language articles, podcasts, and community updates | [Visit](https://zcashesp.com/) |
+| ZK Radio | Community radio and Zcash-focused audio content | [Visit](https://zcashesp.com/zk-radio/) |
+| Zcast | Spanish-language Zcash podcast | [Visit](https://www.youtube.com/@ZcastEsp) |
+| ZecHub | Community education, wiki updates, and ecosystem explainers | [Visit](https://zechub.wiki/) |
+
+## Adding a Blog
+
+To add or refresh a community blog, open a pull request with:
+
+- the blog or author name;
+- a short description of the content;
+- the main link;
+- the language or region if it is not primarily English.
+
+Please avoid adding inactive, duplicate, or purely promotional links.

--- a/site/Zcash_Community/Community_Links.md
+++ b/site/Zcash_Community/Community_Links.md
@@ -2,61 +2,53 @@
   <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
 </a>
 
-# <img src="https://i.ibb.co/qYhRbJM/image-2024-02-03-174147713.png" alt="Alt Text" width="400"/> Zcash Community Links
+# <img src="https://i.ibb.co/qYhRbJM/image-2024-02-03-174147713.png" alt="Zcash community" width="400"/> Zcash Community Links
 
-The Zcash community is a vibrant and passion group of people working towards making ZEC one of the most widely used cryptocurrencies in the world. The community is made up of a diverse group of people from all over the world. They come from a variety of different backgrounds and occupations, but they all work together to help achieve Zcash and ZEC's vision.
+Last reviewed: May 2026.
 
-----
+The Zcash community includes developers, researchers, educators, wallet builders, privacy advocates, miners, merchants, and users from many regions. These links are starting points for discussion, support, events, and ecosystem updates.
 
-## Where you can find community members?
+## Main Community Spaces
 
-The community active in a number of different places:
+| Space | Use it for | Link |
+| --- | --- | --- |
+| Zcash Community Forum | Long-form governance, grants, research, ecosystem, and support discussions. | [Visit](https://forum.zcashcommunity.com/) |
+| Telegram | Day-to-day community chat and general discussion. | [Join](https://t.me/Zcash_Community) |
+| Zcash Global Discord | General Zcash community chat. | [Join](https://discord.gg/zcash) |
+| Zcash R&D Discord | Research, protocol, and developer discussion. | [Join](https://discord.gg/xpzPR53xtU) |
+| Zcash Foundation Discord | Zcash Foundation community and project channels. | [Join](https://discord.gg/na6QZNd) |
+| ZecHub Matrix | Matrix room for ZecHub contributors and community members. | [Join](https://matrix.to/#/#zechub:matrix.org) |
+| ZecHub Social | Mastodon instance for Zcash community discussion. | [Visit](https://zechub.social/public/local) |
 
-### <img src="https://i.ibb.co/qBrb4qK/image-2024-02-03-173937048.png" alt="Alt Text" width="50"/> <span translate="no" class="notranslate">Telegram</span>
+## X / Twitter Accounts
 
-The Zcash community is very active in its community <span translate="no" class="notranslate">Telegram</span>. This is a channel where zcashers talk about the day-to-day, discuss news and updates, and is also a good place for community members to get acquainted with each other. The link to join is [here](https://t.me/Zcash_Community).
+| Account | Focus | Link |
+| --- | --- | --- |
+| Zcash | Main Zcash account. | [@zcash](https://x.com/zcash) |
+| Zcash Community | Community updates and discussion. | [@Zcash_community](https://x.com/zcash_community) |
+| ZecHub | Wiki, education, and bounty updates. | [@Zechub](https://x.com/zechub) |
+| Zcash en Espanol | Spanish-language Zcash community. | [@Zcashesp](https://x.com/zcashesp) |
+| Zcash Brazil | Brazilian Zcash community. | [@zcashbrazil](https://x.com/zcashbrazil) |
+| Zerodartz | Community memes and creative content. | [@Zerodartz](https://x.com/Zerodartz) |
 
-### <img src="https://i.ibb.co/kxVwQxM/image-2024-02-03-174056252.png" alt="Alt Text" width="50"/> <span translate="no" class="notranslate">Discord</span>
+## Official and Ecosystem Sites
 
-[Zcash Global](https://discord.gg/zcash) 
+| Resource | Description | Link |
+| --- | --- | --- |
+| Zcash | Main Zcash website. | [Visit](https://z.cash/) |
+| Zcash Foundation | Public charity building financial privacy infrastructure. | [Visit](https://zfnd.org/) |
+| Electric Coin Company | Developer of Zcash infrastructure and Zashi. | [Visit](https://electriccoin.co/) |
+| Zcash Community Grants | Grants program funding ecosystem work. | [Visit](https://zcashcommunitygrants.org/) |
+| ZecHub Wiki | Community-maintained Zcash education and resource wiki. | [Visit](https://zechub.wiki/) |
+| Zcash Community Website | Community portal and ecosystem information. | [Visit](https://www.zcashcommunity.com/) |
 
-[Zcash R&D](https://discord.gg/xpzPR53xtU)
+## Regional and Language Communities
 
-[Zcash Foundation](https://discord.gg/na6QZNd)
+| Community | Focus | Link |
+| --- | --- | --- |
+| Zcash en Espanol | Spanish-language education, media, and community updates. | [Visit](https://zcashesp.com/) |
+| Zcash Brazil | Portuguese-language community updates. | [X](https://x.com/zcashbrazil) |
 
-### <span translate="no" class="notranslate">Mastodon</span>
+## Keeping Links Current
 
-[ZecHub.Social](https://zechub.social/public/local)
-
-### <span translate="no" class="notranslate">Matrix</span>
-
-[ZecHub](https://matrix.to/#/#zechub:matrix.org)
-
-These places are great options for new community members to join in discussions.
-
-### Zcash Community Forum
-
-The [Zcash community forum](https://forum.zcashcommunity.com/) is a place where long form discussions related to Zcash take place. It's where members voice their support for various proposals in the community, debate specific topics, and also a place where projects seeking grants funding can go to announce their intention for applying to the Zcash Community Grants program. These are not the only topics for discussion, but they are some of the most common.
-
-### <img src="https://i.ibb.co/mqKfr62/image-2024-02-03-174240928.png" alt="Alt Text" width="50"/>   <span translate="no" class="notranslate">Twitter / X</span>
-
-Just like most crypto projects, the Zcash community is extremely active on Twitter. The conversations are lively, debates are plentiful, and of course, there are memes. Here are some interesting accounts to follow
-
-[@Zcash](https://x.com/zcash)
-
-[@Zcash_community](https://x.com/zcash_community)
-
-[@Zechub](https://x.com/zechub)
-
-[@Zcashesp](https://x.com/zcashesp) (Zcash en espanol)
-
-[@Zcash Brazil](https://x.com/zcashbrazil)
-
-[@zerodartz](https://x.com/Zerodartz) (for the memes!)
-
-
-----
-
-### Resources
-
-[Zcash Community Website](https://www.zcashcommunity.com/)
+When updating this page, prefer official invite links and public pages that can be maintained over time. If a chat invite expires, replace it with the newest official community link instead of adding duplicate entries.

--- a/site/Zcash_Community/Community_Projects.md
+++ b/site/Zcash_Community/Community_Projects.md
@@ -4,182 +4,74 @@
 
 ## Zcash Community Projects
 
-[ZECping](https://github.com/emersonian/zecping)
-
-See the gRPC response times of Zcash [Lightwalletd](https://github.com/zcash/lightwalletd) nodes.
-
-[Ziggurat](https://github.com/runziggurat/zcash)
-
-Ziggurat is network test suite that provides zcashd and zebra devs with this reliable foundation. Included in this suite is a Zcash [crawler](https://github.com/runziggurat/zcash/tree/main/src/tools/crawler).
-
-[Exblo](https://testnet.exblo.app/#/)
-
-A block explorer specially design for apps testing transactions over the Zcash Testnet. Currently in active development
-
-The Zcash Block Explorer provides information such as transaction data / block information / Addresses / Mempool Blocks etc. Also allows for Transaction Payment Disclosure Viewing Key to be used.
-
-[Dizzy Wallet](https://forum.zcashcommunity.com/t/dizzy-wallet-a-dedicated-zcash-wallet-for-discord/43988)
-
-Dizzy Wallet is a Discord bot that provides seamless and secure access to Zcash transactions. 
-
-[Frost](https://eprint.iacr.org/2020/852)
-
-Researchers at the Zcash Foundation are collaborating on an IETF informational draft for FROST with researchers at the University of Waterloo and several other organizations, and it’s on the path towards greater adoption within the Zcash ecosystem and beyond.
-
-[Free2z](https://free2z.cash)
-
-Free2z is a tool for anonymous content and private donations.
-
-[Ezcash](https://blog.nerdbank.net/ezcash-app)
-
-An easy to use and fully-feature Zcash wallet multiplatform Zcash Wallet with autoshielding support.
-
-[My First Zcash](https://github.com/massadoptionorg/My-First-Zcash)
-
-An educational workbook created by a team of talented and dedicated content creators and graphic designers from across the Zcash global community.
-
-[Zapp](https://www.justzappit.xyz/)
-
-Zapp is a privacy-first messenger that connects ZEC chats to real‑world payments. [Join for early access](https://www.justzappit.xyz/app)
-
-[Zcash Block Explorer](https://mainnet.zcashexplorer.app/)
-
-A well detailed, comprehensive Zcash block explorer from Nighthawk Apps.
-
-[ZECPublish](https://www.zecpublish.com)
-
-ZECPublish is a censorship resistant, Zcash blockchain-powered social media. It includes a directory of zcash users and an anonymous message board powered by Zcash.
-
-[ZGo](https://zgo.cash)
-
-ZGo is a Zcash Register. Enabling vendors and merchants to accept Zcash. Currently testing the app to get high quality feedback on the usability and features of ZGo.
-
-[Zlink](https://zlink.click)
-
-Zlink is the simplest way to find any link, tool, information you need about Zcash's ecosystem.
-
-[ZK Radio](https://zcashesp.com/zk-radio/)
-
-An online Radio Station to inform, educate and entertain the Zcash Community, developed by Zcash en Español and the ZKAV Club.
-
-## Zimppy.xyz
-[![Zimppy.xyz Logo](https://github.com/betterclever/zimppy/blob/main/site/og.png?raw=true)](https://zimppy.xyz/)
-The Zcash payment method for the Machine Payments Protocol. Shielded by default.
----
-[Visit Site](https://zimppy.xyz/)
-
-## Cypherpunk
-./cypherpunk
-A company dedicated to privacy and self-sovereignty.
-[Visit Site](https://cypherpunk.com/)
-
-## Cipherpay
-[![Cipherpay](https://github.com/atmospherelabs-dev/cipherpay-web/blob/main/public/logo-mark.png?raw=true)](https://www.cipherpay.app/en)
-
-Private payments for the internet. Accept Zcash in minutes. Non-custodial.
-[Visit Site](https://www.cipherpay.app/en)
-
-## Cipherscan
-[![Cipherscan](https://github.com/Kenbak/cipherscan/blob/main/public/logo-small.png?raw=true)](https://cipherscan.app/)
-
-Zcash Blockchain Explorer 🛡️ Decode the blockchain. Privacy meets transparency.
-[Visit Site](https://cipherscan.app/)
-
-## ZcashNames
-[![ZcashNames](https://github.com/zcashme/zcashnames/blob/main/public/brandkit/zcashnames-brand-banner-primary-logo-monochrome-green-monochrome-green-background-377x403.png?raw=true)](https://www.zcashnames.com/)
-
-Personal names
-for
-shielded addresses. A name is all you need to transact privately.
-
-[Visit Site](https://www.zcashnames.com/)
-
-## Zero-knowledge Audiovisual Club
-[![Zero-knowledge Audiovisual Club](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS95FffUJjEeUHAZZ04xRHp9FW1Z0Gzef2UUg&s?raw=true)](https://zkav.club/#additional-reading)
-
-Privacy-first audiovisual (AV) collective for open-source & decentralized tech communities. We train, co-create & run volunteer AV support at community events.
-
-[Visit Site](https://zkav.club/#additional-reading)
-
-## Shielded Labs
-[![Shielded Labs](https://camo.githubusercontent.com/0244df9f30a80c45adfd80c448985f17a6c71cdc9fd0eccd7bf47dec157c0dd4/68747470733a2f2f736869656c6465646c6162732e6e65742f77702d636f6e74656e742f75706c6f6164732f323032342f31312f66617669636f6e5f37325f322e706e67?raw=true)](https://shieldedlabs.net/)
-
-Shielded Labs is an independent, donation-funded Zcash support organization based in Switzerland. It is the first organization in the Zcash ecosystem that has never received direct or indirect funding from the Development Fund or block rewards.
-
-[Visit Site](https://shieldedlabs.net/)
-
-## JustZappIt
-
-JustZappIt is a private messaging app for iOS and Android. In-chat Zcash (ZEC) sending is coming and you'll use an external wallet like Zodl to send ZEC to contacts directly in conversation. No KYC. No middlemen.
-
-[Visit Site](https://www.justzappit.xyz/)
-[Visit Github](https://github.com/JustZappIt/justZappIt/tree/main)
-
-##  Mastering Zcash Video Series 
-
-Mastering Zcash Video Series  is one of the most comprehensive educational pieces about Zcash, covering its technology, cryptography, economics, and governance.
-
-[Visit Site](https://www.youtube.com/watch?v=YWUzh_VtrR8)
-[Visit Github](https://github.com/ZcashCommunityGrants/zcashcommunitygrants/issues/263)
-
-##  Zcast
-
-Zcast is the Spanish-language Zcash podcast, where you can find all the latest and up-to-date information about Zcash.
-
-[Visit Site](https://www.youtube.com/@ZcastEsp)
-
-## Zebra Coverage-Guided Fuzzing Infrastructure
-
-Zebra Coverage-Guided Fuzzing Infrastructure focuses on systematically testing Zebra’s critical parsing, networking, and cryptographic components against malformed inputs, enabling continuous, automated discovery of security vulnerabilities and edge-case bugs.
-
-[Visit Site](https://github.com/ZcashCommunityGrants/zcashcommunitygrants/issues/234)
-
-## ZecDev
-
-ZecDev Launchpad is a Linux first toolkit that brings up a Zebra regtest network with a faucet, Unified Address fixtures, and your choice of lightwalletd or Zaino, plus a reusable GitHub Action that runs golden end to end shielded flows on every pull request. It closes a critical gap as zcashd is deprecated by giving every wallet, SDK, and service a fast repeatable path for local development and CI that catches breakage before users do.
-
-[Visit Site](https://github.com/zecdev)
-
-## TIPZ
-
-TIPZ is a live, non-custodial tipping platform where every tip arrives as shielded ZEC. Fully private ZEC-to-ZEC payments are integrated via Zodl, alongside cross-chain on-ramps from ETH, USDC, USDT, and SOL via NEAR Intents.
-
-[Visit Site](https://tipz.cash/)
-[Visit Github](https://github.com/tipz-cash/tipz.cash)
-
-## Zectastic.com
-
-Zectastic.com is Launch the Zcash rocket, Play the memory game, and Follow the live flippening party
-
-[Visit Site](https://zectastic.com/)
-
-## Zecmap
-
-Zecmap is The global map of businesses accepting Zcash. Discover, verify, and contribute to places that support privacy-focused payments.
-
-[Visit Site](https://zecmap.com/)
-
-
-___
-
-## Applications that Utilize Zcash
-
-[aftok](https://aftok.com)
-
-An aftok is a radical new kind of cooperative, bottom-up business organization. It's a way for you and some trusted friends to build things together and get paid for your efforts, without the hierarchy or overhead of a traditional company.
-
-[Atomic DEX](https://atomicdex.io/en/)
-
-AtomicDEX is a multi-coin wallet, bridge, and DEX rolled into one app. Mobile/Desktop versions available.
-
-[Brave Wallet](https://brave.com/es/wallet/)
-
-A secure crypto wallet directly integrated into Brave Browser that supports Zcash transparent transactions.
-
-[DCRDEX](https://dex.decred.org)
-
-DCRDEX is a decentralized exchange built by the Decred Project. Desktop Client Only.
-
-[Zcash CoinHolder Polling](https://forum.zcashcommunity.com/t/coin-holder-polling-instructions/40170)
-
-A method by which coin-weighted polling took place on the Zcash blockchain using T-addresses and arranged via the community forum.
+Last reviewed: May 2026.
+
+This page collects community-built tools, applications, education projects, and ecosystem services related to Zcash. Projects change quickly, so links should be refreshed when a project moves, becomes inactive, or ships a major update.
+
+## Explorers, Monitoring, and Network Tools
+
+| Project | Description | Links |
+| --- | --- | --- |
+| ZECping | Shows gRPC response times for Zcash lightwalletd nodes. | [GitHub](https://github.com/emersonian/zecping) |
+| Ziggurat | Network test suite and crawler tooling for zcashd and Zebra developers. | [GitHub](https://github.com/runziggurat/zcash) |
+| Exblo | Zcash testnet block explorer for testing applications and transactions. | [Visit](https://testnet.exblo.app/#/) |
+| Zcash Block Explorer | Mainnet explorer with transaction, block, address, mempool, and payment disclosure viewing-key support. | [Visit](https://mainnet.zcashexplorer.app/) |
+| Cipherscan | Zcash blockchain explorer focused on making transparent-chain data easier to inspect. | [Visit](https://cipherscan.app/) |
+| Zecmap | Map of businesses that accept Zcash, with discovery and contribution workflows. | [Visit](https://zecmap.com/) |
+
+## Wallets, Payments, and Commerce
+
+| Project | Description | Links |
+| --- | --- | --- |
+| Dizzy Wallet | Discord bot that helps users access Zcash transactions from Discord. | [Forum](https://forum.zcashcommunity.com/t/dizzy-wallet-a-dedicated-zcash-wallet-for-discord/43988) |
+| Ezcash | Multiplatform Zcash wallet with usability and autoshielding features. | [Blog](https://blog.nerdbank.net/ezcash-app) |
+| ZGo | Register and merchant tooling for accepting Zcash payments. | [Visit](https://zgo.cash) |
+| Zimppy.xyz | Zcash payment method for the Machine Payments Protocol, shielded by default. | [Visit](https://zimppy.xyz/) |
+| Cipherpay | Non-custodial internet payment tooling for accepting Zcash. | [Visit](https://www.cipherpay.app/en) |
+| TIPZ | Non-custodial tipping platform where tips arrive as shielded ZEC. | [Visit](https://tipz.cash/) / [GitHub](https://github.com/tipz-cash/tipz.cash) |
+| JustZappIt | Private messaging app with in-chat Zcash payment plans and external wallet support. | [Visit](https://www.justzappit.xyz/) / [GitHub](https://github.com/JustZappIt/justZappIt/tree/main) |
+| AtomicDEX | Multi-coin wallet, bridge, and decentralized exchange with desktop and mobile apps. | [Visit](https://atomicdex.io/en/) |
+| DCRDEX | Decentralized exchange built by the Decred project. | [Visit](https://dex.decred.org) |
+| Brave Wallet | Browser-integrated wallet with support for Zcash transparent transactions. | [Visit](https://brave.com/wallet/) |
+
+## Publishing, Identity, and Community Apps
+
+| Project | Description | Links |
+| --- | --- | --- |
+| Free2Z | Platform for anonymous content, private donations, and Zcash community publishing. | [Visit](https://free2z.cash) |
+| ZECPublish | Zcash blockchain-powered publishing and social media experiment. | [Visit](https://www.zecpublish.com) |
+| ZcashNames | Human-readable names for shielded addresses. | [Visit](https://www.zcashnames.com/) |
+| Zlink | Link directory for Zcash ecosystem resources, tools, and information. | [Visit](https://zlink.click) |
+| Zapp | Privacy-first messaging and payments project for ZEC users. | [Visit](https://www.justzappit.xyz/) |
+| Zectastic | Community game and live Zcash-themed experience site. | [Visit](https://zectastic.com/) |
+| aftok | Cooperative, bottom-up organization tooling for shared work and payments. | [Visit](https://aftok.com) |
+
+## Education, Media, and Outreach
+
+| Project | Description | Links |
+| --- | --- | --- |
+| My First Zcash | Educational workbook created by contributors from the global Zcash community. | [GitHub](https://github.com/massadoptionorg/My-First-Zcash) |
+| Mastering Zcash Video Series | Educational video series covering Zcash technology, cryptography, economics, and governance. | [Video](https://www.youtube.com/watch?v=YWUzh_VtrR8) / [Grant](https://github.com/ZcashCommunityGrants/zcashcommunitygrants/issues/263) |
+| ZK Radio | Online radio for informing, educating, and entertaining the Zcash community. | [Visit](https://zcashesp.com/zk-radio/) |
+| Zcast | Spanish-language Zcash podcast. | [YouTube](https://www.youtube.com/@ZcastEsp) |
+| Zero-knowledge Audiovisual Club | Privacy-first audiovisual collective for open-source and decentralized technology communities. | [Visit](https://zkav.club/#additional-reading) |
+| ZecDev | Developer launchpad and CI tooling for local Zebra regtest, faucets, lightwalletd, Zaino, and shielded flow testing. | [GitHub](https://github.com/zecdev) |
+
+## Research, Protocol, and Security Infrastructure
+
+| Project | Description | Links |
+| --- | --- | --- |
+| FROST | Threshold signature research and standardization work used across the Zcash ecosystem. | [Paper](https://eprint.iacr.org/2020/852) |
+| Shielded Labs | Independent Zcash support organization based in Switzerland. | [Visit](https://shieldedlabs.net/) |
+| Zebra Coverage-Guided Fuzzing Infrastructure | Fuzzing infrastructure for Zebra parsing, networking, and cryptographic components. | [Grant](https://github.com/ZcashCommunityGrants/zcashcommunitygrants/issues/234) |
+| Cypherpunk | Privacy and self-sovereignty company. | [Visit](https://cypherpunk.com/) |
+
+## Governance and Historical Tools
+
+| Project | Description | Links |
+| --- | --- | --- |
+| Zcash CoinHolder Polling | Historical method for coin-weighted polling using Zcash transparent addresses and forum coordination. | [Forum](https://forum.zcashcommunity.com/t/coin-holder-polling-instructions/40170) |
+
+## Keeping This Page Current
+
+When adding a project, include a short description, the most useful public link, and whether the project is active, experimental, or historical. Remove malformed entries and update moved links so readers can reach the project directly.

--- a/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -1,12 +1,61 @@
-## Zcash Ecosystem Security Lead:
+<a href="https://github.com/Zechub/zechub/edit/main/site/Zcash_Community/Zcash_Ecosystem_Security.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
 
-This ecosystem role began as a ZCG grant application by [earthrise](https://forum.zcashcommunity.com/t/zcash-ecosystem-security-lead/42090) to work as a security engineer serving the wider Zcash ecosystem outside of ECC and ZF, with a focus on ZCG grantees. You can learn more about Earthrise's work as the Zcash Ecosystem Security Lead [here](https://zecsec.com). After this grant was completed, ZCG put out an [RFP](https://forum.zcashcommunity.com/t/rfp-zcash-ecosystem-security-lead-2023/45723) to find a replacement. & at the end of March 2024 ZCG selected [Least Authority](https://leastauthority.com) to step into the role through another grant. You can learn more about Least Authority's work as the Zcash Ecosystem Security Lead [here](https://forum.zcashcommunity.com/t/grant-update-zcash-ecosystem-security-lead/47541).
+# Zcash Ecosystem Security
 
+Last reviewed: May 2026.
 
-## Responsible Disclosure:
+This page summarizes public security resources for Zcash ecosystem contributors. Do not disclose exploitable vulnerability details in public issues, public pull requests, social media, or chat rooms.
 
-The Electric Coin Company & Zcash Foundation both conform to this Responsible Disclosure [standard](https://github.com/RD-Crypto-Spec/Responsible-Disclosure/tree/d47a5a3dafa5942c8849a93441745fdd186731e6) with the following Deviation: 
+## Ecosystem Security Lead
 
->"Zcash is a technology that provides strong privacy. Notes are encrypted to their destination, and then the monetary base is kept via zero-knowledge proofs intended to only be creatable by the real holder of Zcash. If this fails, and a counterfeiting bug results, that counterfeiting bug might be exploited without any way for blockchain analyzers to identify the perpetrator or which data in the blockchain has been used to exploit the bug. Rollbacks before that point, such as have been executed in some other projects in such cases, are therefore impossible.The standard describes reporters of vulnerabilities including full details of an issue, in order to reproduce it. This is necessary for instance in the case of an external researcher both demonstrating and proving that there really is a security issue, and that security issue really has the impact that they say it has - allowing the development team to accurately prioritize and resolve the issue. In the case of a counterfeiting bug, however, just like in CVE-2019-7167, we might decide not to include those details with our reports to partners ahead of coordinated release, so long as we are sure that they are vulnerable."
+The Zcash Ecosystem Security Lead role began as a Zcash Community Grants proposal by [earthrise](https://forum.zcashcommunity.com/t/zcash-ecosystem-security-lead/42090). The role focused on supporting security work across the wider Zcash ecosystem, especially for ZCG-funded projects outside ECC and the Zcash Foundation.
 
+After the original grant, ZCG opened an [RFP for a new Ecosystem Security Lead](https://forum.zcashcommunity.com/t/rfp-zcash-ecosystem-security-lead-2023/45723). In 2024, ZCG selected [Least Authority](https://leastauthority.com/) for the next phase of this work. Updates have been shared on the forum, including the [Least Authority grant update](https://forum.zcashcommunity.com/t/grant-update-zcash-ecosystem-security-lead/47541).
 
+Additional ecosystem security notes are published at [zecsec.com](https://zecsec.com/).
+
+## Responsible Disclosure
+
+Zcash uses coordinated vulnerability disclosure. If you find a security issue:
+
+- report it through the affected project's official security policy;
+- include enough detail for maintainers to reproduce and assess the issue;
+- keep sensitive details private until the maintainers coordinate a fix and disclosure;
+- avoid filing public issues for exploitable bugs.
+
+Public references:
+
+- Zcash security information: [z.cash/support/security](https://z.cash/support/security/2/)
+- zcashd security policy: [github.com/zcash/zcash/security/policy](https://github.com/zcash/zcash/security/policy)
+- Zebra security policy: [github.com/ZcashFoundation/zebra/security/policy](https://github.com/ZcashFoundation/zebra/security/policy)
+- librustzcash security policy: [github.com/zcash/librustzcash/security/policy](https://github.com/zcash/librustzcash/security/policy)
+- lightwalletd security policy: [github.com/zcash/lightwalletd/security/policy](https://github.com/zcash/lightwalletd/security/policy)
+
+## ZCG Security and Vulnerability Disclosure Initiative
+
+The Zcash Community Grants security initiative coordinates eligible vulnerability disclosures and bounty handling for covered projects. Disclosure should still begin with the relevant project's SECURITY.md so the maintainers can triage and remediate the issue.
+
+- Initiative announcement: [ZCG Security & Vulnerability Disclosure Initiative](https://forum.zcashcommunity.com/t/zcg-security-vulnerability-disclosure-initiative/55545)
+- Program information: [bountyzcash.org](https://bountyzcash.org/)
+
+## Security Announcements and Audits
+
+Security announcements, release notes, and audit reports may be published by multiple ecosystem organizations. Useful starting points include:
+
+- Electric Coin Company security information and announcements: [z.cash/support/security](https://z.cash/support/security/2/)
+- Zcash Foundation updates: [zfnd.org](https://zfnd.org/)
+- Zcash Community Forum security and grant updates: [forum.zcashcommunity.com](https://forum.zcashcommunity.com/)
+- Zcash documentation security warnings: [Security Warnings](https://zcash.readthedocs.io/en/latest/rtd_pages/security_warnings.html)
+
+## Reporter Checklist
+
+Before submitting a report, prepare:
+
+- affected project, version, commit, or deployed service;
+- impact summary and affected users or funds;
+- reproduction steps or proof of concept, shared privately;
+- logs, screenshots, or test data that do not expose unrelated secrets;
+- suggested remediation if known;
+- preferred name or handle for credit, if you want acknowledgement.

--- a/site/Zcash_Community/Zcash_Global_Ambassadors.md
+++ b/site/Zcash_Community/Zcash_Global_Ambassadors.md
@@ -4,18 +4,39 @@
 
 # Zcash Global Ambassadors
 
+Last reviewed: May 2026.
 
-The Global Ambassador Program is designed to identify community members who make high-quality contributions to the Zcash community and empower them to become leaders. Ambassadors lead activities that grow the Zcash community, drive user adoption, and advance awareness of Zcash’s privacy-preserving technology.
+The Zcash Global Ambassador Program recognizes community members who make sustained, high-quality contributions to Zcash and helps them grow into local and regional leaders.
 
-## What does an Ambassador do?
+Ambassadors support adoption, education, and awareness of Zcash's privacy-preserving technology. Activities may be online, local, regional, or language-specific.
 
-  * Hosting physical or virtual meetup events
-  * Maintaining an active presence on social media, and creating original content related to Zcash.
-  * Ambassadors have creative freedom over the activities they plan. 
-  
-## [Global Ambassador Website](https://zcashambassadors.com)
-  
+## What Ambassadors Do
 
+- host physical or virtual meetups;
+- create educational content, tutorials, videos, articles, or translations;
+- help new users learn how to use Zcash safely;
+- represent Zcash at local events and community spaces;
+- maintain an active presence on social media and community channels;
+- connect builders, merchants, educators, and users with relevant Zcash resources.
 
- 
+## Useful Links
 
+- Global Ambassador website: [zcashambassadors.com](https://zcashambassadors.com)
+- Community discussion: [Zcash Community Forum](https://forum.zcashcommunity.com/)
+- ZecHub resources: [zechub.wiki](https://zechub.wiki/)
+- Main community links: [Zcash Community Links](./Community_Links.md)
+
+## Good Ambassador Activities
+
+Strong ambassador work is practical, public, and easy for others to build on. Examples include:
+
+- running a meetup and sharing photos, notes, or a recap;
+- translating important Zcash resources into another language;
+- helping local merchants understand shielded payments;
+- onboarding new users with wallet safety basics;
+- publishing explainers about privacy, self-custody, and Zcash use cases;
+- coordinating with other community groups before major events.
+
+## Updating This Page
+
+Add new ambassador resources when they are public, current, and useful for future contributors. Remove links that are inactive or no longer represent the program.


### PR DESCRIPTION
## Summary

- Updates the six requested Zcash Community wiki pages: Community Blogs, Arborist Calls, Community Projects, Zcash Ecosystem Security, Community Links, and Global Ambassadors.
- Replaces stale Arborist registration links with the official Zcash Foundation Arborist Calls page and current recurring time slots.
- Refreshes community project lists, security disclosure guidance, official/community links, and ambassador guidance.
- Cleans up outdated descriptions and the malformed Cypherpunk project entry.

Closes #1592