### PR TITLE
docs(wiki): standardize 4 Zcash Tech pages — TL;DR + Related Pages

### DIFF
--- a/site/Zcash_Tech/Pepper_Sync.md
+++ b/site/Zcash_Tech/Pepper_Sync.md
@@ -1,5 +1,15 @@
 # Zingo 2.0 - Pepper Sync
 
+## TL;DR
+
+- **Pepper Sync** is the syncing engine in Zingo! 2.0 — the open-source Zcash wallet built by Zingo Labs
+- Replaces the older full-rescan approach with **incremental, resumable block fetching** — minutes, not hours
+- **Privacy-preserving**: shielded Orchard and Sapling transactions remain fully private throughout sync
+- Works by processing blockchain data in small chunks and saving progress between sessions
+- Particularly beneficial for mobile users and devices with limited CPU/memory
+
+---
+
 ## INTRODUCTION
 Zingo 2.0 is the latest version of the Zingo! wallet, a lightweight, open-source wallet built for the Zcash community. The star of this release is Pepper Sync, a major upgrade that completely rethinks how wallets connect with the blockchain.
 
@@ -139,3 +149,13 @@ With Zingo 2.0 Pepper Sync, syncing is no longer the biggest pain point of shiel
 For users, it means less waiting and more privacy. For developers, it means a stronger foundation to build on. For the Zcash ecosystem, it's another step toward making shielded transactions accessible to everyone.
 
 Zingo 2.0 with Pepper Sync isn't just an upgrade, it's a leap forward for private, usable crypto.
+
+---
+
+## Related Pages
+
+- [Zcash Wallet Syncing](/zcash-tech/zcash-wallet-syncing) — Overview of how wallets sync with the Zcash blockchain
+- [Zaino](/zcash-tech/zaino) — The Rust-based indexer that replaces lightwalletd (which Zingo 2.0 connects to)
+- [Halo](/zcash-tech/halo) — The ZK-SNARK proving system that powers the Orchard shielded pool Pepper Sync processes
+- [Viewing Keys](/zcash-tech/viewing-keys) — Selective disclosure feature available after syncing completes
+- [What is ZEC and Zcash](/start-here/what-is-zec-and-zcash) — Introduction to Zcash and shielded transactions

--- a/site/Zcash_Tech/ZAP1_Attestation_Protocol.md
+++ b/site/Zcash_Tech/ZAP1_Attestation_Protocol.md
@@ -1,5 +1,15 @@
 # ZAP1 Attestation Protocol
 
+## TL;DR
+
+- **ZAP1** is an open-source attestation protocol that anchors lifecycle event proofs on the Zcash blockchain via shielded memos
+- Events (deployments, payments, transfers) are hashed into a **BLAKE2b Merkle tree**; only the tree root goes on-chain
+- **Anyone can verify** an event happened without trusting the operator — just a leaf hash + chain access
+- Written in Rust; available as a crate (`zap1-verify`) and JavaScript SDK on npm
+- Converging toward a ZIP 302 partType for standardized on-chain attestation payloads
+
+---
+
 ZAP1 is an open-source attestation protocol for Zcash. It writes structured lifecycle events to a BLAKE2b Merkle tree and anchors the tree root on-chain via Orchard shielded memos. Proofs are publicly verifiable. Event data stays private.
 
 ## How it works
