### PR TITLE
docs(wiki): standardize 5 high-priority pages with TL;DR and Related Pages

### DIFF
--- a/site/Start_Here/New_User_Guide.md
+++ b/site/Start_Here/New_User_Guide.md
@@ -4,6 +4,16 @@
 
 # Zcash New User Guide
 
+## TL;DR
+
+- **Buy ZEC** on a supported exchange (Gemini, BitcoinVN, etc.)
+- **Set up a shielded wallet** (Zashi, YWallet, or ZODL recommended)
+- **Withdraw** your ZEC from the exchange to your shielded wallet
+- **Send a shielded transaction** — your first private payment on Zcash
+- **Join the community** on the forum or Discord
+
+---
+
 New to Zcash? This guide will walk you through getting onboarded as a Zcash user and *ZEC* holder.
 
 ---
@@ -93,3 +103,13 @@ The community is passionate and very welcoming of new members. Sometimes convers
 <a href="">
     <img width="auto" height="200" alt="zcash-logo-horizontal-transparent" src="https://github.com/user-attachments/assets/c1d40441-4336-4754-b3bf-5a746b19a9d5" />
 </a>
+
+---
+
+## Related Pages
+
+- [What is ZEC and Zcash](/start-here/what-is-zec-and-zcash) — Understand the basics before you start
+- [Buying ZEC](/using-zcash/buying-zec) — Full list of exchanges supporting shielded withdrawals
+- [Wallets](/using-zcash/wallets) — Compare all Zcash wallets by features and platform
+- [Shielded Pools](/using-zcash/shielded-pools) — Learn why shielded transactions matter
+- [Transactions](/using-zcash/transactions) — How to send and receive ZEC privately

--- a/site/Start_Here/What_is_ZEC_and_Zcash.md
+++ b/site/Start_Here/What_is_ZEC_and_Zcash.md
@@ -4,6 +4,15 @@
 
 # Zcash Basics
 
+## TL;DR
+
+- **ZEC** is a privacy-first digital currency built on the Zcash blockchain
+- Unlike Bitcoin, ZEC supports fully **shielded (private) transactions** using zero-knowledge proofs
+- You control your financial privacy: choose what to reveal, and to whom
+- Zcash is open-source, permissionless, and decentralized
+
+---
+
 ## What is ZEC?
 
 
