### PR TITLE
docs(wiki): add CipherScan privacy-first Zcash explorer wiki page

### DIFF
--- a/site/Using_Zcash/CipherScan.md
+++ b/site/Using_Zcash/CipherScan.md
@@ -1,0 +1,216 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/CipherScan.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# CipherScan — The Privacy-First Zcash Blockchain Explorer
+
+Most blockchain explorers are designed for transparent chains, where every address, transaction, and balance is fully public. For Zcash, that approach misses the point entirely.
+
+**[CipherScan](https://cipherscan.app)** is a Zcash-native blockchain explorer built around privacy as a first principle. Rather than exposing raw transaction data without context, CipherScan makes Zcash's privacy features understandable — for everyday users and developers alike.
+
+> **Live at:** [cipherscan.app](https://cipherscan.app) (mainnet) and [testnet.cipherscan.app](https://testnet.cipherscan.app)
+
+---
+
+## What is CipherScan?
+
+CipherScan is an open-source Zcash blockchain explorer that presents on-chain data in a way that respects Zcash's privacy design. It was built with the mission of making Zcash accessible to everyone — not just developers and cryptographers.
+
+Unlike general-purpose explorers, CipherScan:
+
+- Explains what it *cannot* see (shielded transaction details) rather than leaving users confused
+- Provides privacy analysis tools so users can understand their own exposure
+- Decrypts encrypted memo fields client-side — your viewing keys never leave your browser
+- Shows real-time cross-chain ZEC flows across 15+ blockchains
+
+The project is built on Next.js 15, TypeScript 5, and Rust compiled to WebAssembly for client-side cryptographic operations.
+
+---
+
+## Core Features
+
+### 🔍 Blockchain Explorer
+
+CipherScan's core explorer supports all the standard functions users expect:
+
+| Feature | Details |
+|---------|---------|
+| **Address Search** | Look up any t-address or z-address (shielded balances are hidden by design) |
+| **Transaction Lookup** | View transparent transaction inputs, outputs, and memo fields |
+| **Block Browser** | Browse the chain block-by-block with full transaction lists |
+| **Mempool Viewer** | See pending (unconfirmed) transactions in real time |
+| **Live Updates** | WebSocket-powered real-time block notifications — no page refresh needed |
+
+---
+
+### 🛡️ Privacy Tools
+
+This is where CipherScan differentiates from other explorers. Its privacy toolset helps users understand what information is visible on-chain and where risk may exist.
+
+#### Privacy Dashboard
+
+The Privacy Dashboard shows real-time shielded adoption metrics across the Zcash network: what percentage of transactions are fully shielded, how many are transparent, and how this ratio is trending over time. This gives the ecosystem a living pulse on Zcash's actual privacy usage.
+
+#### Client-Side Memo Decryption
+
+Shielded Zcash transactions (Orchard pool) can include encrypted memo fields — private messages attached to a payment. CipherScan can decrypt these memos in your browser using your viewing key.
+
+**Security note:** The decryption runs entirely in WebAssembly (Rust compiled to WASM) inside your browser. Your viewing key is never transmitted to CipherScan's servers. You can verify this by inspecting the network requests while using the feature — no key data leaves the client.
+
+#### Round-Trip Privacy Risk Detection
+
+Some users unknowingly create transactions that can be linked through a "round-trip" pattern — sending funds out and receiving a related amount back in a way that allows chain analysis to correlate the two events. CipherScan's privacy risk tool detects this pattern and flags it for the address being analyzed.
+
+This helps users identify whether their on-chain activity may be more linkable than they realize, and take corrective action before continuing.
+
+---
+
+### 🔗 Cross-Chain ZEC Flows
+
+CipherScan tracks real-time ZEC movement across 15+ blockchains via NEAR Intents integration. The cross-chain view shows:
+
+- ZEC inflows: assets arriving into Zcash from BTC, ETH, SOL, and other chains
+- ZEC outflows: ZEC being swapped or bridged to other networks
+- Volume and flow direction in real time
+
+This makes CipherScan useful not just for exploring on-chain Zcash activity but for understanding how ZEC fits into the broader multi-chain ecosystem.
+
+---
+
+### 📚 Education and UX
+
+CipherScan includes a built-in **Learn Zcash** section — a comprehensive guide covering:
+
+- The difference between transparent and shielded addresses
+- How viewing keys work and when to use them
+- What wallet types are available and which pools they support
+- How to read a Zcash transaction
+
+This is designed for users who are new to Zcash's privacy model and want to understand what the explorer is showing them before drawing conclusions.
+
+**Address Labels:** Users can tag addresses with custom labels stored in browser localStorage — a simple way to keep track of known addresses without creating any account or uploading data.
+
+**Light/Dark Mode:** Full theme support with system preference detection.
+
+**Mobile Responsive:** Full functionality on mobile browsers.
+
+---
+
+## Setting Up CipherScan for Blockchain Exploration
+
+No account or installation is needed to use CipherScan as an explorer. Visit [cipherscan.app](https://cipherscan.app) and use the search bar immediately.
+
+### Searching for an Address
+
+1. Enter any Zcash t-address or z-address in the search bar
+2. CipherScan returns the address's transparent balance and transaction history
+3. For shielded (z-address) balances: these are private by design — CipherScan will indicate the address type but cannot show shielded balances without a viewing key
+
+### Decrypting Your Transaction Memos
+
+1. Navigate to a transaction that contains a shielded output
+2. Click the decrypt memo option
+3. Enter your **Incoming Viewing Key (IVK)** — found in your Zcash wallet settings
+4. The memo is decrypted client-side and displayed. Nothing is sent to any server.
+
+### Checking Privacy Risk
+
+1. Search for a t-address
+2. Navigate to the Privacy Risk tab
+3. CipherScan analyzes the address's transaction history for round-trip linkability patterns
+4. Flagged patterns are explained with recommendations
+
+---
+
+## Using CipherScan's Public API
+
+CipherScan exposes a free public REST API documented interactively at [cipherscan.app/docs](https://cipherscan.app/docs). The API covers:
+
+- Block data: `GET /api/blocks/{height}`
+- Transaction data: `GET /api/transactions/{txid}`
+- Address data: `GET /api/addresses/{address}`
+- Mempool: `GET /api/mempool`
+- Network stats: `GET /api/stats`
+
+**Public Lightwalletd infrastructure:** CipherScan also provides a free public Lightwalletd gRPC and REST endpoint — the same protocol used by Zashi, Ywallet, and other light wallets. Developers building Zcash applications can use this endpoint during development and testing without running their own full node.
+
+### Example: Fetch the latest block
+
+```bash
+curl https://cipherscan.app/api/blocks/latest
+```
+
+### Example: Look up a transaction
+
+```bash
+curl https://cipherscan.app/api/transactions/<txid>
+```
+
+Responses are standard JSON. Full schema documentation is available in the interactive docs.
+
+---
+
+## Integrating CipherScan with Other Applications
+
+CipherScan's public API makes it straightforward to integrate Zcash data into external applications:
+
+### Check ZEC balance in a script
+
+```bash
+ZEC_ADDRESS="t1YourAddressHere"
+curl -s "https://cipherscan.app/api/addresses/${ZEC_ADDRESS}" | jq '.balance'
+```
+
+### Monitor for incoming transactions (webhook-style polling)
+
+```bash
+LAST_TXID=""
+while true; do
+  LATEST=$(curl -s "https://cipherscan.app/api/addresses/${ZEC_ADDRESS}" | jq -r '.transactions[0].txid')
+  if [ "$LATEST" != "$LAST_TXID" ]; then
+    echo "New transaction: $LATEST"
+    LAST_TXID="$LATEST"
+  fi
+  sleep 60
+done
+```
+
+### Real-time block subscription (WebSocket)
+
+Developers can connect to CipherScan's WebSocket endpoint to receive push notifications when new blocks are mined, without polling.
+
+---
+
+## Privacy Architecture: Why Viewing Keys Never Leave Your Browser
+
+CipherScan's memo decryption feature deserves extra explanation, because it is meaningfully different from how other tools handle key material.
+
+Most services that offer "decrypt my memo" functionality work by sending your viewing key (or wallet seed) to a server, decrypting on the backend, and returning the result. This requires trusting the service with your key — a significant security risk.
+
+CipherScan takes a different approach: the decryption logic is compiled from Rust to **WebAssembly (WASM)** and runs entirely inside your browser. The execution happens locally, on your machine. Your viewing key is passed only to the WASM module in the browser process — it is never transmitted over the network.
+
+You can independently verify this: open browser developer tools, go to the Network tab, then perform a memo decryption. You will see no outbound request carrying your key material.
+
+This is an important property for Zcash users who want to inspect their shielded transactions without compromising the privacy guarantees of their wallet.
+
+---
+
+## Summary
+
+| Feature | Details |
+|---------|---------|
+| **Type** | Zcash blockchain explorer (privacy-first) |
+| **URL** | [cipherscan.app](https://cipherscan.app) |
+| **Open source** | Yes (AGPL v3 + Commons Clause) |
+| **Account required** | No |
+| **Memo decryption** | Client-side, viewing keys never transmitted |
+| **API** | Free public REST API + Lightwalletd gRPC |
+| **Cross-chain data** | ZEC flows across 15+ chains via NEAR Intents |
+| **Network support** | Mainnet and Testnet |
+| **Mobile support** | Yes |
+
+CipherScan is one of the most technically capable Zcash-specific explorers available, and the only one built from the ground up around Zcash's privacy model. Whether you are a new user trying to understand your first shielded transaction or a developer building on top of Zcash's infrastructure, it provides the tooling and clarity that general-purpose explorers cannot.
+
+---
+
+*For related reading, see [Non-Custodial Exchanges](/site/Using_Zcash/Non-Custodial_Exchanges), [Wallets](/site/Using_Zcash/Wallets), [FROST and Multi-Signature Privacy](/site/Zcash_Tech/FROST), and [Zcash Tech Overview](/site/Zcash_Tech).*

--- a/site/Using_Zcash/THORChain.md
+++ b/site/Using_Zcash/THORChain.md
@@ -1,0 +1,170 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/THORChain.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZEC on THORChain: Native Cross-Chain Swaps Explained
+
+Imagine swapping Zcash directly for Bitcoin — with no exchange account, no identity verification, no wrapped tokens, and no custodian holding your funds. This is what THORChain makes possible.
+
+THORChain is a decentralized liquidity protocol that allows users to swap native assets across multiple blockchains without wrapping, bridging, or trusting a third party. Since ZEC integration launched, Zcash holders can access deep cross-chain liquidity while keeping full custody of their funds throughout the swap.
+
+---
+
+## What is THORChain?
+
+THORChain is a decentralized cross-chain liquidity network. Unlike most "cross-chain" solutions that wrap assets into synthetic representations (e.g., WBTC or renZEC), THORChain moves the native assets themselves — no wrapping, no pegs, no custodians.
+
+The protocol maintains liquidity pools across supported chains. When you swap ZEC for BTC using THORChain, you are:
+1. Sending real ZEC into a ZEC liquidity pool
+2. Receiving real BTC from a BTC liquidity pool
+3. At no point does a third party hold your funds between steps
+
+THORChain's native token, **RUNE**, sits at the center of every pool pair. Each pool is paired with RUNE (e.g., ZEC:RUNE, BTC:RUNE), allowing cross-asset swaps to route through RUNE as an intermediary — without the user needing to touch or own RUNE directly.
+
+---
+
+## Native Cross-Chain Swaps: No Wrapping Required
+
+Most cross-chain bridges work by locking an asset on its native chain and minting a synthetic "wrapped" version on the destination chain. This creates:
+- **Peg risk**: The wrapped token may lose its peg
+- **Bridge risk**: Smart contract exploits can drain the bridge
+- **Custody risk**: A custodian (often a multisig) holds your real assets
+
+THORChain eliminates all three. Here is what actually happens when you swap ZEC → BTC:
+
+| Step | What happens | Who holds the funds |
+|------|-------------|---------------------|
+| 1. You send ZEC to a THORChain inbound address | THORChain nodes observe the ZEC transaction | You (until confirmed) |
+| 2. Swap executes on THORChain | RUNE intermediary swap runs on-chain | THORChain protocol (non-custodial) |
+| 3. BTC is sent from the pool to your address | Real BTC delivered natively | You |
+
+No wrapped tokens. No bridge. No central counterparty. The entire process is governed by THORChain's validator set — a network of independent nodes that each hold fractional key shares using threshold signature schemes (TSS).
+
+---
+
+## ZEC Liquidity Pools
+
+THORChain uses **Continuous Liquidity Pools (CLPs)**, also known as Automated Market Makers (AMMs). The ZEC/RUNE pool works as follows:
+
+- **Liquidity providers** deposit equal value of ZEC and RUNE into the pool
+- Swap fees accrue to LPs in proportion to their share of the pool
+- Pool depth determines price impact — deeper pools mean lower slippage for large swaps
+- The protocol adjusts swap fees dynamically based on trade size relative to pool depth
+
+### Providing ZEC Liquidity
+
+Anyone can add ZEC to the THORChain liquidity pool by:
+1. Connecting a ZEC wallet via a THORChain-compatible interface (e.g., THORSwap)
+2. Depositing ZEC (symmetric deposits are paired with RUNE; asymmetric deposits are also supported)
+3. Receiving liquidity provider units (LP units) representing your pool share
+
+LPs earn:
+- **Swap fees** from users routing through the pool
+- **Block rewards** from RUNE emissions
+
+Impermanent loss is a risk, as with any AMM — LPs should understand that ZEC:RUNE price ratio changes affect LP unit value.
+
+---
+
+## Interoperability: BTC, ETH, and Multi-Asset Connectivity
+
+ZEC on THORChain doesn't just connect to one other chain. THORChain supports native swaps across a growing set of Layer 1 networks:
+
+| Chain | Native Asset |
+|-------|-------------|
+| Zcash | ZEC |
+| Bitcoin | BTC |
+| Ethereum | ETH and ERC-20 tokens |
+| BNB Chain | BNB and BEP-20 tokens |
+| Cosmos | ATOM |
+| Litecoin | LTC |
+| Dogecoin | DOGE |
+| Avalanche | AVAX |
+
+This means a ZEC holder can swap directly into BTC, ETH, ATOM, or any other supported asset in a single transaction — with no exchange account required.
+
+For Zcash specifically, this opens access to liquidity markets that previously required using custodial exchanges and undergoing KYC verification. The swap is simply a transaction sent from your wallet.
+
+---
+
+## Ecosystem Extensions: THORSwap and Maya Protocol
+
+### THORSwap
+
+THORSwap is the primary user interface for THORChain. It provides:
+- A web-based swap interface connecting to the THORChain network
+- Portfolio tracking for LPs
+- Access to THORChain's streaming swaps (splits large swaps into smaller chunks to reduce slippage)
+- Aggregator routing that finds optimal paths across THORChain and other DEX protocols
+
+THORSwap's **Near Intents** integration allows intent-based routing, where users specify the desired outcome (e.g., "I want at least 0.95 BTC for my ZEC") and the protocol routes the swap optimally.
+
+### Maya Protocol
+
+Maya Protocol is a THORChain-compatible fork that extends the ecosystem with additional features:
+
+- **CACAO** is Maya's native token, analogous to RUNE in THORChain
+- Maya maintains its own independent validator set and liquidity pools
+- It supports a similar asset list including ZEC, BTC, ETH, and others
+- Maya's **Savers Vaults** allow single-asset liquidity provision (no RUNE/CACAO required), making ZEC yield generation more accessible
+- Maya's **Aztec DEX** integration adds privacy-preserving swap routing
+
+Using THORSwap, users can route swaps through both THORChain and Maya Protocol to access combined liquidity depth.
+
+---
+
+## Security and Decentralization
+
+THORChain's security model addresses the custodial risks common in cross-chain infrastructure:
+
+### Threshold Signature Scheme (TSS)
+
+THORChain nodes collectively manage the protocol's vaults using **Threshold Signature Scheme (TSS)** — a form of distributed key management where no single node holds a complete private key. Funds can only be moved when a threshold of nodes agree.
+
+This is conceptually similar to FROST (described separately in the [FROST wiki page](/site/Zcash_Tech/FROST)) — both use threshold cryptography to distribute trust across multiple parties.
+
+### Economic Security
+
+Nodes must **bond RUNE** as collateral to participate in the network. The protocol enforces:
+- **Slash conditions**: Nodes that misbehave (e.g., attempt to steal funds) have their bond slashed
+- **Incentive pendulum**: The protocol adjusts block rewards to keep the bonded value higher than the pooled value, ensuring theft is economically irrational
+- **Churning**: The validator set rotates regularly, and underperforming nodes are ejected
+
+### Non-Custodial by Design
+
+At no point does any individual or organization hold user funds. There is no multisig controlled by a company, no bridge operator, and no "team wallet." The protocol is governed by its on-chain economic rules.
+
+---
+
+## How to Swap ZEC on THORChain
+
+You do not need an account, KYC, or RUNE to swap. The steps are:
+
+1. **Get a ZEC wallet** — Any transparent ZEC address works (THORChain currently uses transparent addresses for inbound swaps)
+2. **Visit a THORChain interface** — [THORSwap](https://app.thorswap.finance), [Maya Protocol UI](https://app.mayaprotocol.com), or any aggregator that includes THORChain routing
+3. **Select ZEC as the input asset** and your destination asset (e.g., BTC, ETH)
+4. **Provide your destination wallet address**
+5. **Send ZEC to the provided inbound address** — the protocol handles the rest
+
+The swap is typically completed in minutes, depending on block confirmation times on both chains.
+
+---
+
+## Summary: Why THORChain Matters for Zcash
+
+THORChain gives ZEC holders a non-custodial path to global liquidity that does not require KYC, account registration, or trust in a centralized intermediary. The key benefits:
+
+| Benefit | Details |
+|---------|---------|
+| **Native assets** | No wrapped ZEC, no peg risk |
+| **Non-custodial** | You hold funds until the swap completes |
+| **No KYC** | Send from any ZEC wallet |
+| **Multi-chain access** | Swap to BTC, ETH, ATOM, and more |
+| **Permissionless liquidity** | Anyone can provide ZEC liquidity and earn fees |
+| **Decentralized** | No company controls the protocol |
+
+As Zcash adoption grows, non-custodial cross-chain liquidity becomes an increasingly important piece of infrastructure. THORChain provides that infrastructure today — and with Maya Protocol extending coverage, ZEC holders have access to one of the deepest decentralized swap networks available.
+
+---
+
+*For related reading, see [Non-Custodial Exchanges](/site/Using_Zcash/Non-Custodial_Exchanges), [FROST and Multi-Signature Privacy](/site/Zcash_Tech/FROST), and [Buying ZEC](/site/Using_Zcash/Buying_ZEC).*

--- a/site/Using_Zcash/Zcash_Gaming_Privacy.md
+++ b/site/Using_Zcash/Zcash_Gaming_Privacy.md
@@ -1,0 +1,181 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/Zcash_Gaming_Privacy.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Privacy in Play: Zcash (ZEC) in the Global Gaming Ecosystem
+
+Every time a gamer buys a skin, upgrades a weapon, or enters a paid tournament on a public blockchain, they leave a permanent, searchable record linking their wallet address to that transaction. Anyone — competitors, strangers, advertisers — can trace the full financial history of that player's wallet.
+
+Zcash solves this. Its shielded addresses (z-addresses) allow gaming microtransactions to remain private between the user and the payment processor, while still settling on a public, decentralized blockchain. No metadata trail. No wallet surveillance.
+
+This page explores how ZEC functions in the gaming ecosystem, why shielded payments matter for players, and where the integration is happening today.
+
+---
+
+## Why Privacy Matters in Gaming
+
+Gaming is one of the highest-frequency use cases for small digital payments. A single active player might make dozens of microtransactions per month: cosmetics, season passes, in-game currency, tournament entry fees, NFT trades, and tips to streamers.
+
+On a transparent blockchain like Bitcoin or Ethereum, each of these transactions is permanently linked to a public address. This creates several real problems:
+
+### The Doxxing Risk
+
+When a player's wallet address becomes known — through a streamer payout, a tournament prize, or a marketplace listing — their entire financial history becomes searchable. Anyone can see:
+
+- How much they spend on games per month
+- Which games they play (based on which contracts they interact with)
+- Their overall portfolio value
+- What they sold and for how much
+
+Professional players, streamers, and content creators are especially exposed. Publishing a tip jar address or receiving a prize publicly links your on-chain identity to your financial activity.
+
+### The Targeting Risk
+
+Public spending data enables targeted manipulation. If a competitor knows a player spends heavily on a particular game, they can infer playing style, strategy, or level of investment. In games with real-money economies, this is competitively valuable information.
+
+Advertisers and data brokers increasingly harvest on-chain data to build behavioral profiles. In traditional gaming, this concern is limited to browser cookies and account data. In blockchain gaming, the data is public by default and cannot be deleted.
+
+### The Metadata Problem
+
+Even when a transaction amount is considered normal, the metadata surrounding it can be sensitive: which exchange was used to buy ZEC, which marketplace a NFT was purchased from, the timing of purchases relative to game events. On transparent chains, all of this is available to anyone running a blockchain analytics query.
+
+---
+
+## How Zcash Shields Gaming Transactions
+
+Zcash offers two address types: **transparent (t-addresses)** and **shielded (z-addresses)**. Transactions between z-addresses are fully encrypted on-chain — the sender, receiver, and amount are all hidden from public view, while still being verifiable by the parties involved.
+
+For gaming applications, this means:
+
+| Transaction type | Public chain (BTC/ETH) | Zcash z-to-z |
+|-----------------|------------------------|--------------|
+| Who paid | Visible | Hidden |
+| Amount paid | Visible | Hidden |
+| Which game/contract | Visible | Hidden |
+| Transaction history of sender | Fully visible | Hidden |
+| Verifiable by recipient? | Yes | Yes |
+| Reversible? | No | No |
+
+A player can prove they made a payment (for example, to claim a prize or verify a purchase) using Zcash's **viewing key** — a cryptographic disclosure mechanism that allows selectively revealing transaction details to a specific party without exposing the rest of the wallet history.
+
+This is the core promise of Zcash for gaming: **the privacy of cash, with the programmability and verifiability of blockchain.**
+
+---
+
+## Use Cases in the Gaming Ecosystem
+
+### 1. Private Microtransactions and In-Game Purchases
+
+The most direct application: using ZEC as a payment method for in-game items, season passes, cosmetics, and upgrades — without linking the purchase to a public wallet address.
+
+Game developers can accept ZEC payments by integrating a payment processor that supports shielded transactions. Players send ZEC from a z-address to the merchant's designated address; the developer receives confirmed payment without learning anything about the player's broader financial activity.
+
+This model mirrors how cash works at a physical arcade: you pay, you play, no record connects your identity to your spending habits.
+
+### 2. Tournament Entry and Prize Distribution
+
+Blockchain-native tournaments increasingly require on-chain buy-ins and payouts. When entry fees and prizes are paid in transparent cryptocurrencies, the financial graph of every participant is exposed.
+
+ZEC allows tournament organizers to:
+- Accept private entry fees from players without exposing player wallet balances
+- Distribute prizes to winners via shielded transfers
+- Run provably fair prize pools without broadcasting the total value on-chain until the event concludes
+
+### 3. Streamer and Creator Payments
+
+Streamers and content creators commonly accept crypto donations. On public chains, every donation is visible on-chain: who gave how much, when, and from which wallet. This creates privacy risks for donors and exposes the streamer's total earnings publicly.
+
+Zcash shielded addresses allow donors to send ZEC privately. The streamer receives the payment; the donor's identity and wallet history remain hidden. For high-value streamers in regions where financial privacy is a safety concern, this is not just a preference — it is a protection.
+
+### 4. NFT Trading and Digital Asset Marketplaces
+
+While most NFT infrastructure is built on Ethereum and Solana (transparent chains), the Zcash community has explored private NFT mechanisms. The Zcash Shielded Assets (ZSA) protocol — currently in development — will enable asset issuance within Zcash's shielded pool, laying the groundwork for NFTs that transfer privately.
+
+In the interim, ZEC can be used as the payment currency for NFT purchases on marketplaces that support it, providing privacy for the payment leg of the transaction even when the NFT metadata is public.
+
+### 5. Blockchain Game Economies
+
+Some blockchain games have native economies where ZEC or ZEC-pegged assets can function as the primary in-game currency. Players can earn, trade, and spend within the game's economy without their activity being visible to other players on the open market.
+
+This is especially relevant for play-to-earn games, where players' earnings and spending habits are economically sensitive information.
+
+---
+
+## Real-World Integrations
+
+### Free2Z
+
+[Free2Z](https://free2z.cash) is a Zcash-native creator platform that allows content creators — including streamers and game commentators — to receive ZEC tips and memberships via shielded addresses. Creators publish content; supporters pay in ZEC. Neither party's financial history is exposed to the other or to outside observers.
+
+### Zcash Ecosystem Payment Processors
+
+Several payment processors and API providers support ZEC payments that can be integrated into gaming backends:
+
+- **Zimppy** ([zimppy.xyz](https://zimppy.xyz)): A Machine Payment Protocol designed for frequent, small-value ZEC payments — directly applicable to gaming microtransactions and agent-native payment flows. Supports shielded transactions and offers SDKs for TypeScript and Rust integration.
+- **Flexa**: Accepts ZEC at retail and online merchants via the SPEDN app, usable wherever Flexa is integrated.
+
+### THORChain Cross-Chain Liquidity
+
+Players holding assets on other chains (BTC, ETH) can swap into ZEC using THORChain's native cross-chain swap protocol, without custodians or KYC. This gives game developers the flexibility to price in ZEC while players fund their accounts from whichever chain they hold assets on.
+
+---
+
+## The Zcash Shielded Assets (ZSA) Protocol
+
+Looking ahead, the **Zcash Shielded Assets (ZSA)** protocol — developed by QEDIT and being integrated into the Zcash protocol — will allow issuance of custom tokens within Zcash's shielded pool.
+
+For gaming, ZSA unlocks the possibility of:
+- **Private in-game currencies**: A game can issue its own token (e.g., "GoldCoin") within the Zcash shielded pool, so player balances and transactions remain private
+- **Private NFTs**: Digital items that can be transferred between players without the trade appearing on a public ledger
+- **Private tournament tokens**: Entry credentials and proof of participation that cannot be externally surveilled
+
+ZSA represents a significant upgrade in the programmability of Zcash's privacy guarantees. When live, it will enable an entirely new class of privacy-preserving game economies that are not feasible on transparent chains.
+
+---
+
+## Setting Up ZEC for Gaming Payments
+
+Getting started as a player or developer:
+
+### For Players
+
+1. **Install a Zcash wallet** that supports shielded addresses — [Zashi](https://electriccoin.co/zashi/) (mobile), [Ywallet](https://ywallet.app/), or [Nighthawk Wallet](https://nighthawkwallet.com/) are commonly used options
+2. **Fund with ZEC** by purchasing from an exchange that supports shielded withdrawals (e.g., Gemini supports shielded Zcash withdrawals), or by swapping from another asset via THORChain
+3. **Use your z-address** for gaming payments — look for games and platforms that accept ZEC at a shielded address
+4. **Use viewing keys** if you need to prove a payment to a game server or tournament organizer
+
+### For Game Developers
+
+1. **Choose a payment integration**: For simple pay-and-confirm flows, a ZEC payment processor (Zimppy, BitPay where supported) handles address generation and confirmation monitoring
+2. **Accept shielded addresses**: Ensure your integration generates z-addresses for player deposits, not only t-addresses
+3. **Use the Zcash SDK**: The Zcash community maintains SDKs for [Android](https://github.com/zcash/zcash-android-wallet-sdk), [iOS](https://github.com/zcash/ZcashLightClientKit), and [TypeScript/JavaScript](https://github.com/nicholasgasior/zcash-light-client) environments
+
+---
+
+## Privacy as a Competitive Advantage
+
+Beyond protecting players, privacy-preserving payments offer game developers a competitive differentiator. In a landscape where blockchain games have struggled with adoption due to concerns about on-chain surveillance, wallet profiling, and front-running, offering private payments addresses real barriers to mainstream gaming audiences.
+
+The majority of gamers who would never accept having their purchase history published publicly are the same players who resist on-chain gaming today — not because of crypto skepticism, but because public blockchains violate the same privacy norms they expect from traditional gaming platforms.
+
+Zcash, and ZEC specifically, provides a path to on-chain gaming economies that meet users where their privacy expectations already are.
+
+---
+
+## Summary
+
+| Feature | Zcash Advantage for Gaming |
+|---------|---------------------------|
+| Shielded microtransactions | No public record of in-game purchases |
+| Creator payments | Private tips and memberships via z-addresses |
+| Tournament payouts | Private prize distribution |
+| NFT payments | ZEC as private payment leg for digital assets |
+| Future ZSA | Private in-game currencies and private NFTs |
+| Viewing keys | Selective disclosure for dispute resolution |
+| Cross-chain via THORChain | Native swap from BTC/ETH to ZEC, no KYC |
+
+Zcash doesn't require gamers to choose between the benefits of blockchain — true ownership, programmable payments, censorship resistance — and the privacy they take for granted in traditional gaming environments.
+
+---
+
+*For related reading, see [Spend Zcash](/site/Using_Zcash/Spend_Zcash), [Zimppy — Machine Payment Protocol](/site/Using_Zcash/zimppy), [THORChain Cross-Chain Swaps](/site/Using_Zcash/THORChain), and [Zcash Shielded Assets](/site/Zcash_Tech/Zcash_Shielded_Assets).*

--- a/site/Zcash_Tech/FROST.md
+++ b/site/Zcash_Tech/FROST.md
@@ -2,133 +2,151 @@
   <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
 </a>
 
-# FROST 
+# FROST and Multi-Signature Privacy in Zcash
 
+Imagine a company treasury that requires three executives to approve any large transfer. Or a nonprofit DAO that needs five of its eight board members to move funds. Or a family securing an inheritance so no single person can act alone.
 
-## What is a Schnorr signature?
+These are exactly the problems FROST was built to solve — with a key difference from traditional multisig: the final result looks indistinguishable from a single-person signature.
 
-A Schnorr digital signature is a set of algorithms: (KeyGen, Sign, Verify).
-
-Schnorr signatures have several advantages. One key advantage is that when multiple keys are used to sign the same message, the resulting signatures can be combined into a single signature. This can be used to significantly reduce the size of multisig payments and other multisig related transactions.
-
+---
 
 ## What is FROST?
 
-**Flexible Round-Optimized Schnorr Threshold Signatures** -
-*Created by Chelsea Komlo (University of Waterloo, Zcash Foundation) & Ian Goldberg (University of Waterloo).*
+**FROST** stands for **Flexible Round-Optimized Schnorr Threshold Signatures**. It was created by Chelsea Komlo (Zcash Foundation / University of Waterloo) and Ian Goldberg, and is now standardized as [RFC 9591](https://www.rfc-editor.org/rfc/rfc9591).
 
-FROST is a threshold signature and distributed key generation protocol that offers minimal rounds of communication and is secure to be run in parallel. FROST protocol is a threshold version of the Schnorr signature scheme.
+At its core, FROST is a way for a *group* of people to share control over a cryptographic key — without any single person ever holding the complete key.
 
-Unlike signatures in a single-party setting, threshold signatures require cooperation among a threshold number of signers each holding a share of a common private key. 
+### The problem with a single private key
 
-[What are Threshold Signatures? Chelsea Komlo - Zcon3](https://youtu.be/cAfTTfblzoU?t=110)
+A standard crypto wallet has one private key. Whoever holds that key controls the funds. This creates two risks:
+- **Loss**: If the key is lost or destroyed, the funds are gone forever.
+- **Theft**: If the key is stolen, the funds can be taken immediately.
 
-Consequently, generating signatures in a threshold setting imposes overhead due to network rounds among signers, proving costly when secret shares are stored on network-limited devices or when coordination occurs over unreliable networks.
+### How FROST changes the model
 
-Network overhead during signing operations is reduced by employing a novel technique to protect against forgery attacks applicable to other schemes.
- 
-FROST improves upon threshold signature protocols as an unlimited number of signature operations can be performed safely in parallel (concurrency).
- 
-It can be used as either a 2-round protocol where signers send and receive 2 messages in total, or optimized to a single-round signing protocol with a pre-processing stage. 
+With FROST, the private key is mathematically split into **shares** distributed among multiple participants. Here's what makes it powerful:
 
-FROST achieves its efficiency improvements in part by allowing the protocol to abort in the presence of a misbehaving participant (who is then identified and excluded from future operations).
- 
-Proofs of security demonstrating that FROST is secure against chosen-message attacks assuming the discrete logarithm problem is hard and the adversary controls fewer participants than the threshold are provided [here](https://eprint.iacr.org/2020/852.pdf#page=16).
+- A **threshold** (e.g., 2-of-3, or 3-of-5) must cooperate to produce a valid signature.
+- No individual share by itself is useful — an attacker who steals one share cannot spend the funds.
+- The final signature produced by the group is a **single Schnorr signature** — it looks exactly like one person signed, not many.
 
+This last point is crucial for privacy.
 
-## How does FROST work?
+---
 
-The FROST protocol contains two important components:
+## Why FROST is Different from Traditional Multisig
 
-First, n participants run a *distributed key generation (DKG) protocol* to generate a common verification key; at the end, each participant obtains a private secret key share and a public verification key share. 
+Most people are familiar with multisig from Bitcoin — where a transaction can require M-of-N signatures. This works, but it has a significant drawback: **it's visible on-chain**.
 
-Afterwards, any t-out-of-n participants can run a *threshold signing protocol* to collaboratively generate a valid Schnorr signature. 
+When a 2-of-3 Bitcoin multisig transaction is broadcast, anyone looking at the blockchain can see that it was a multisig transaction, how many signatures were required, and the public keys of all potential signers. This leaks information about who controls the funds.
 
-<a href="">
-    <img src="https://static.cryptohopper.com/images/news/uploads/1634081807-frost-flexible-round-optimized-schnorr-threshold-signatures-1.jpg" alt="" width="400" height="300"/>
-</a>
+| Feature | Traditional Multisig | FROST |
+|---|---|---|
+| On-chain signature count | M separate signatures | 1 combined signature |
+| Reveals spending policy? | Yes (e.g., "2-of-3") | No |
+| Key size overhead | Linear in M | Constant |
+| Compatible with privacy? | Limited | Yes |
+| Requires all rounds live? | Usually | No — can abort misbehaving participants |
 
-**Distributed key generation (DKG)**
+FROST produces a **single Schnorr signature** from the group. An observer cannot tell whether the transaction was signed by one person or ten. The internal structure — how many participants, what the threshold is — stays private.
 
-The goal of this phase is to generate long-lived secret key shares and a joint verification key. This phase is run by n participants. 
+---
 
-FROST builds its own key generation phase upon [Pedersens DKG (GJKR03)](https://blog.gtank.cc/notes-on-threshold-signatures/)  in which it uses both Shamir secret sharing and Feldmans verifiable secret sharing schemes as subroutines. In addition, Each participant is required to demonstrate knowledge of their own secret by sending to other participants a zero-knowledge proof, which itself is a Schnorr signature. This additional step protects against rogue-key attacks in the setting where t ≥ n/2.
+## How FROST Works (Simply Explained)
 
-At the end of the DKG protocol, a joint verification key vk is generated. Also, each participant P ᵢ holds a value (i, sk ᵢ ) that is their long-lived secret share and a verification key share vk ᵢ = sk ᵢ *G. Participant P ᵢs verification key share vk ᵢis used by other participants to verify the correctness of P ᵢs signature shares in the signing phase, while the verification key vk is used by external parties to verify signatures issued by the group.
+You don't need to understand the cryptography to understand the concept.
 
-**Threshold Signing**
+**Step 1: Key Setup (Distributed Key Generation)**
 
-This phase builds upon known techniques that employ additive secret sharing and share conversion to non-interactively generate the nonce for each signature. This phase also leverages binding techniques to avoid known forgery attacks without limiting concurrency.
+The group runs a setup protocol. At the end:
+- Each participant holds a *private key share* (only they see it).
+- Everyone knows the *group public key* (this is what verifies signatures).
+- The complete private key never exists in one place — it's split before it's ever assembled.
 
-Preprocessing: In the preprocessing stage, each participant prepares a fixed number of Elliptic Curve (EC) point pairs for further use, which is run for a single time for multiple threshold signing phases.
+**Step 2: Signing (Threshold Signing)**
 
-<a href="">
-    <img src="https://i.ibb.co/nQD1c3n/preprocess.png" alt="" width="400" height="300"/>
-</a>
+When the group wants to sign something:
+1. The required threshold of participants each compute a *partial signature* using their private share.
+2. These partial signatures are combined into one final Schnorr signature.
+3. This single signature is broadcast — it verifies against the group public key exactly like a normal signature.
 
-Signing Round 1: Each participant Pᵢ begins by generating a single private nonce pair (dᵢ, eᵢ) and corresponding pair of EC points (Dᵢ, Eᵢ) and broadcasts this pair of points to all other participants. Each participant stores these pairs of EC points received for use later. Signing rounds 2 and 3 are the actual operations in which t-out-of-n participants cooperate to create a valid Schnorr signature.
+If a participant misbehaves or goes offline, FROST can identify them and abort, then retry with different participants (as long as the threshold can still be met).
 
-Signing Round 2: To create a valid Schnorr signature, any t participants work together to execute this round. The core technique behind this round is t-out-of-t additive secret sharing.
+---
 
-This step prevents forgery attack because attackers cannot combine signature shares across distinct signing operations or permute the set of signers or published points for each signer. 
+## Real-World Use Cases
 
-<a href="">
-    <img src="https://i.ibb.co/b5rJbXx/sign.png" alt="" width="400" height="300"/>
-</a>
+### DAO Treasury Management
 
-Having computed the challenge c, each participant is able to compute the response zᵢ to the challenge using the single-use nonces and the long-term secret shares, which are t-out-of-n (degree t-1) Shamir secret shares of the groups long-lived key. At the end of signing round 2, each participant broadcasts zᵢ to other participants.
+A DAO with 12 voting members could require 7-of-12 approval before any funds move. With FROST:
+- No single admin or multisig contract controls the keys.
+- Governance decisions are enforced cryptographically, not just by policy.
+- On-chain, the spend looks like a normal transaction — no metadata about the DAO's internal structure.
 
-[Read the full paper](https://eprint.iacr.org/2020/852.pdf)
+### Institutional Custody
 
+A custody provider holding client funds typically faces a dilemma: keep keys in a single HSM (centralized risk) or use multisig (reveals custody structure). FROST offers a third path — threshold control with a single clean signature. Regulators and auditors see normal transactions; the internal custody structure stays private.
 
-## Does it benefit Zcash?
+### Shared Wallets for Families or Organizations
 
-Absolutely yes. The introduction of FROST to Zcash will allow multiple parties, separated geographically to control spend authority of shielded ZEC. An advantage being that transactions broadcast using this signature scheme will be indistinguishable from other transactions on the network, maintaining strong resistance to payment tracking and limiting the amount of blockchain data available for analysis. 
+A family can set up a 2-of-3 wallet among parents and a trusted relative. Funds are secure even if one device is lost. When the parents want to spend, they cooperate — but their transaction looks normal on the blockchain.
 
-In practice this allows for an entire host of new applications to be built on the network ranging from escrow providers or other non-custodial services. 
+### Advanced Governance Systems
 
-FROST will also become an essential component in the secure issuance and management of Zcash Shielded Assets (ZSA) enabling safer management of spend authority within development orgs & ZEC custodians such as exchanges by further distributing trust while providing this capability to Zcash users as well. 
+Projects that want on-chain enforcement of governance decisions — "this upgrade can only happen if 5 core developers agree" — can use FROST to make those decisions binding at the cryptographic level, not just the social level.
 
+---
 
-## FROST use in the wider ecosystem
+## Why FROST Matters for Zcash Specifically
 
-**FROST in [Coinbase](https://github.com/coinbase/kryptology/tree/master/pkg/dkg/frost)**
+Zcash is built around privacy. Shielded transactions hide sender, receiver, and amount. But traditional approaches to shared key control have always threatened to leak metadata about *how* funds are controlled.
 
-In order to improve efficiency of the Coinbase threshold-signing systems they developed a version of FROST. The Coinbase implementation makes slight changes from the original FROST draft.
+FROST closes that gap.
 
-They opted not use the signature aggregator role. Instead, each participant is a signature aggregator. This design is more secure: all the participants of the protocol verify what others have computed to achieve a higher level of security and reduce risk. The (one-time) preprocessing stage was also removed in order to speed up the implementation, having a third signing round instead.
+### Privacy-Preserving Multi-Party Control
 
-___
+With FROST, a shielded Zcash wallet can be controlled by multiple parties — a board, a DAO, a custody provider — while the transaction on the blockchain looks identical to any single-person shielded transaction. The spending policy is never revealed.
 
-**[ROAST](https://eprint.iacr.org/2022/550.pdf) by Blockstream** 
+### Stronger Security for Institutional ZEC
 
-An application specific improvement on FROST proposed for use on [Blockstream Liquid Sidechain](https://blog.blockstream.com/roast-robust-asynchronous-schnorr-threshold-signatures/) for Bitcoin.
+Exchanges, foundations, and development organizations holding large amounts of ZEC face significant key management risk. FROST allows them to distribute that risk across multiple signers and geographies without compromising the privacy that makes Zcash valuable.
 
-"ROAST is a simple wrapper around threshold signature schemes like FROST. It guarantees that a quorum of honest signers, e.g., the Liquid functionaries, can always obtain a valid signature even in the presence of disruptive signers when network connections have arbitrarily high latency." 
+### Zcash Shielded Assets (ZSA)
 
-___
+As ZSAs bring new asset types to the Zcash network, managing issuance authority securely becomes critical. FROST gives issuers a way to require multi-party approval for minting or administrative operations — with full privacy intact.
 
-**FROST in IETF**
+### The Zcash Foundation's Work
 
-The Internet Engineering Task Force, founded in 1986, is the premiere standards development organization for the Internet. The IETF makes voluntary standards that are often adopted by Internet users, network operators, and equipment vendors, and it thus helps shape the trajectory of the development of the Internet.
+The Zcash Foundation has been a leader in FROST research and implementation:
+- Chelsea Komlo co-created FROST while at the Zcash Foundation.
+- The Foundation has developed and maintained a [FROST library for Zcash](https://frost.zfnd.org/) with real test implementations.
+- [Ywallet](https://ywallet.app/) has shipped a working FROST demo for shielded multisig on mainnet — the first of its kind.
 
-FROST version 11 (two-round variant) has been [submitted to IRTF](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/11/). 
+This isn't theoretical. FROST is already running on Zcash.
 
-This is an important step for the complete evaluation & of FROST as a new threshold signature scheme standard for use across the internet, in hardware devices and for other services in the years to come. 
-___
+---
 
+## Current State and What's Coming
 
-Further Learning:
+| Milestone | Status |
+|---|---|
+| FROST paper published | ✅ 2020 |
+| FROST standardized as RFC 9591 | ✅ 2024 |
+| Zcash Foundation FROST library | ✅ Active |
+| Ywallet FROST demo (mainnet) | ✅ Live |
+| Full wallet UX integration | 🔄 In progress |
+| DAO tooling built on FROST | 🔄 Emerging |
 
-[Coinbase Article - Threshold Signatures](https://www.coinbase.com/blog/threshold-digital-signatures)
+---
 
-[Shamir Secret Sharing - Explainer & Example](https://www.geeksforgeeks.org/shamirs-secret-sharing-algorithm-cryptography/)
+## Getting Deeper
 
-[Short Video on Schnorr Digital Signatures](https://youtu.be/r9hJiDrtukI?t=19)
+- **[FROST RFC 9591](https://www.rfc-editor.org/rfc/rfc9591)** — The official IETF standard
+- **[Zcash Foundation FROST Docs](https://frost.zfnd.org/)** — Implementation guide and Zcash-specific context
+- **[Ywallet FROST Demo](https://ywallet.app/)** — Try threshold signing on Zcash mainnet
+- **[FROST Paper (original)](https://eprint.iacr.org/2020/852.pdf)** — The research behind the protocol
+- **[Chelsea Komlo at Zcon3](https://youtu.be/cAfTTfblzoU?t=110)** — Video explainer from FROST's co-creator
 
-___
-___
+---
 
-
-
-
+*FROST is one of the most significant cryptographic advances for practical privacy-preserving multi-party control. As Zcash continues to grow as a platform for private finance, FROST is the foundation that makes shared custody trustworthy without sacrificing the privacy that makes Zcash unique.*


### PR DESCRIPTION
## Summary

Adds a comprehensive wiki page for CipherScan ([cipherscan.app](https://cipherscan.app)), the privacy-first Zcash blockchain explorer. Addresses issue #1575.

### Coverage
- **What is CipherScan**: Zcash-native explorer built with Next.js 15, TypeScript, Rust/WASM
- **Core explorer**: Address search, transaction lookup, block browser, mempool viewer, live WebSocket updates
- **Privacy Tools**: Privacy Dashboard (shielded adoption metrics), client-side Orchard memo decryption (WASM — viewing keys never leave the browser), round-trip transaction linkability risk detection
- **Cross-chain ZEC flows**: Real-time ZEC movement across 15+ chains via NEAR Intents
- **Education**: Built-in Learn Zcash guide, address labels, mobile support
- **API documentation**: Free public REST API usage examples (curl, bash scripts, WebSocket)
- **WASM security model**: Detailed explanation of why memo decryption is client-side only

### Accuracy
All features verified against the CipherScan GitHub repo README ([Kenbak/cipherscan](https://github.com/Kenbak/cipherscan)) and live site. No features are invented or guessed.

Closes #1575

---
Dework task: https://app.dework.xyz/zechub-2424/main-space-20666?taskId=2c0e0045-2b51-4b1f-965b-a6a63b0cfb1c