@@ -46,3 +56,13 @@ Each operator runs their own ZAP1 instance with their own keys, Merkle tree, and
 - ZIP draft: [PR #1243](https://github.com/zcash/zips/pull/1243)
 - Live API: [pay.frontiercompute.io/protocol/info](https://pay.frontiercompute.io/protocol/info)
 - Operator guide: [frontiercompute.io/operators.html](https://frontiercompute.io/operators.html)
+
+---
+
+## Related Pages
+
+- [Viewing Keys](/zcash-tech/viewing-keys) — Selective disclosure mechanism that complements ZAP1 attestations
+- [ZK-SNARKs](/zcash-tech/zk-snarks) — The zero-knowledge proof system underlying Zcash privacy
+- [FROST](/zcash-tech/frost) — Threshold signing used in ZAP1's multi-party anchor broadcasting design
+- [Zcash Shielded Assets](/zcash-tech/zcash-shielded-assets) — Other on-chain capability built on Zcash's memo field
+- [Privacy as a Core Principle](/privacy/privacy-as-a-core-principle) — Why anchoring proofs privately matters

--- a/site/Zcash_Tech/Zaino.md
+++ b/site/Zcash_Tech/Zaino.md
@@ -1,5 +1,15 @@
 # Zaino Indexer
 
+## TL;DR
+
+- **Zaino** is a Rust-based blockchain indexer built by Zingo Labs to replace the aging C++ lightwalletd service
+- It supports both **light clients** (wallets without full blockchain history) and **full clients** (block explorers, full wallets)
+- Connects to **Zebra** (the Rust full node) rather than zcashd, supporting the zcashd deprecation project
+- Backwards-compatible by design — existing wallets can adopt Zaino without major rewrites
+- Provides RPC access and a client library, so wallets can query Zaino directly without depending on a separate server
+
+---
+
 Zaino is an Indexer, developed in Rust by the Zingo team, that aims to replace lightwalletd and to push forward the zcashd deprecation project.
 
 Zaino offers essential features for both light clients, such as wallets and applications that do not require the full blockchain history, and full clients or wallets. It also supports block explorers, granting access to both the finalized blockchain and the non-finalized best chain and mempool managed by a Zebra or Zcashd full validator.
@@ -28,3 +38,13 @@ Also, Zaino will allow to separate light client functionality from the full node
 
 ## Where Can I learn more?
 You can read more about Zaino Indexer in the official [Zcash Community Forum thread](https://forum.zcashcommunity.com/t/zingo-labs-accelerates-zcashd-deprecation/48545/38) or in its official [Github page](https://github.com/zingolabs/zaino)
+
+---
+
+## Related Pages
+
+- [Zebra Full Node](/zcash-tech/zebra-full-node) — The Rust full node that Zaino connects to
+- [Zcash Wallet Syncing](/zcash-tech/zcash-wallet-syncing) — Overview of syncing methods (including lightwalletd, which Zaino replaces)
+- [Pepper Sync](/zcash-tech/pepper-sync) — Zingo! wallet's sync engine, built on top of Zaino
+- [Full Nodes](/zcash-tech/full-nodes) — What full nodes do and why they matter
+- [What is ZEC and Zcash](/start-here/what-is-zec-and-zcash) — Introduction to the Zcash ecosystem

--- a/site/Zcash_Tech/Zcash_Wallet_Syncing.md
+++ b/site/Zcash_Tech/Zcash_Wallet_Syncing.md
@@ -4,6 +4,16 @@
 
 # Zcash Wallet Syncing
 
+## TL;DR
+
+- **Shielded wallets can't be indexed server-side** — servers can't see encrypted transactions, so wallets must download compact blocks and decrypt them locally with their own private keys
+- **Warp Sync** (YWallet): uses cryptographic shortcuts to skip block-by-block decryption, processing thousands of blocks per second
+- **Spend-before-sync** (ECC SDK V2): scans blocks in non-linear order so recently received funds become spendable immediately, before full sync completes
+- **Blaze Sync** (Zecwallet): starts from the newest blocks and works backwards, using parallel out-of-order processing for ~5× speed improvement
+- **DAGSync**: proposed algorithm that models note/witness/nullifier dependencies as a directed acyclic graph for smarter, more efficient syncing
+
+---
+
 ### How Zcash syncing works
 
 To understand how warp sync works, let me explain a bit more about Zcash. It is a privacy-oriented cryptocurrencies that use a technology called zero-knowledge proofs to shield the details of transactions from anyone who is not authorized to see them. This means that the transactions recorded on the blockchain are encrypted or hidden, and only the sender and receiver can decrypt them with their private keys.
@@ -60,3 +70,13 @@ A DAG is a data structure that consists of nodes and edges, where each edge has 
 Interestingly enough, all these mechanism try to solve the inquiries proposed by Zcash Security in its post about [Scalable Private Messaging](https://zecsec.com/posts/scalable-private-money-needs-scalable-private-messaging/) and its relationship with private payment systems, some even taking the extra step of downloading all memo data from servers, except for those exclusive to an address, increasing privacy at the cost of a bit of extra resources.
 
 Also, the Zcash Foundation has been looking at other alternatives to improve the performance of light wallets. That's the case with [Oblivious Message Retrieval (OMR](https://zfnd.org/oblivious-message-retrieval/)), a construction the foundation has been studying "to determine whether it offers a potential solution to the recent performance problems that have affected Zcash wallet users"
+
+---
+
+## Related Pages
+
+- [Zaino](/zcash-tech/zaino) — The Rust-based indexer replacing lightwalletd that compact-block wallets connect to
+- [Pepper Sync](/zcash-tech/pepper-sync) — Zingo! 2.0's incremental sync engine built on top of Zaino
+- [Full Nodes](/zcash-tech/full-nodes) — What full nodes like Zebra do and why light wallets depend on them
+- [ZK-SNARKs](/zcash-tech/zk-snarks) — The zero-knowledge proof system that makes shielded transactions private (and wallet syncing complex)
+- [What is ZEC and Zcash](/start-here/what-is-zec-and-zcash) — Introduction to the Zcash ecosystem


### PR DESCRIPTION
## Summary

Continues the content standardization effort from issue #1580, applying the standard template to four more Zcash Tech wiki pages.

### Pages updated

| Page | TL;DR added | Related Pages added |
|------|-------------|---------------------|
| ZAP1 Attestation Protocol | ✅ 5 bullets | ✅ 5 links |
| Pepper Sync (Zingo 2.0) | ✅ 5 bullets | ✅ 5 links |
| Zaino Indexer | ✅ 5 bullets | ✅ 5 links |
| Zcash Wallet Syncing | ✅ 5 bullets | ✅ 5 links |

### Template applied

Each page now follows the structure from #1580:
- **TL;DR** — 5 concise bullet points summarizing the page for new readers
- **Related Pages** — cross-links to 4-5 relevant wiki articles with short descriptions

No existing content was removed or restructured. All additions are additive.

Closes #1580 (partial — additional pages in this batch)