@@ -44,3 +53,13 @@ Zcash solves Bitcoin's biggest flaw; private ownership and transfer of data. In 
 [How It Works](https://z.cash/technology/)
 
 [The HTTPS of Blockchains](https://nakamoto.com/zcash-the-https-of-blockchains/)
+
+---
+
+## Related Pages
+
+- [New User Guide](/start-here/new-user-guide) — Step-by-step onboarding for new ZEC holders
+- [Wallets](/using-zcash/wallets) — Choose a shielded wallet to hold your ZEC
+- [Buying ZEC](/using-zcash/buying-zec) — Where and how to acquire ZEC
+- [Shielded Pools](/using-zcash/shielded-pools) — How Zcash pools keep transactions private
+- [ZK-SNARKs](/zcash-tech/zk-snarks) — The cryptography behind Zcash privacy

--- a/site/Using_Zcash/Buying_ZEC.md
+++ b/site/Using_Zcash/Buying_ZEC.md
@@ -5,6 +5,15 @@
 
 # Obtaining Zcash
 
+## TL;DR
+
+- Buy ZEC on an exchange that supports **shielded withdrawals** (Gemini, BitcoinVN, Flyp.me) when possible
+- Most major centralized exchanges (Coinbase, Kraken, Binance) support **transparent withdrawals** only — shield your ZEC after receiving it
+- Decentralized exchanges allow non-custodial swaps but typically withdraw to transparent addresses
+- You do **not** need to buy a full ZEC — fractions work fine
+
+---
+
 In order to use Zcash in private (shielded) transactions, you need to have ZEC. To get ZEC, you'll need to buy it. You can buy ZEC from a number of different exchanges, which we will list below. It is recommended that you use an exchange that supports shielded withdrawals.
 
 _You can also mine ZEC, but that is usually not possible for average consumers. More on that [here](https://forum.zcashcommunity.com/t/mining-to-shielded-addresses-community-mining-pool/50281) and [here](https://zec.suprnova.cc/StartMining)_.
@@ -65,4 +74,18 @@ When doing this, we recommend using one of the following [wallets](https://zechu
   />
 </div>
 
+## Common Mistakes to Avoid
 
+- **Withdrawing to a transparent address** when the exchange supports shielded withdrawals — always use your z-address if available
+- **Skipping the shielding step** after receiving to a transparent address — use your wallet's "Shield Funds" feature immediately
+- **Buying more than needed initially** — start small to learn the flow before larger purchases
+
+---
+
+## Related Pages
+
+- [Wallets](/using-zcash/wallets) — Choose a wallet before withdrawing from an exchange
+- [Non-Custodial Exchanges](/using-zcash/non-custodial-exchanges) — Full list of DEXes supporting ZEC
+- [Custodial Exchanges](/using-zcash/custodial-exchanges) — Full list of CEXes supporting ZEC
+- [Shielded Pools](/using-zcash/shielded-pools) — Why shielded withdrawals matter
+- [New User Guide](/start-here/new-user-guide) — Full onboarding checklist for new Zcash users

--- a/site/Using_Zcash/Shielded_Pools.md
+++ b/site/Using_Zcash/Shielded_Pools.md
@@ -4,6 +4,16 @@
 
 # Zcash Value Pools 
 
+## TL;DR
+
+- Zcash has **4 value pools**: Sprout (legacy), Sapling, Orchard, and Transparent
+- **Orchard** (Unified Addresses / z-addresses starting with `u1`) is the current recommended shielded pool
+- **Sapling** (z-addresses starting with `zs`) is the previous shielded pool, still widely supported
+- **Transparent** (t-addresses) offers no privacy — similar to Bitcoin
+- Always prefer **z → z** (shielded-to-shielded) transactions for maximum privacy
+
+---
+
 There are currently 4 [value pools](https://zcash.readthedocs.io/en/latest/rtd_pages/addresses.html) in Zcash. Sprout, Sapling, Orchard and Transparent.
 
 ![img1](https://github.com/user-attachments/assets/4ba8cca2-cea5-42d2-8ec2-2122b26f5144)
@@ -99,6 +109,25 @@ Transferring ZEC from a Transparent Address (T-address) to a Z-address is simply
 
 Sending ZEC from a Transparent Address (T-address) to another Transparent Address (T-address) on Zcash Network (T-T transaction) is very similar to that of Bitcoin transaction and this is why T-T transactions on Zcash are always called Public transactions because both the sender and the receiver transaction details becomes visible to the public which makes the level of Privacy very low in such transaction. 
 
-Most Cryptocurrency Centralized exchanges make use of Transparent Address ("T-address) when it comes to transacting on the Zcash blockchain but this type of transaction (T-T) will not have any private properties. 
+Most Cryptocurrency Centralized exchanges make use of Transparent Address ("T-address) when it comes to transacting on the Zcash blockchain but this type of transaction (T-T) will not have any private properties.
+
+---
+
+## Common Mistakes to Avoid
+
+- **Sending from t-address to t-address** — fully public, no privacy. Always shield funds first.
+- **Confusing Sapling and Orchard addresses** — Sapling addresses start with `zs`, Orchard/Unified addresses start with `u1`
+- **Leaving funds in the Sprout pool** — Sprout is deprecated; migrate funds to Orchard
+- **Assuming t → z (shielding) is fully private** — the act of shielding itself is visible on-chain; the contents are not
+
+---
+
+## Related Pages
+
+- [Wallets](/using-zcash/wallets) — Which wallets support Orchard and Sapling pools
+- [Transactions](/using-zcash/transactions) — How to send shielded transactions
+- [Buying ZEC](/using-zcash/buying-zec) — Acquiring ZEC before using it in pools
+- [ZK-SNARKs](/zcash-tech/zk-snarks) — The cryptographic foundation of shielded pools
+- [What is ZEC and Zcash](/start-here/what-is-zec-and-zcash) — Background on Zcash privacy
 
 

--- a/site/Zcash_Tech/zk_SNARKS.md
+++ b/site/Zcash_Tech/zk_SNARKS.md
@@ -4,6 +4,16 @@
 
 # ZKP & ZK-SNARKS
 
+## TL;DR
+
+- **ZK-SNARKs** = Zero-Knowledge Succinct Non-Interactive Arguments of Knowledge
+- They let one party **prove they know something** without revealing the information itself
+- Zcash uses ZK-SNARKs to prove a transaction is valid (correct amounts, unspent inputs) **without revealing sender, receiver, or amount**
+- "Succinct" means the proof is tiny and fast to verify even for complex statements
+- The Orchard pool uses Halo 2, a ZK-SNARK system with **no trusted setup required**
+
+---
+
 ## What is a Proof?
 
 Proofs are the basis for all mathematics. A proof is a claim or theorem you are trying to prove & sequence of derivations made to declare the theorem has been proved. eg. all angles in a triangle total 180° can be independently checked by anyone (verifier).
@@ -207,3 +217,13 @@ Further Learning:
 [Simple Explanation of Arithmetic Circuits - Medium](https://medium.com/web3studio/simple-explanations-of-arithmetic-circuits-and-zero-knowledge-proofs-806e59a79785)
 
 [Scalability is Boring, Privacy is Dead: ZK-Proofs, What are They Good for?](https://www.youtube.com/watch?v=AX7eAzfSB6w)
+
+---
+
+## Related Pages
+
+- [Shielded Pools](/using-zcash/shielded-pools) — How ZK-SNARKs are used in Zcash value pools
+- [Halo](/zcash-tech/halo) — Zcash's ZK-SNARK system that eliminates trusted setups
+- [Zcash Shielded Assets](/zcash-tech/zcash-shielded-assets) — ZSAs built on ZK-SNARK technology
+- [What is ZEC and Zcash](/start-here/what-is-zec-and-zcash) — Introduction to Zcash and its privacy model
+- [Privacy as a Core Principle](/privacy/privacy-as-a-core-principle) — Why financial privacy matters


### PR DESCRIPTION
Submitted for issue #1580: https://github.com/ZecHub/zechub/issues/1580

## What this does

Standardizes 5 of the highest-traffic ZecHub wiki pages using the consistent content template from the bounty spec. All existing content is preserved and reorganized — nothing is rewritten.

## Pages standardized

| Page | Added |
|------|-------|
| `Start_Here/What_is_ZEC_and_Zcash.md` | TL;DR, Related Pages |
| `Start_Here/New_User_Guide.md` | TL;DR, Related Pages |
| `Using_Zcash/Buying_ZEC.md` | TL;DR, Common Mistakes, Related Pages |
| `Using_Zcash/Shielded_Pools.md` | TL;DR, Common Mistakes, Related Pages |
| `Zcash_Tech/zk_SNARKS.md` | TL;DR, Related Pages |

## Template applied per page

**Always Required (added to all 5):**
- ✅ Title (existing)
- ✅ TL;DR (new — 3–5 bullet points for at-a-glance understanding)
- ✅ Core Explanation (existing, preserved)
- ✅ Related Pages (new — links to adjacent wiki content)

**Optional (added where relevant):**
- ✅ Common Mistakes (added to Buying_ZEC and Shielded_Pools)

## Approach

Per the issue spec: *"Ensure existing content is reorganized rather than rewritten where possible."* Every page's existing explanations, links, images, and videos are unchanged. Only the TL;DR summary and Related Pages navigation are new additions.