### PR TITLE
docs(use-cases): comprehensive rewrite of all 6 real-world Zcash playbooks

### DIFF
--- a/site/Zcash_Use_Cases/About.md
+++ b/site/Zcash_Use_Cases/About.md
@@ -1,50 +1,74 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Use_Cases/About.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
 # Use Zcash in the Real World
 
-Zcash is not just about privacy in theory — it's about **practical, everyday financial freedom**.
+Zcash privacy is most valuable when it becomes practical. This section turns the concepts behind shielded ZEC into step-by-step playbooks for everyday situations — from receiving your first private donation to running an operationally secure journalist setup.
 
-This section shows you **exactly how to use Zcash in real-life scenarios**, with step-by-step guides and best practices.
+## Before You Start
 
-## What You'll Learn
+Three basics matter throughout every guide:
 
-- How to protect your financial privacy
-- How to avoid common mistakes that expose your data
-- How to apply Zcash in real-world situations
+- **Shielded addresses** (`u1...` Unified or `zs1...` Sapling) protect sender, receiver, amount, and memo from all outside observers
+- **Transparent addresses** (`t1...`) are fully public — equivalent to Bitcoin
+- **Operational privacy** also depends on behavior: where you post your address, how you manage your device, how you separate identities
 
-## How to Use These Guides
+If you are new to Zcash, read [What is Zcash](/start-here/what-is-zec-and-zcash) first. All you need to start is a wallet like [Zashi](https://electriccoin.co/zashi/) (mobile) or [Ywallet](https://ywallet.app/) (desktop/advanced).
 
-Each playbook is:
-- Short (5-7 minutes)
-- Step-by-step
-- Focused on real-world 
+## Recommended Path
 
+Follow the guides in order. Each one builds on the habits from the previous page, moving from beginner to advanced.
 
-If you're new, start here: [What is Zcash](/start-here/what-is-zec-and-zcash)
+### 1. [💸 Receive Donations Privately](Receive_Donations_Privately.md)
+**Beginner · 6 min**
 
+Publish a shielded address to accept ZEC donations. Donor identities and amounts are hidden from all outside observers. Includes viewing key setup for donation reporting.
 
-##  Recommended Path
+---
 
-Follow this step-by-step journey to master real-world Zcash usage:
+### 2. [🔐 Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
+**Intermediate · 7 min**
 
-###  [Receive Donations Privately](/zcash-use-cases/receive-donations-privately)
-Learn how to accept funds without exposing your identity or financial history.
+Shield any transparent funds, verify recipient addresses, and send privately. Covers timing patterns, address types, and how to prove payment without exposing history.
 
+---
 
-###  [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity) 
-Avoid exposing your wallet, identity, or transaction graph when sending funds.
+### 3. [🧑‍💻 Freelancer Privacy Setup](Freelance_Privacy_Setup.md)
+**Beginner–Intermediate · 8 min**
 
+Get paid by clients without publishing your income or client list. Covers per-client address separation, invoice memo standards, viewing key accounting, and fiat conversion paths.
 
-###  [Freelancer Privacy Setup](/zcash-use-cases/freelancer-privacy-setup)  
-Get paid in Zcash while keeping your clients and income private.
+---
 
+### 4. [🛒 Accept Payments as a Merchant](Accept_Payments_AS_A_Merchant.md)
+**Intermediate · 8 min**
 
-###  [Accept Payments as a Merchant](/zcash-use-cases/accept-payment-as-a-merchant)  
-Accept payments using a shielded address and avoid exposing customer transaction data
+Set up a repeatable business payment flow with ZEC. Covers payment processor integration (ZGo, Zimppy), order reconciliation via memos, refund handling, and customer privacy.
 
+---
 
-###  [Run a Private Community Treasury](/zcash-use-cases/run-a-private-community-treasury)
-Use shielded addresses to hold shared funds and limit visibility of balances and transactions
+### 5. [🏛️ Run a Private Community Treasury](Private_Community_treasury.md)
+**Intermediate · 8 min**
 
-###  [Journalist Privacy Setup](/zcash-use-cases/journalist-privacy-setup)   
-Use shielded addresses for all transactions and protect sources by avoiding traceable payments. Use memos carefully for secure communication
+Hold shared community funds with a hidden balance and private payment history. Covers custody models (single-custodian, shared-seed, FROST multi-sig), viewing key governance, and custodian rotation.
+
+---
+
+### 6. [📰 Journalist Privacy Setup](Journalist_privacy_setup.md)
+**Advanced · 10 min**
+
+The most sensitive workflow: protecting sources, payments, and operational metadata. Covers dedicated wallet discipline, shielded-only transaction enforcement, memo security, source payment flows, and legal disclosure via viewing keys.
+
+---
+
+## Completion Goal
+
+After working through all six guides you should be able to:
+
+- Choose between shielded and transparent ZEC intentionally, knowing the privacy implications of each
+- Receive, send, and track ZEC without unnecessary public exposure
+- Explain the privacy tradeoffs in each workflow — donation, freelance, merchant, treasury, high-stakes
+- Build a simple payment process for personal, professional, or source-protection use
 
 <br/>

--- a/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md
+++ b/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md
@@ -1,128 +1,184 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
 # <img src="https://raw.githubusercontent.com/amochuko/zechub/68acdb6f311bff85fe8ded7b47b2e362d7712474/assets/icons/programmer-software-engineer-coder-software-developer-svgrepo-com.svg" width="24" height="24" alt="Freelancer icon"/> Freelancer Privacy Setup with Zcash
 
 <span className="inline-flex items-center gap-[6px]">
   <span className="inline-block w-[12px] h-[12px] bg-green-500 rounded-full"></span>
-  Beginner - 6 min
+  Beginner–Intermediate · 8 min
 </span>
 
 ## TL;DR
 
-- Receive payments via shielded addresses
-- Separate identities per client (if needed)
-- Use memos for internal tracking
-- Keep your income private
+- Use a shielded z-address for client payments — keeps income and client list private
+- Add an invoice memo to every payment request so you can reconcile without a public ledger
+- Never reuse the same address across different clients — it links them together
+- Use a viewing key to prove payment receipt for tax or accounting without exposing your full wallet
 
+---
 
-<br/>
+## Who is this for?
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/user-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="user icon"/> Who is this for?
+- Freelancers and independent contractors paid in crypto
+- Remote workers across multiple clients or platforms
+- Privacy-conscious professionals who don't want income or counterparties visible on-chain
+- Anyone transitioning from transparent-chain crypto to private payments
 
-- Freelancers and contractors
-- Remote workers paid in crypto
-- Privacy-conscious professionals
+---
 
-<br/>
+## The Problem
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/warning-error-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="warning icon"/> The Problem
+When freelancers receive payment in Bitcoin, Ethereum, or other transparent cryptocurrencies, every transaction is publicly visible and permanently searchable. Anyone who learns your wallet address — from a payment link, a public invoice, or a marketplace listing — can see:
 
-Freelancers using public crypto expose:
-- Their income
-- Their clients
-- Their financial history
+- **Every payment you've ever received**: clients, amounts, timing
+- **Every payment you've sent**: vendors, platforms, subscriptions
+- **Your current balance**: whether you're in a strong or weak negotiating position
+- **Your full payment history with every client**: enabling competitors or future employers to profile your career
 
-This can lead to:
-- Loss of negotiation power
-- Privacy risks
-- Unwanted visibility
-  
+For a freelancer, this means the client you're currently negotiating with can see what every other client paid you. A prospective employer can see your total freelance income. A marketplace can see if you have competing clients.
 
-<br/>
+Zcash's shielded transactions hide sender, receiver, amount, and memo from all outside observers while still settling on a public, decentralized blockchain.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-lock.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> Why Zcash?
+---
 
-Zcash allows you to:
-- Receive payments privately
-- Hide your earnings
-- Protect client relationships
+## Why Zcash?
 
-<br/>
+Zcash's **Orchard shielded pool** (z-to-z transactions) provides:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-toolbox.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> What You Need
+- **Sender privacy**: the client's identity is not visible on-chain
+- **Receiver privacy**: your wallet address and balance are not revealed
+- **Amount privacy**: the payment size is encrypted
+- **Memo privacy**: the encrypted 512-byte memo field is visible only to you and the sender
 
-- A Zcash wallet with memo support
-- Basic understanding of shielded addresses
+This is the functional equivalent of receiving a bank wire: you see the funds arrive, the sender can confirm it left, and no third party can read the details.
 
+---
 
-<br/>
+## What You Need
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/ladder-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="step icon"/> Step-by-Step Guide
+| Item | Recommended | Purpose |
+|------|-------------|---------|
+| Zcash wallet | [Zashi](https://electriccoin.co/zashi/) (mobile) or [Ywallet](https://ywallet.app/) (advanced) | Generate shielded addresses, receive payments |
+| Unified Address | Generated by your wallet | Share with clients for payment |
+| Incoming Viewing Key (IVK) | Exported from wallet settings | Prove payment receipt to accountant |
+| Invoice memo standard | Text format you define | Reconcile payments without public ledger |
 
-### Step 1: Create a Payment Address
+---
 
-Generate a shielded (z) address.
+## Step-by-Step Guide
 
-Optionally:
-- Use different addresses for different clients
+### Step 1: Install a Wallet and Generate Your Address
 
+Download [Zashi](https://electriccoin.co/zashi/) on iOS or Android, or [Ywallet](https://ywallet.app/) on desktop.
 
-### Step 2: Share Address with Client
+After setup, your wallet will generate a **Unified Address** (starts with `u1...`). This is the address you share with clients. Unified Addresses automatically route payments to the most private pool available (Orchard shielded by default when the sender's wallet supports it).
 
-Send your z-address directly to your client.
+**Do not use** a transparent address (starts with `t1...`) for client payments — all data would be public.
 
-Avoid:
-- Posting it publicly if not necessary
+### Step 2: Define an Invoice Memo Format
 
-### Step 3: Use Memos for Tracking
+Zcash shielded transactions support a 512-byte encrypted memo. This is only visible to the sender and receiver — it is not on any public ledger.
 
-When receiving payments:
-- Ask clients to include a memo (e.g., invoice ID)
+Use the memo for invoice tracking:
 
-This helps you:
-- Track payments without exposing data publicly
+```
+INV-2026-042 | Project: API integration | Due: 2026-05-20
+```
 
+Ask clients to include this reference when they send payment. This lets you match payments to invoices without storing any financial data publicly.
 
-### Step 4: Maintain Identity Separation
+If your client doesn't know how to add a memo, provide these instructions:
+- **Zashi**: tap the memo field below the amount when sending
+- **Ywallet**: memo field is in the send screen
+- **Any Zcash wallet**: look for "Memo" or "Message" field in the send flow
 
-If needed:
-- Use separate wallets or addresses per client
-- Avoid linking identities together
+### Step 3: Use a Separate Address Per Client (Optional but Recommended)
 
-<br/>
+For maximum separation, generate a fresh z-address for each major client:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-cancel.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="cancel icon"/> Common Mistakes to Avoid
+1. In Ywallet, go to **Accounts → Add Account** — each account has its own address
+2. In Zashi, you can use account-level separation if you manage multiple clients
 
-- Using transparent addresses for payments  
-- Reusing the same address across all clients  
-- Publicly linking wallet to identity  
-- Not tracking payments (leading to confusion)
+This ensures that if one client's address ever becomes known, it cannot be linked to your other clients. Your negotiating position with each client remains independently protected.
 
+### Step 4: Share Your Address Securely
 
-<br/>
+Share your Unified Address through a private channel (email, encrypted message), not by posting it publicly on your website or LinkedIn profile.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/checked-checkbox-svgrepo-com.svg" width="28" height="28" className="inline-block align-middle mr-1 p-[2px]" alt="done icon"/> Result
+**If you need a public tip address**, use a separate dedicated address that you don't mind being linked to your public identity — and keep it separate from your client-payment addresses.
 
-You can:
-- Receive payments privately
-- Protect your income data
-- Maintain professional flexibility
+### Step 5: Request Payment and Receive
 
-<br/>
+When a client sends ZEC to your shielded address, the funds appear in your wallet once confirmed (typically 5–20 minutes, 10+ confirmations for large amounts).
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
+Your wallet will show:
+- The ZEC amount received
+- The memo (if the client included one)
+- The transaction ID (txid) for your records
 
-- [Wallets](/wallets)
+The txid is public, but with a shielded transaction, the txid reveals nothing about the sender, receiver, or amount. You can share the txid with a client as confirmation that a transaction exists on-chain.
 
-<br/>
+### Step 6: Prove Receipt for Accounting Without Exposing Your Wallet
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/progress-arrows-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="progress icon"/> Progress
+If your accountant or a client needs proof of payment receipt, export your **Incoming Viewing Key (IVK)** from wallet settings:
+
+- **Zashi**: Settings → Wallet → Export Viewing Key
+- **Ywallet**: Accounts → your account → Show Viewing Key
+
+The IVK allows the recipient (your accountant) to see all incoming transactions to your addresses — amounts, memos, timestamps — without being able to spend funds. Share it only with trusted parties.
+
+You can also use [CipherScan](https://cipherscan.app) to decrypt specific memos using your IVK for verification, without exposing your full wallet.
+
+### Step 7: Convert to Fiat (If Needed)
+
+To convert ZEC to fiat:
+1. Send ZEC to an exchange that supports shielded Zcash deposits (Gemini supports shielded withdrawals)
+2. Sell on the exchange
+3. Withdraw to your bank account
+
+Note: the exchange knows your identity (KYC), but they only see the ZEC you sent to them — not your full client list or income history.
+
+Alternatively, swap ZEC to other assets natively via [THORChain](https://app.thorswap.finance) without KYC.
+
+---
+
+## Common Mistakes to Avoid
+
+| Mistake | Why it matters | Fix |
+|---------|----------------|-----|
+| Using a t-address for client payments | All income, amounts, and timing are public | Switch to Unified Address (u1...) |
+| Reusing one address across all clients | Links all clients together in the transaction graph | One address or account per client |
+| Posting your z-address publicly | Links your on-chain identity to your public identity | Use a separate throwaway address for public tips |
+| Not including a memo reference | Hard to reconcile payments without accounting trail | Set a memo standard before first invoice |
+| Sending ZEC to an exchange from a transparent address | Exposes your income to anyone who traces the exchange's deposit address | Shield funds first, then send to exchange |
+
+---
+
+## Result
+
+After this setup you can:
+
+- Receive client payments with income and counterparties hidden from the public ledger
+- Track payment reconciliation via encrypted memos without any public exposure
+- Prove payment receipt to an accountant using a viewing key — without revealing your full financial history
+- Negotiate with multiple clients without any one client knowing what others paid you
+
+---
+
+## Related Pages
+
+- [Wallets](/Using_Zcash/Wallets)
+- [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
+- [Accept Payments as a Merchant](Accept_Payments_AS_A_Merchant.md)
+- [CipherScan Explorer](/Using_Zcash/CipherScan)
+
+---
+
+## Progress
 
 **Step 3 of 6**
 
-You now understand how to receive income privately.
+← Previous: [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
 
-<br/>
-
-## Next Step
-
-- [Accept Payments as a Merchant](/use-cases/accept-payments-as-a-merchant)
-<br/>
+→ Next: [Accept Payments as a Merchant](Accept_Payments_AS_A_Merchant.md)

--- a/site/Zcash_Use_Cases/Journalist_privacy_setup.md
+++ b/site/Zcash_Use_Cases/Journalist_privacy_setup.md
@@ -1,140 +1,196 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Use_Cases/Journalist_privacy_setup.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
 # <img src="https://raw.githubusercontent.com/amochuko/zechub/68acdb6f311bff85fe8ded7b47b2e362d7712474/assets/icons/journalist-host-profession-interview-svgrepo-com.svg" width="24" height="24" alt="Journalist icon"/> Journalist Privacy Setup with Zcash
 
 <span className="inline-flex items-center gap-[6px]">
-  <span className="inline-block w-[12px] h-[12px] bg-green-500 rounded-full"></span>
-  Beginner - 7 min
+  <span className="inline-block w-[12px] h-[12px] bg-red-500 rounded-full"></span>
+  Advanced · 10 min
 </span>
 
 ## TL;DR
 
-- Use shielded addresses for all transactions
-- Never expose wallet identity publicly
-- Protect sources by avoiding traceable payments
-- Use memos carefully for secure communication
+- Use exclusively shielded (z-to-z) transactions — transparent transactions expose you and your sources
+- Create a dedicated wallet for sensitive work, entirely separate from personal finances
+- Never link a public identity to a wallet used for source protection
+- Use Zcash memos cautiously — they are encrypted but should never contain names, identifying details, or sensitive content
+- Use a viewing key only when legally required and only with counsel
 
-<br/>
+---
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/user-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="user icon"/> Who is this for?
+## Who is this for?
 
-- Journalists
-- Investigators
-- Activists
-- High-risk individuals handling sensitive payments
+- Journalists receiving tips or payments related to sensitive reporting
+- Investigators, whistleblower support organizations, and advocacy groups
+- Activists in regions where financial surveillance is a safety threat
+- High-risk individuals paying or receiving payment for sensitive work
 
+---
 
-<br/>
+## The Problem
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/warning-error-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="warning icon"/> The Problem
+A journalist's financial trail is an intelligence trail. Adversaries — governments, corporations, or bad actors — have historically used financial records to identify and prosecute journalists and their sources. On transparent blockchains (Bitcoin, Ethereum, most others):
 
-Journalists face:
-- Surveillance
-- Source exposure risks
-- Financial tracking by adversaries
+- **Every payment you send is permanently recorded**: who you paid, when, and how much
+- **Every payment you receive is visible**: editorial payments, fundraising, source-related transactions
+- **Address clustering** links all payments through a single wallet into a profile
+- **Exchange KYC** connects your on-chain identity to your legal identity if you ever convert to fiat
 
-Using transparent crypto can reveal:
-- Who paid you
-- Who you paid
-- When and how much
+Even one transparent transaction can unravel a private setup — a partial payment from a transparent address, a change output sent to a t-address, or a memo field containing identifiable information can permanently link identities.
 
-<br/>
+---
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-lock.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> Why Zcash?
+## Why Zcash?
 
+Zcash's **Orchard shielded pool** is the only production privacy system that:
 
-Zcash provides:
-- Strong financial privacy
-- Protection for sensitive transactions
-- Reduced risk of linking journalists to sources
+- Hides sender, receiver, and amount simultaneously in a single transaction
+- Uses **zero-knowledge proofs** — the blockchain verifies the transaction is valid without learning who transacted or how much
+- Is open source and independently audited
+- Provides **selective disclosure** via viewing keys — you can prove a transaction occurred to a regulator or lawyer without exposing your full wallet history
 
-<br/>
+For journalists, Zcash provides the same financial privacy that cash provides in person — without requiring physical proximity.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-toolbox.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> What You Need
+---
 
-- A Zcash wallet with shielded support
-- Secure communication channel (outside blockchain)
-- Operational discipline
+## What You Need
 
-<br/>
+| Item | Recommended | Notes |
+|------|-------------|-------|
+| Dedicated wallet | [Ywallet](https://ywallet.app/) or [Zashi](https://electriccoin.co/zashi/) | Use a device not linked to your identity |
+| Dedicated device | Separate phone or computer | Never mix with personal accounts |
+| Shielded-only discipline | Use only z-to-z transactions | One transparent transaction can undo the setup |
+| Secure communication | Signal, SecureDrop, or encrypted email | Zcash memos are not a substitute for secure messaging |
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/ladder-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="step icon"/> Step-by-Step Guide
+---
 
+## Step-by-Step Guide
 
-### Step 1: Create a Dedicated Wallet
+### Step 1: Create a Dedicated Wallet on a Dedicated Device
 
-- Use a wallet only for sensitive work
-- Do not mix with personal transactions
+Use a separate phone or computer not linked to your identity or personal accounts. Do not install the wallet on a device that has your email, social media, or employer accounts.
 
-### Step 2: Use Shielded Addresses Only
+Download [Zashi](https://electriccoin.co/zashi/) or [Ywallet](https://ywallet.app/). Both support Orchard shielded transactions.
 
-- Always transact using z-addresses
-- Avoid transparent transactions entirely
+**Write down your seed phrase** and store it physically in a secure location. Do not store it in the cloud, in a screenshot, or in any app that syncs online.
 
+### Step 2: Generate a Shielded Address and Never Post It Publicly
 
-### Step 3: Protect Source Payments
+Your wallet will generate a **Unified Address** (starts with `u1...`). This address routes incoming payments to the Orchard shielded pool by default.
 
-If paying sources:
-- Use shielded transactions (z → z)
-- Avoid predictable timing patterns
-- Do not reuse addresses
+**Critical:** Do not associate this address with your name, employer, or any public profile. If a source sends payment to an address linked to your identity, the privacy benefit is lost.
 
+Share the address only through secure channels: end-to-end encrypted messaging (Signal), SecureDrop, or in-person exchange.
 
-### Step 4: Be Careful with Memos
+### Step 3: Use Only Shielded (z-to-z) Transactions
 
-- Do NOT include sensitive information in memos
-- Use neutral or coded references if needed
+When receiving payments:
+- Ensure senders are using a wallet that supports Orchard or Sapling shielded transactions (Zashi, Ywallet, Nighthawk)
+- Confirm that transactions show "Shielded" in your wallet's transaction list — not "Transparent"
 
+When sending payments:
+- Always send from your shielded balance to a shielded address
+- Before sending, verify the recipient's address is a Unified Address (`u1...`) or Sapling address (`zs1...`), not a transparent address (`t1...`)
 
-### Step 5: Maintain Operational Security
+Never send from your wallet to a transparent address if source protection matters. A transparent transaction links your wallet to a public identity.
 
-- Avoid linking wallet to your identity
-- Do not publicly confirm transactions
-- Use separate channels for communication
+### Step 4: Use Memos With Extreme Caution
 
+Zcash's shielded memo field (512 bytes, encrypted) is visible only to the sender and receiver. It is NOT readable by outside observers.
 
-<br/>
+However:
+- **Do not include names** of sources, locations, or story subjects
+- **Do not include anything** you would not want visible if your device were seized and your viewing key obtained via legal process
+- Use only neutral references: `ACCT-042`, `Research-May`, or leave the memo blank
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-cancel.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="cancel icon"/> Common Mistakes to Avoid
+The memo can be used for basic reconciliation (invoice numbers, project codes) but is not a substitute for secure messaging.
 
-- Using transparent addresses  
-- Reusing addresses across sources  
-- Including sensitive data in memos  
-- Linking wallet to public identity  
+### Step 5: Receive Source Tips Without Linking Identity
 
-<br/>
+If you want to receive tips related to sensitive reporting:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/checked-checkbox-svgrepo-com.svg" width="28" height="28" className="inline-block align-middle mr-1 p-[2px]" alt="done icon"/> Result
+1. Create a **dedicated account** in Ywallet (separate from any accounts linked to your identity)
+2. Generate a fresh Unified Address for each story or source
+3. Publish that address only through secure channels or in-person
+4. Use a separate account for each story or source — never reuse addresses across sources
 
-You can:
-- Protect your sources
-- Reduce surveillance risks
-- Maintain financial privacy in sensitive work
+This means that if one address is ever linked to a specific story, it cannot be connected to your other sources or reporting.
 
-<br/>
+### Step 6: Pay Sources Without a Traceable Financial Link
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
+If you need to pay a source for travel costs, security equipment, or other legitimate support:
 
-- [Privacy - Best practices](/privacy/best-practices)
-- [Send money without linking identity](/use-cases/send-money-without-linking-identity)
+1. Send ZEC from your shielded balance to the source's Unified Address
+2. Confirm the source is using a shielded wallet (Zashi or Ywallet)
+3. Use a memo only if strictly necessary and only with coded references
+4. Avoid patterns: vary timing, amounts slightly, and don't create a regular cadence
 
- <br/>
+Z-to-z transactions on Zcash reveal nothing on-chain about who sent what to whom. The blockchain record is cryptographically verified but private.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/68acdb6f311bff85fe8ded7b47b2e362d7712474/assets/icons/celebration-spark-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="celebration icon"/> Completion
+### Step 7: Handling Viewing Keys If Required by Law
 
-**Step 6 of 6 — Completed**
+If you are served with a legal demand for financial records:
 
-You’ve reached the most advanced level of Zcash usage.
+- A viewing key for a specific account can be disclosed while protecting other accounts
+- Your lawyer can use the viewing key with [CipherScan](https://cipherscan.app) to decrypt specific transactions for review
+- You do not need to disclose your seed phrase or full wallet — only the viewing key for the account at issue
 
-You now understand:
-- Private transactions
-- Identity protection
-- Operational security
+Export a viewing key (Ywallet: Accounts → Show Viewing Key; Zashi: Settings → Export Viewing Key) only when specifically required and with legal guidance.
 
-<br/> 
+### Step 8: Converting ZEC to Fiat Without Breaking Privacy
 
-## What Next?
+If you receive ZEC and need to convert to fiat:
 
-- [Go to home page](/)
-- [Explore developer paths](/developers)
+1. **Option A (Maximum privacy):** Swap ZEC to Monero via a non-custodial DEX, then use Monero for cash-equivalent purchases or convert via a Monero peer-to-peer marketplace
+2. **Option B (Practical):** Send to Gemini (supports shielded deposits); Gemini will associate your fiat identity with the ZEC you send them, but cannot see your prior transaction history
+3. **Avoid:** sending ZEC from a transparent address to an exchange — this creates a direct on-chain link between your exchange account and your transparent address
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| Using one wallet for personal and work finances | One subpoena exposes both | Separate wallets, separate devices |
+| Sending even one transparent transaction | Links wallet to an on-chain identity | Delete the wallet and start fresh |
+| Reusing an address across multiple sources | Links all those sources to one address | Fresh address per source or story |
+| Publishing your z-address publicly | Ties on-chain identity to your public persona | Never post the address publicly |
+| Including source names in memos | Memos survive device seizure with viewing key | Only use coded references or leave memo blank |
+| Using Zcash as a messaging tool | Memos are not encrypted messaging | Use Signal or SecureDrop for sensitive comms |
+
+---
+
+## Result
+
+After this setup you can:
+
+- Receive source tips with no on-chain record of who sent what
+- Pay sources with no traceable financial link visible on the public blockchain
+- Prove specific financial records to a lawyer via viewing key without exposing your full financial history
+- Maintain operational separation across different stories and sources
+
+---
+
+## Related Pages
+
+- [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
+- [Privacy — Best Practices](/privacy/best-practices)
+- [Wallets](/Using_Zcash/Wallets)
+- [CipherScan Explorer](/Using_Zcash/CipherScan)
+
+---
+
+## Progress
+
+**Step 6 of 6 — Complete**
+
+← Previous: [Run a Private Community Treasury](Private_Community_treasury.md)
+
+You've reached the most advanced level of Zcash operational privacy. The same principles used here — shielded-only transactions, identity separation, viewing key discipline — apply to any high-stakes financial privacy scenario.
+
+## What's Next
+
+- [Explore the Zcash developer ecosystem](/developers)
 - [Contribute to ZecHub](/contribute/help-build-zechub)
-
-<br/> 
+- [Return to the Use Cases overview](About.md)

--- a/site/Zcash_Use_Cases/Private_Community_treasury.md
+++ b/site/Zcash_Use_Cases/Private_Community_treasury.md
@@ -1,129 +1,179 @@
-# <img src="https://raw.githubusercontent.com/amochuko/zechub/68acdb6f311bff85fe8ded7b47b2e362d7712474/assets/icons/people-community-add-svgrepo-com.svg" width="24" height="24" alt="Journalist icon"/>  Run a Private Community Treasury with Zcash
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Use_Cases/Private_Community_treasury.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# <img src="https://raw.githubusercontent.com/amochuko/zechub/68acdb6f311bff85fe8ded7b47b2e362d7712474/assets/icons/people-community-add-svgrepo-com.svg" width="24" height="24" alt="community icon"/> Run a Private Community Treasury with Zcash
 
 <span className="inline-flex items-center gap-[6px]">
-  <span className="inline-block w-[12px] h-[12px] bg-green-500 rounded-full"></span>
-  Intermediate - 7 min
+  <span className="inline-block w-[12px] h-[12px] bg-yellow-500 rounded-full"></span>
+  Intermediate · 8 min
 </span>
 
 ## TL;DR
 
-- Use shielded addresses to hold shared funds
-- Limit visibility of balances and transactions
-- Separate operational roles from public identity
-- Use memos for internal accountability
+- Use a shared shielded wallet — not a multisig on a transparent chain — to hold community funds privately
+- Assign treasurer role(s) with wallet access, and share viewing keys with auditors
+- Use encrypted memos to record the purpose of each payment
+- Rotate custodians by transferring seed phrase responsibility — not by moving funds publicly
 
-<br/>
+---
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/user-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="user icon"/> Who is this for?
+## Who is this for?
 
-- DAOs and communities
-- Grant programs
-- Open-source teams
-- Crypto collectives
-  
+- DAO treasuries that want private financial operations
+- Community groups, local chapters, or grassroots organizations managing shared funds
+- Open-source project treasuries that don't want to publish every vendor payment
+- Activist groups or advocacy organizations that want spending decisions to remain internal
 
-<br/>
+---
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/warning-error-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="warning icon"/> The Problem
+## The Problem
 
-Community funds in public blockchains expose:
-- Total treasury balance
-- Spending history
-- Contributor identities
+Most on-chain community treasuries operate transparently. When a DAO or community group holds funds in a public Ethereum or Bitcoin multisig:
 
-This creates risks:
-- Targeting of funds
-- Internal conflicts due to transparency pressure
-- Loss of strategic privacy
+- Every incoming donation is visible to the public and to competitors
+- Every outgoing payment reveals who you paid and how much
+- Members' individual contributions and claims are permanently linked to their public addresses
+- Adversaries can track treasury health and target the community during low-balance periods
 
-<br/>
+For many communities — particularly activist organizations, independent media groups, or communities in regions with government surveillance — public treasury management is a significant security risk.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-lock.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> Why Zcash?
+---
 
-Zcash allows communities to:
-- Hold funds privately
-- Execute transactions without exposing details
-- Maintain internal accountability without public exposure
+## Why Zcash?
 
-<br/>
+A Zcash shielded address can hold community funds privately. Incoming deposits are hidden. Outgoing payments are hidden. The current balance is hidden from all outside observers.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-toolbox.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> What You Need
+Members authorized to view the treasury (auditors, governance participants) can be granted **viewing keys** — read-only access that shows all transactions without enabling spending. This supports internal accountability without external visibility.
 
-- A Zcash wallet (or multiple wallets for role separation)
-- Clear internal processes for managing funds
-- Optional: shared documentation for tracking
+---
 
-<br/>
+## Treasury Models
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/ladder-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="step icon"/> Step-by-Step Guide
+Choose the model that fits your community size and governance needs:
 
-### Step 1: Create a Shielded Treasury Address
+| Model | Description | Best for |
+|-------|-------------|----------|
+| **Single-custodian** | One trusted person holds the seed phrase | Small groups, informal communities |
+| **Shared-seed** | Seed phrase split via Shamir's Secret Sharing (SLIP-39) | Medium groups needing distributed custody |
+| **Multi-approver** | Use FROST threshold signatures (2-of-3 or 3-of-5) | High-value treasuries needing cryptographic multi-party approval |
 
-- Generate a **z-address** for the treasury
-- This becomes the main holding account
+For most community groups starting out, the single-custodian or shared-seed model is practical. FROST multi-sig is covered in the [FROST wiki](/Zcash_Tech/FROST).
 
+---
 
-### Step 2: Define Roles
+## Step-by-Step Guide
 
-Separate responsibilities:
-- Treasurer (controls funds)
-- Contributors (request spending)
-- Reviewers (approve internally)
+### Step 1: Create the Treasury Wallet
 
-Avoid linking these roles to public identities.
+Download [Ywallet](https://ywallet.app/) (recommended for advanced treasury management) or [Zashi](https://electriccoin.co/zashi/) on a device dedicated to treasury operations.
 
+Generate a new wallet. **Write down the 24-word seed phrase** — this is the root of custody. Do not store it digitally. For communities larger than 3 people, split the seed phrase using [SLIP-39](https://github.com/trezor/python-shamir-mnemonic): split into N shares where M are required to reconstruct (e.g., 3-of-5 shares among founding members).
 
+### Step 2: Establish the Treasury Address
 
-### Step 3: Receive Funds Privately
+The wallet will generate a Unified Address. This is the public-facing address where:
+- Members contribute funds
+- Donors or grantors send contributions
 
-- Accept contributions via the shielded address
-- Encourage contributors to send from shielded wallets
+This address can be shared publicly with contributors — all incoming transactions will be shielded.
 
+### Step 3: Distribute Viewing Keys for Internal Accountability
 
+Export the **Incoming Viewing Key (IVK)** from wallet settings:
+- Ywallet: Accounts → your account → Show Viewing Key
+- Zashi: Settings → Export Viewing Key
 
-### Step 4: Track Transactions Internally
+Share the IVK with:
+- Community auditors
+- Governance committee members
+- Any member responsible for financial oversight
 
-Use:
-- Wallet memos
-- Off-chain logs (e.g., shared docs)
+The IVK allows read-only visibility into all incoming transactions — amounts, timestamps, memos — without the ability to spend funds. This creates internal transparency without external exposure.
 
-Example memo: 
- - Grant #12 - Developer Payment
+### Step 4: Define a Payment Memo Standard
 
+Before making any payments, establish a memo standard for all outgoing transactions. The memo is encrypted and visible only to sender and receiver, but it serves as your internal accounting ledger:
 
+```
+PAYMENT | Category: Operations | Purpose: Server hosting Q2 | Approved-by: Governance-vote-042
+```
 
-### Step 5: Execute Payments Privately
+This is your internal record. No outside observer can read it. But if a member later questions a payment, the memo proves the purpose and authorization.
 
-- Send funds via shielded transactions (z → z)
-- Avoid exposing recipient identities publicly
+### Step 5: Accept Contributions
 
-<br/>
+Share the treasury Unified Address with members and supporters. To receive contributions:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-cancel.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="cancel icon"/> Common Mistakes to Avoid
+- Members with shielded wallets can send directly (z-to-z, fully private)
+- Members using exchanges can withdraw ZEC to the treasury address
+- Grant makers and donors send to the treasury address
 
-- Using transparent addresses for treasury  
-- Publishing wallet balances publicly  
-- Not tracking transactions internally  
-- Linking treasury address to identifiable individuals  
+All contributions are privately received. Auditors with the IVK can verify total contributions.
 
+### Step 6: Make Payments
 
-<br/>
+When making a payment from the treasury:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/checked-checkbox-svgrepo-com.svg" width="28" height="28" className="inline-block align-middle mr-1 p-[2px]" alt="done icon"/> Result
+1. Open the wallet with the seed phrase or on the treasury device
+2. Enter the recipient's Unified Address (z-address preferred)
+3. Enter the amount
+4. Add a memo using your community's memo standard
+5. Confirm and send
 
-Your community can:
-- Manage funds securely
-- Protect contributors and recipients
-- Operate without exposing financial strategy
+For large payments, consider requiring approval through an off-chain governance vote first, and include the vote reference in the memo (e.g., `Vote-042-approved`).
 
+### Step 7: Produce Spending Reports
 
-<br/>
+To produce a spending report for community members:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
+1. Use the IVK with [CipherScan](https://cipherscan.app) to decrypt all transactions for a period
+2. Export the data to a spreadsheet
+3. Match memos to approved expenditures
+4. Share the report with members — the IVK shows transaction data without exposing community member identities
 
-- [Privacy - Best practices](/privacy/best-practices)
-- [Send money without linking identity](/use-cases/send-money-without-linking-identity)
- 
+The report proves how funds were spent without revealing which community members contributed what amounts.
+
+### Step 8: Rotate Custodians
+
+When treasury custodianship needs to change (e.g., new treasurer elected):
+
+**Option A (clean rotation):** Transfer the seed phrase responsibility from the outgoing treasurer to the incoming treasurer. No funds need to move.
+
+**Option B (new wallet):** Create a new treasury wallet, transfer all funds from old to new wallet via a shielded transaction, and share the new wallet's viewing key with auditors. The transfer is private — no outside observer can correlate old and new treasury.
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| Storing seed phrase digitally | Single point of compromise | Write physically, store in multiple secure locations |
+| Not establishing a memo standard before first payment | No internal accounting record | Define memo format before any spending |
+| Using a transparent address | All treasury activity is public | Use Unified Address for all community treasury activity |
+| Not distributing viewing keys to auditors | Zero internal accountability | Share IVK with 2–3 trusted governance members |
+| Mixing personal funds with treasury | Complicates accounting; exposes personal privacy | Separate wallets for personal and treasury |
+
+---
+
+## Result
+
+After this setup your community can:
+
+- Hold shared funds with a balance and activity invisible to outsiders
+- Receive contributions from members and donors privately
+- Make payments to vendors and contributors with amounts hidden from competitors
+- Maintain internal accountability via viewing keys distributed to auditors
+- Produce spending reports without exposing individual contributor or recipient identities
+
+---
+
+## Related Pages
+
+- [FROST Multi-Signature Privacy](/Zcash_Tech/FROST)
+- [Receive Donations Privately](Receive_Donations_Privately.md)
+- [Wallets](/Using_Zcash/Wallets)
+- [CipherScan Explorer](/Using_Zcash/CipherScan)
 
 <br/>
 
@@ -131,10 +181,6 @@ Your community can:
 
 **Step 5 of 6**
 
-You understand how to manage shared funds privately.
+← Previous: [Accept Payments as a Merchant](Accept_Payments_AS_A_Merchant.md)
 
- <br/>
-
-## Next Step
-
-- [Journalist Privacy Setup](/use-cases/journalist-privacy-setup)
+→ Next: [Journalist Privacy Setup](Journalist_privacy_setup.md)

--- a/site/Zcash_Use_Cases/Receive_Donations_Privately.md
+++ b/site/Zcash_Use_Cases/Receive_Donations_Privately.md
@@ -1,128 +1,162 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Use_Cases/Receive_Donations_Privately.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
 # <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/money-business-and-finance-svgrepo-com.svg" width="24" height="24" alt="finance icon"/> Receive Donations Privately with Zcash
 
 <span className="inline-flex items-center gap-[6px]">
   <span className="inline-block w-[12px] h-[12px] bg-green-500 rounded-full"></span>
-  Beginner - 5 min
+  Beginner · 6 min
 </span>
-
 
 ## TL;DR
 
-- Use a **shielded (z) address**
-- Never share a transparent (t) address publicly
-- Encourage donors to send from shielded wallets
-- Avoid linking your identity to transactions
+- Publish a Unified Address (`u1...`) to receive donations — not a transparent address
+- Donors' identities and amounts are hidden from all outside observers in shielded transactions
+- Use a dedicated donation wallet, separate from personal funds
+- Export a viewing key to verify donation totals for reporting without exposing donors
 
-<br/>
+---
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/user-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="user icon"/> Who is this for?
-- Creators accepting donations
-- Open-source contributors
-- Communities raising funds
-- Anyone who wants private financial support
+## Who is this for?
 
-<br/>
+- Independent journalists, writers, and researchers accepting reader support
+- Open-source developers accepting ZEC tips for their projects
+- Nonprofits and advocacy organizations accepting private contributions
+- Content creators who want to receive support without publishing their income
+- Anyone who currently has a Bitcoin tip address and wants to protect donors
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/warning-error-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="warning icon"/> The Problem
+---
 
-Most cryptocurrencies expose everything:
-- Your wallet balance
-- Who sent you money
-- Your entire transaction history
+## The Problem
 
-This creates serious risks:
-- Loss of financial privacy
-- Targeting or surveillance
-- Public exposure of donors
+Accepting donations via a Bitcoin or Ethereum address means every donation is permanently public. Anyone can:
 
-<br/>
+- See how many people donated and the exact amounts
+- Identify repeat donors if they use the same wallet across donations
+- Correlate donation timing with your publishing activity
+- Calculate your total income from donations
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-lock.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> Why Zcash?
+For donors, this creates risk: their charitable or political giving is permanently on-chain and can be used against them in regimes where certain views are criminalized. For recipients, it means your total income from donations is public information.
 
-Zcash shielded transactions hide:
-- Sender address
-- Receiver address
-- Transaction amount
+---
 
-This allows you to receive funds **without exposing your financial graph**.
+## Why Zcash?
 
-<br/>
+Zcash shielded (z-to-z) donations are functionally private cash gifts. When a donor sends ZEC from a shielded address to your shielded donation address:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-toolbox.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> What You Need
+- The donor's wallet address is not visible on-chain
+- The donation amount is encrypted
+- No outside observer can see who donated, how much, or when
+- The recipient (you) sees the funds arrive, the amount, and any encrypted memo
 
-- A Zcash wallet that supports shielded addresses:
-  - Zashi
-  - YWallet
-  - Other supported wallets
+Both parties have what they need — you know you received a donation, the donor knows it was sent — and no third party learns anything.
 
-<br/>
+---
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/ladder-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="step icon"/> Step-by-Step Guide
+## What You Need
 
-### Step 1: Create a Shielded Address
-Open your wallet and generate a **z-address**.
-This usually starts with: `zs...`
+| Item | Recommended | Notes |
+|------|-------------|-------|
+| Zcash wallet | [Zashi](https://electriccoin.co/zashi/) (mobile) or [Ywallet](https://ywallet.app/) | Both support Orchard shielded |
+| Unified Address | Generated by wallet | Share this with donors |
+| Optional: donation page | Website, Free2Z, or direct share | Where you publish the address |
+| Optional: viewing key | Export from wallet settings | For donation reporting |
 
+---
 
-### Step 2: Share Only Your Shielded Address
+## Step-by-Step Guide
 
-- Publish your z-address on:
-  - Website
-  - Social media
-  - Donation pages
+### Step 1: Create a Dedicated Donation Wallet
 
-**Do NOT share a transparent (t) address.**
+Create a separate wallet or account specifically for donations. This keeps donations separate from personal spending and makes reporting cleaner.
 
-### Step 3: Guide Donors (Optional but Recommended)
+- **Zashi**: install the app, complete setup, and use the generated address
+- **Ywallet**: install, go to Accounts → Add Account for a dedicated donation account
 
-Encourage donors to:
-- Use wallets that support shielded transactions
-- Send from shielded pools (not transparent)
+Write down the seed phrase and store it securely offline.
 
-### Step 4: Maintain Basic Privacy Hygiene
+### Step 2: Copy Your Unified Address
 
-- Avoid reusing the same address across unrelated identities
-- Do not publicly associate your address with personal identity unless necessary
+Open your wallet and find your **Unified Address** — it starts with `u1` and is a long alphanumeric string. This is the address you will share with donors.
 
-<br/>
+You can also display a **QR code** from your wallet for in-person or visual donation prompts.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-cancel.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="cancel icon"/> Common Mistakes to Avoid
+### Step 3: Publish Your Donation Address
 
-- Sharing a transparent (t) address  
-- Posting your wallet alongside personal identity  
-- Accepting funds from transparent sources without shielding  
-- Reusing the same address across multiple contexts  
+You can publish your Unified Address anywhere:
 
-<br/>
+- On your website or blog as a ZEC donation button
+- On your [Free2Z](https://free2z.cash) creator page — Free2Z is built for Zcash-native creator support with shielded address integration
+- In a newsletter or article
+- On social media profiles (X, Mastodon, GitHub)
+- In your project's README file
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/checked-checkbox-svgrepo-com.svg" width="28" height="28" className="inline-block align-middle mr-1 p-[2px]" alt="done icon"/> Result
+**Note:** Publishing a Unified Address links your identity to that address. All amounts and senders remain private, but the address itself is associated with you. If you want to accept anonymous donations from donors who don't want even you to know their identity, this is still the right setup — you see the funds but not who sent them.
 
-You can:
-- Receive donations privately
-- Protect your supporters
-- Avoid exposing your financial activity
+### Step 4: Tell Donors How to Send
 
-<br/>
+Many potential donors may not yet have Zcash. Include a brief note with your donation link:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
+> "To donate in ZEC: download [Zashi](https://electriccoin.co/zashi/) (iOS/Android), acquire ZEC through an exchange, and send to the address above. Your donation is fully private — your identity and amount are not visible to anyone."
 
-- [Privacy - Shielded vs Transparent](/privacy/shielded-vs-transparent)
-- [Wallets](/wallets)
+Donors who already hold Bitcoin or Ethereum can swap to ZEC without KYC via [THORChain](https://app.thorswap.finance).
+
+### Step 5: Receive and Verify Donations
+
+When a donor sends ZEC to your Unified Address:
+
+1. The transaction confirms on-chain (typically 1–2 minutes for initial detection, 10+ confirmations for high confidence)
+2. Your wallet displays the ZEC amount received and any memo the donor included
+3. The transaction ID (txid) appears in your wallet — this is a public record that a transaction occurred, but reveals no details about sender, receiver, or amount for shielded transactions
+
+If a donor wants to prove they donated (e.g., for a matching campaign), they can share their **outgoing viewing key** which lets you verify the specific transaction came from their wallet.
+
+### Step 6: Report Donations Without Exposing Donors
+
+If you need to report donation totals (for legal, tax, or transparency purposes):
+
+1. Export your **Incoming Viewing Key (IVK)** from wallet settings
+2. Share the IVK with your accountant or auditor
+3. They can use [CipherScan](https://cipherscan.app) to calculate total inflows without exposing donor identities
+
+The IVK lets a trusted party see all incoming amounts and memos — but not who sent them (shielded sender addresses are not exposed even with the IVK, by design).
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| Using a transparent t-address for donations | All donors, amounts, and timing are public | Switch to Unified Address (u1...) |
+| Reusing one address forever | Builds a permanent public profile linked to your identity | Rotate donation addresses annually or per campaign |
+| Mixing donation funds with personal spending | Makes reporting harder | Dedicated donation wallet |
+| Not sharing instructions for new ZEC users | Donors don't know how to send | Include wallet setup link with your donation address |
+
+---
+
+## Result
+
+After this setup you can:
+
+- Receive donations with amounts and donor identities invisible to the public
+- Acknowledge donations privately via encrypted memo replies
+- Report total donation amounts to an accountant using a viewing key
+- Accept donations from donors in sensitive contexts without creating a public record of their giving
+
+---
+
+## Related Pages
+
+- [Wallets](/Using_Zcash/Wallets)
+- [Free2Z Creator Platform](https://free2z.cash)
+- [THORChain Cross-Chain Swaps](/Using_Zcash/THORChain)
+- [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)
 
 <br/>
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/progress-arrows-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="progress icon"/> Progress
 
-**Step 1 of 6**
+**Step 1 of 6 — Start here**
 
-You have learned how to receive funds privately.
-
-<br/>
-
-## Next Step
-
-Continue your journey:
-
-- [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity)
-  
-<br/>
+→ Next: [Send Money Without Linking Identity](Send_Money_Without_Linking_Identity.md)

--- a/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md
+++ b/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md
@@ -1,102 +1,171 @@
-# <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/send-svgrepo-com.svg" width="24" height="24" alt="Journalist icon"/> Send Money Without Linking Your Identity
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
 
-<span className="inline-flex items-center gap-[6px]"><span className="inline-block w-[12px] h-[12px] bg-green-500 rounded-full"></span>Intermediate - 7 min</span>
+# <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/send-svgrepo-com.svg" width="24" height="24" alt="send icon"/> Send Money Without Linking Your Identity
+
+<span className="inline-flex items-center gap-[6px]">
+  <span className="inline-block w-[12px] h-[12px] bg-yellow-500 rounded-full"></span>
+  Intermediate · 7 min
+</span>
 
 ## TL;DR
 
-- Always send from a **shielded address**
-- Avoid direct t to t transactions
-- Break linkability between identities
-- Be mindful of timing and patterns
+- Shield any transparent ZEC before sending — never send t-to-t if privacy matters
+- Send from shielded (z) addresses only to shielded (z) addresses for full privacy
+- Avoid patterns: vary timing and don't send immediately after receiving
+- Use a memo to communicate context privately without revealing it on-chain
 
-<br/>
+---
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/user-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="user icon"/> Who is this for?
+## Who is this for?
 
-- Anyone sending sensitive payments
-- Privacy-conscious users
-- People operating under surveillance risk
+- Anyone sending sensitive payments — support to family in high-surveillance regions, contributions to advocacy groups, payments for sensitive services
+- Privacy-conscious users who don't want counterparties or amounts public
+- People operating under financial surveillance risk
+- Users who want to understand how blockchain privacy actually works in practice
 
-<br/>
+---
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/warning-error-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="warning icon"/> The Problem
+## The Problem
 
-Sending crypto often reveals:
-- Your wallet identity
-- Your transaction history
-- Who you interact with
+On most blockchains, every transaction is public and permanently recorded. Sending funds creates a traceable connection between two addresses. Anyone monitoring the chain can:
 
-This creates a **traceable financial graph**.
+- See exactly what you sent and when
+- Build a graph of all your counterparties
+- Correlate addresses if you interact with the same people repeatedly
+- Link your on-chain identity to your real identity if any address is ever associated with a KYC account
 
-<br/>
+Even "privacy-conscious" users who avoid transparent addresses can inadvertently break privacy through **change outputs** (Bitcoin returns change to an address linked to the sender), **timing correlation** (sending immediately after receiving), or **address reuse** (one address linked to multiple identities).
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-lock.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> Why Zcash?
+---
 
+## Why Zcash?
 
-Zcash enables **fully private transfers** using shielded transactions.
+Zcash's Orchard shielded pool solves the transaction graph problem at the protocol level:
 
-This breaks:
-- Address linkability
-- Public transaction tracing
+- Sender address: hidden
+- Receiver address: hidden
+- Amount: hidden
+- Memo: encrypted (512 bytes, visible only to sender and receiver)
+- All of the above are verified by zero-knowledge proofs without revealing the data
 
-<br/>
+A z-to-z transaction on Zcash produces a public blockchain record that a transaction occurred, but reveals nothing about the participants.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-toolbox.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> What You Need
+---
 
-- A wallet that supports shielded transactions
-- Basic understanding of z-addresses
+## Address Types in Zcash
 
-<br/>
+Understanding the address types matters for privacy:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/ladder-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="step icon"/> Step-by-Step Guide
+| Address type | Prefix | Privacy level | Notes |
+|-------------|--------|---------------|-------|
+| Transparent | `t1...` | None | Fully public — like Bitcoin |
+| Sapling shielded | `zs1...` | High | Legacy shielded, still private |
+| Unified Address | `u1...` | Highest (Orchard) | Default for current wallets |
 
-### Step 1: Ensure Funds Are Shielded
+When you send to a Unified Address, the transaction uses the most private pool available. Always prefer Unified Addresses over transparent addresses.
 
-If your funds are in a transparent address:
-- Move them into a shielded address first
+---
 
+## Step-by-Step Guide
 
-### Step 2: Send from Shielded to Shielded
-Always prefer `z to z` transaction
+### Step 1: Check Where Your Funds Are
 
-This ensures maximum privacy.
+Open your wallet and check whether your funds are in the **shielded balance** or the **transparent balance**.
 
+- **Zashi**: your main balance is shielded by default; check Settings for transparency status
+- **Ywallet**: balance screen shows separate shielded and transparent totals
 
-### Step 3: Avoid Identity Linkage
+If you received ZEC from an exchange, it may have arrived in a transparent address. If so, proceed to Step 2.
 
-Do NOT:
-- Announce transactions publicly
-- Reuse the same address across contexts
-- Link addresses to known identities
+### Step 2: Shield Any Transparent Funds First
 
-### Step 4: Consider Timing Patterns
+If your ZEC is in a transparent balance, move it to your shielded balance before sending:
 
-Advanced tip:
-- Avoid sending immediately after receiving large amounts
-- Break predictable patterns where possible
+- **Zashi**: tap "Send" and send to your own shielded address (the app may offer a "Shield" button directly)
+- **Ywallet**: Accounts → your account → Send to your own Sapling or Unified address
 
-<br/>
+This shielding step is visible on-chain (the transparent → shielded transaction is recorded), but from this point forward, your shielded funds have no traceable history.
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/icons8-cancel.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="cancel icon"/> Common Mistakes to Avoid
+### Step 3: Verify the Recipient's Address
 
-- Sending directly from transparent addresses  
-- Reusing addresses across multiple people  
-- Publicly confirming transactions  
-- Ignoring metadata (timing, frequency)
+Before sending, confirm the recipient is using a shielded address:
 
-<br/>
+- **Unified Address** (`u1...`) ✅ — safest, uses Orchard by default
+- **Sapling address** (`zs1...`) ✅ — still shielded and private
+- **Transparent address** (`t1...`) ❌ — the amount sent will be visible on-chain, and the transaction links your shielded balance to a public address
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/checked-checkbox-svgrepo-com.svg" width="28" height="28" className="inline-block align-middle mr-1 p-[2px]" alt="done icon"/> Result
+If a recipient gives you a transparent address and privacy matters, ask them to provide a shielded address instead.
 
-You can:
-- Send funds privately
-- Avoid linking your identity
-- Reduce traceability
+### Step 4: Send the Payment
 
-<br/>
+In your wallet:
 
-## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
-- [Privacy - Shielded vs Transparent](/privacy/shielded-vs-transparent)
+1. Tap or click "Send"
+2. Paste the recipient's Unified Address
+3. Enter the amount
+4. (Optional) Add a memo — the memo is encrypted and private; use it to communicate context (invoice number, purpose, etc.)
+5. Confirm and send
+
+The transaction will take approximately 1–3 minutes to be included in a block, and 10+ confirmations for finality (about 12–15 minutes total).
+
+### Step 5: Avoid Timing and Pattern Correlation
+
+Even with fully shielded transactions, behavioral patterns can create correlations:
+
+- **Don't send immediately after receiving**: a chain analysis tool seeing X ZEC arrive then X ZEC leave moments later can infer they're related, even without seeing addresses
+- **Avoid round numbers for large transfers**: $100 exactly is more distinctive than $97.43
+- **Avoid regular cadences**: weekly transfers at 9 AM every Monday are identifiable patterns
+
+For most everyday use, these precautions are optional. For high-stakes privacy scenarios, they matter.
+
+### Step 6: Confirm the Transaction
+
+After sending, you'll see the transaction appear in your wallet history with a transaction ID (txid). This txid is public — it proves a transaction occurred — but for a shielded transaction, reveals nothing about sender, receiver, or amount.
+
+You can share the txid with the recipient as confirmation. They can look it up in any Zcash block explorer (such as [CipherScan](https://cipherscan.app)) to confirm it exists, but they will only see encrypted data unless they also have the viewing key.
+
+### Step 7: Prove the Payment If Needed
+
+If you need to prove you sent a specific payment (for a contract, dispute resolution, or legal requirement):
+
+- Export your **Outgoing Viewing Key (OVK)** from wallet settings
+- Share it only with the party that needs to verify the payment
+- They can use the OVK to confirm the specific transaction details
+
+This allows selective disclosure without exposing your full transaction history.
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| Sending from a transparent address | Amount and recipient visible on-chain | Shield funds first, then send |
+| Sending to a transparent address | Amount and recipient visible on-chain | Ask recipient for a Unified Address |
+| Announcing the transaction publicly | Links on-chain txid to your identity | Don't publicly confirm transactions |
+| Reusing addresses | Links multiple payments together | Wallets generate new addresses automatically |
+| Sending the exact amount received immediately | Timing correlation | Wait or vary the amount |
+
+---
+
+## Result
+
+After this setup you can:
+
+- Send ZEC to any shielded address with amount, sender identity, and recipient identity hidden from public view
+- Include an encrypted memo for context that only the recipient can read
+- Prove the payment occurred using a viewing key without revealing your full history
+
+---
+
+## Related Pages
+
+- [Privacy — Shielded vs Transparent](/privacy/shielded-vs-transparent)
+- [Wallets](/Using_Zcash/Wallets)
+- [Receive Donations Privately](Receive_Donations_Privately.md)
+- [Freelancer Privacy Setup](Freelance_Privacy_Setup.md)
 
 <br/>
 
@@ -104,10 +173,6 @@ You can:
 
 **Step 2 of 6**
 
-You can now send funds privately without exposing identity.
+← Previous: [Receive Donations Privately](Receive_Donations_Privately.md)
 
-<br/>
-
-## Next Step
-
-- [Freelancer Privacy Setup](/use-cases/freelancer-privacy-setup)
+→ Next: [Freelancer Privacy Setup](Freelance_Privacy_Setup.md)


### PR DESCRIPTION
## Summary

Comprehensive rewrite of all six Use Zcash in the Real World playbooks. The previous versions were thin bullet-point lists with almost no actionable content. This PR rewrites all six with specific, practical instructions.

**Changes:**

- **About.md**: New index with beginner/intermediate/advanced difficulty labels, improved prerequisites ("Before You Start"), clear completion goal, and consistent linking
- **Receive_Donations_Privately.md**: Full guide covering dedicated donation wallet setup, Free2Z platform integration, donor instructions for acquiring ZEC, and viewing key reporting for auditors
- **Send_Money_Without_Linking_Identity.md**: Address type comparison table (transparent/Sapling/Unified), step-by-step fund shielding, timing correlation avoidance, and selective disclosure via outgoing viewing key
- **Freelance_Privacy_Setup.md**: Per-client address separation, invoice memo standard, accountant viewing key workflow, and fiat conversion paths via Gemini shielded deposits and THORChain
- **Private_Community_treasury.md**: Three custody models (single-custodian, SLIP-39 shared-seed, FROST multi-sig), viewing key governance for auditors, encrypted memo accounting standard, and custodian rotation procedure
- **Journalist_privacy_setup.md**: Dedicated device discipline, shielded-only transaction enforcement, source payment flow, memo security rules, fiat conversion without breaking privacy, and legal disclosure via incoming viewing key

All guides follow the existing page structure (TL;DR, Who is this for, The Problem, Why Zcash, What You Need, Step-by-Step, Common Mistakes, Result, Related, Progress/Next).

Closes #1555

---

ZEC address for payment (Unified Address):
`u1l6vp9rqzaujmx57c8grgxstqcq4gchpw3rqxhgydttnj4nfqzuf7v8guzl2xhwn96qtnw46mp2fjvme6vaqkevhkf39djvx2q0uqx3r6smmvlzq5dzjc3wqdjx9f3c0r79qpmzxcfhjvujwwlnecf6xjxqgdts3`