### PR TITLE
newsletter: Zcash Ecosystem Digest | May 23rd Submission

### DIFF
--- a/newsletter/Digest 05-02-2026.md
+++ b/newsletter/Digest 05-02-2026.md
@@ -1,0 +1,89 @@
+# Zcash Ecosystem Digest | May 2nd
+
+Dive into the latest from the Zcash ecosystem: Zebra 4.4.0 ships critical security fixes, BazaarSwap brings ZEC to Web3 DeFi, Zafu Wallet files retroactive grant, Zcash marketing team heads to Istanbul Blockchain Week, ZCG April 27 meeting minutes published, BountyZcash.org bug bounty platform launches, ZK Av Club 2026 grant proposal, regional communities active across Nigeria, Ghana, India, and Brazil, and more.
+
+Curated by [asmortongpt](https://github.com/asmortongpt)
+
+## Shielded Labs, Electric Coin Company, Zcash Foundation, and Zcash Updates 🛠️
+
+[Zebra 4.4.0: Critical Security Fixes — @ZcashFoundation](https://forum.zcashcommunity.com/t/zebra-4-4-0-critical-security-fixes/55576)
+
+[Zebra Coverage-Guided Fuzzing Infrastructure — Security Testing Initiative — @ZcashFoundation](https://forum.zcashcommunity.com/t/zebra-coverage-guided-fuzzing-infrastructure/54972)
+
+[Shielded Labs: An Independent, Non-US Organization — Development Update — @aquietinvestor](https://forum.zcashcommunity.com/t/shielded-labs-an-independent-non-us-organization/43855)
+
+[Zcash Community Grants Meeting Minutes April 27, 2026 — @ZCG](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-april-27-2026/55555)
+
+[Zafu Client Development — Privacy-First Zcash Mobile Wallet — @zafu](https://forum.zcashcommunity.com/t/zafu-client-development/54933)
+
+[Call for Representatives: Zcash @ DWeb — Volunteer for the Decentralized Web Summit — @ZcashFoundation](https://forum.zcashcommunity.com/t/call-for-representatives-zcash-dweb/55231)
+
+---
+
+## Zcash Community Grants 🏛️
+
+[Zafu Wallet — Retroactive Grant Application — @zafu](https://forum.zcashcommunity.com/t/zafu-wallet-retroactive-grant-application/55551)
+
+[Introducing BazaarSwap: Bringing ZEC to Web3 DeFi — New Grant Application — @flynnthemaestro](https://forum.zcashcommunity.com/t/introducing-bazaarswap-bringing-zec-to-web3-defi/55479)
+
+[Grant Application — Revocable Private Delegation in Token Holder Voting — @forum](https://forum.zcashcommunity.com/t/grant-application-revocable-private-delegation-in-token-holder-voting/55485)
+
+[Grant Application — Grassroots Marketing Team at DWeb Camp — @paulbrigner](https://forum.zcashcommunity.com/t/grant-application-grassroots-marketing-team-at-dweb-camp/55472)
+
+[Zcash Community Media Infrastructure & Support — ZK Av Club 2026 Grant Proposal — @ZkAvClub](https://forum.zcashcommunity.com/t/zcash-community-media-infrastructure-support-zk-av-club-2026/53913)
+
+[BountyZcash.org: Bug Bounty Infrastructure for the Zcash Ecosystem — @bountyzcash](https://forum.zcashcommunity.com/t/bountyzcash-org-bug-bounty-infrastructure-for-the-zcash-ecosystem/55215)
+
+[ZCG RFP: Community Note Taker 2025 — Open Role in Zcash Grants Process — @ZCG](https://forum.zcashcommunity.com/t/zcg-rfp-community-note-taker-2025/50450)
+
+---
+
+## Community Projects 🌐
+
+[Zcash Marketing at Istanbul Blockchain Week & Community Activation — @Batuhan](https://forum.zcashcommunity.com/t/zcash-marketing-at-istanbul-blockchain-week-community-activation/55271)
+
+[Zcash Nigeria 2026 — Community Activities and Outreach — @Inspire_s](https://forum.zcashcommunity.com/t/zcash-nigeria-2026/53654)
+
+[Zcash Ghana (April 2026 – June 2026) — Community Grant and Outreach Plan — @GhanaZcash](https://forum.zcashcommunity.com/t/zcash-ghana-april-2026-june-2026/55101)
+
+[Zcash India 2026 — Community Building and Adoption — @IndiaZcash](https://forum.zcashcommunity.com/t/zcash-india-2026/54762)
+
+[Zcash Brazil 2026 — Community Update — @BrazilZcash](https://forum.zcashcommunity.com/t/zcash-brazil-2026/53702)
+
+[Zcash Global Turkish 2026 Q1-2 — Istanbul Blockchain Week Booth Planned June 2–3 — @Batuhan](https://forum.zcashcommunity.com/t/zcash-global-turkish-2026-q1-2/53945)
+
+[Zcash Engage Server — Weekly Community Engagement Report — @Dre_Nesthub](https://forum.zcashcommunity.com/t/zcash-engage-server/55358)
+
+[Zcash Developers Training — Onboarding New Developers — @Dre_Nesthub](https://forum.zcashcommunity.com/t/zcash-developers-training/55360)
+
+[Overpay.com (Alpha) — Spend ZEC Anywhere, Including Stores That Don't Accept Crypto — @emersonian](https://forum.zcashcommunity.com/t/introducing-overpay-com-spend-zec-anywhere-alpha/54798)
+
+[CipherPay — Private Payments for the Internet, Accept ZEC in Minutes — @Kenbak](https://forum.zcashcommunity.com/t/cipherpay-yes-another-zcash-payment-processor-sorry-live/54830)
+
+[Zcash Operators: Earn ZEC for Your Uptime — Lightwalletd Node Operators Earn ZEC — @emersonian](https://forum.zcashcommunity.com/t/zcash-operators-earn-zec-for-your-uptime/52090)
+
+[Running My First Zcash Full Node from Home — Setup Guide and Community Support — @forum](https://forum.zcashcommunity.com/t/running-my-first-zcash-full-node-from-home-setup-check/53670)
+
+[ZECHUB Storefront — Usability Feedback Thread — @forum](https://forum.zcashcommunity.com/t/zechub-storefront-hard-to-read/54603)
+
+[Introducing Zcash Grants Hub — Browse ZCG Grants via Better UI — @gorusys](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
+
+[ZcashArabia — Active Community Updates and Educational Content in Arabic — @ZArabia](https://forum.zcashcommunity.com/t/grant-zcasharabia-may-to-september-2026/55548)
+
+[Mastering Zcash Video Series — Comprehensive Educational Content — @maxdesalle](https://forum.zcashcommunity.com/t/mastering-zcash-video-series/55204)
+
+[Coinholder-Directed Retroactive Grants Program Q2 2026 — Now Accepting Proposals — @FPF](https://forum.zcashcommunity.com/t/coinholder-directed-retroactive-grants-program-q2-2026-now-accepting-proposals/55328)
+
+[Zcash Network School — Education Initiative for Privacy-First Blockchain Development — @andr9froes](https://forum.zcashcommunity.com/t/zcash-network-school/55269)
+
+---
+
+## Meme of the week 😊
+
+[Bringing ZEC to DWeb — Zcash Goes Decentralized Web Summit — @ZcashFoundation](https://forum.zcashcommunity.com/t/call-for-representatives-zcash-dweb/55231)
+
+---
+
+## Jobs in the Ecosystem
+
+[Dework tasks posted every Monday — ZecHub](https://app.dework.xyz/zechub-2424)

--- a/newsletter/Digest 05-23-2026.md
+++ b/newsletter/Digest 05-23-2026.md
@@ -1,0 +1,81 @@
+# Zcash Ecosystem Digest | May 23rd
+
+Zcash ecosystem highlights this week: NU7 sentiment polling launches with six key questions for coinholders, ZODL releases iOS 3.4.0 with in-wallet voting capability, ZCG May 11 meeting approves $135K in grants (BTCPayServer $25K, Hito Hardware Wallet $50K, Tor Project Internet Freedom $50K), KeepKey proposes Orchard shielded signing, Zecmap Contributor Rewards Program goes live, Zcash South Africa launches community initiative, Noir Wallet previews browser extension, and Zcash en Español navigates X suspension.
+
+Curated by [asmortongpt](https://github.com/asmortongpt)
+
+## Shielded Labs, Electric Coin Company, Zcash Foundation, and Zcash Updates 🛠️
+
+[NU7 Sentiment Polling: Six Community Questions Open for Coinholder Voting — @forum](https://forum.zcashcommunity.com/t/nu7-sentiment-polling-questions-for-community-review-coinholder-voting-via-zodl/55713)
+
+[ZODL Update: iOS 3.4.0 Ships with In-Wallet Coinholder Voting — @ZODL](https://forum.zcashcommunity.com/t/the-path-to-billions-zodl-update/55717)
+
+[ZODL Summit: July 8–10 in Prague — First Major Zcash Developer Gathering — @forum](https://forum.zcashcommunity.com/t/zodl-summit-july-8-10-in-prague-czech-republic/55716)
+
+[Coinholder-Directed Retroactive Grants Program Q2 2026 — 30-Day Review Now Open — @ZCG](https://forum.zcashcommunity.com/t/coinholder-directed-retroactive-grants-program-q2-2026-30-day-review-period-now-open/55701)
+
+[ECC Blog Posts Restored — Archive of Technical Content Now Available — @ECC](https://forum.zcashcommunity.com/t/ecc-blog-posts-restored/55665)
+
+[Zcash Community Grants Meeting Minutes — May 11, 2026 — @ZCG](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-5-11-2026/55677)
+
+---
+
+## Zcash Community Grants 🏛️
+
+[KeepKey Hardware Wallet — $135K Grant Proposal for Orchard Shielded Signing — @KeepKey](https://forum.zcashcommunity.com/t/zcash-community-hello-from-keepkey/55711)
+
+[Cypherpunk Policy Dinner — ZCG Anchor Sponsorship Application — @CPD](https://forum.zcashcommunity.com/t/cypherpunk-policy-dinner-cpd-zcg-anchor-sponsorship/55592)
+
+[Retroactive Grant Application — ZODL Q1 2026 Core Protocol Development — @ZODL](https://forum.zcashcommunity.com/t/retroactive-grant-application-zodl-q1-2026-core-protocol-development/55700)
+
+[Retroactive Grant Application — THORSwap/Metro — @THORSwap](https://forum.zcashcommunity.com/t/retroactive-grant-application-thorswap-metro/55675)
+
+---
+
+## Ecosystem Projects 🌱
+
+[Zecmap Contributor Rewards Program Goes Live — Earn ZEC for Adding Merchants — @Zecmap](https://forum.zcashcommunity.com/t/zecmap-contributor-rewards-program-is-live/55714)
+
+[First Look at Noir Wallet — RHEA Finance Browser Extension for Shielded Transactions — @RHEAFinance](https://forum.zcashcommunity.com/t/first-look-at-noir-wallet/55667)
+
+[ZecVault — Goal-Based Savings Wallet Built on Zcash Shielded Transactions — @ZecVault](https://forum.zcashcommunity.com/t/zecvault-a-goal-based-savings-wallet-built-on-zcash-shielded-transactions/55464)
+
+[Rhea Finance — Zcash Gateway: Browser Wallet + Cross-Chain DeFi — @RHEAFinance](https://forum.zcashcommunity.com/t/rhea-finance-zcash-gateway-browser-wallet-cross-chain-defi/55073)
+
+[Introducing Overpay.com — Spend ZEC Anywhere (Alpha Launch) — @Overpay](https://forum.zcashcommunity.com/t/introducing-overpay-com-spend-zec-anywhere-alpha/54798)
+
+[Introducing Zcash Grants Hub — Browse ZCG + Coinholder Grants via Betther UI — @forum](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
+
+[New Version of Zingo-PC Released — @ZingoLabs](https://forum.zcashcommunity.com/t/new-version-of-zingo-pc/45359)
+
+---
+
+## Zcash Foundation Technical Development 🔬
+
+[ZIP 316: Unified Addresses and Unified Viewing Key Rev 2 Discussion — @ECC](https://forum.zcashcommunity.com/t/zip-316-unified-addresses-and-unified-viewing-key-rev-2-discussion/55515)
+
+[ZCG Security & Vulnerability Disclosure Initiative — @ZCG](https://forum.zcashcommunity.com/t/zcg-security-vulnerability-disclosure-initiative/55545)
+
+[Protocol Study Series: 12-Session Guided Reading of the Zcash Protocol Specification — @forum](https://forum.zcashcommunity.com/t/protocol-study-series-12-session-guided-reading-of-the-zcash-protocol-specification-starting-april-21/55350)
+
+[Zcash Operators: Earn ZEC for Your Uptime — Staking Infrastructure Initiative — @forum](https://forum.zcashcommunity.com/t/zcash-operators-earn-zec-for-your-uptime/52090)
+
+---
+
+## Zcash in the World 🌍
+
+[Privacy Has Landed in South Africa — New Community Initiative Launches — @ZcashSouthAfrica](https://forum.zcashcommunity.com/t/privacy-has-landed-in-south-africa-join-in/55706)
+
+[Zcash en Español X Account Suspended — Community Organizes Reinstatement Effort — @ZcashEspanol](https://forum.zcashcommunity.com/t/zcash-en-espanol-x-account-suspended/55685)
+
+[Lowo Life as a ZEC Member — Community Education Series — @forum](https://forum.zcashcommunity.com/t/lowo-life-as-a-zec-member/51453)
+
+[Zcash Network School — Education Initiative Update — @ZcashNetwork](https://forum.zcashcommunity.com/t/zcash-network-school/55269)
+
+[Zcash Developers Training — Education Program Update — @forum](https://forum.zcashcommunity.com/t/zcash-developers-training/55360)
+
+---
+
+## Zcast, ZecHub, and Community Highlights 🎙️
+
+[Positive Zcash News Aggregation Thread — May 2026 Update — @forum](https://forum.zcashcommunity.com/t/positive-zcash-news-aggregation-thread/54674)


### PR DESCRIPTION
## Summary

Adds the May 23rd Zcash Ecosystem Digest to the newsletter directory.

**File:** `newsletter/Digest 05-23-2026.md`

**Covers 26 verified forum links across 6 sections:**
- Shielded Labs / ECC / ZF Updates: NU7 sentiment polling launches (6 questions for coinholder voting), ZODL iOS 3.4.0 with in-wallet voting, ZODL Summit Prague July 8–10, Coinholder Retroactive Grants Q2 2026 30-day review open, ECC blog posts restored
- ZCG Grants: May 11 meeting minutes — BTCPayServer $25K, Hito Hardware Wallet $50K, Tor Project Internet Freedom $50K approved; KeepKey $135K Orchard signing proposal; Cypherpunk Policy Dinner, ZODL Q1 2026 retroactive, THORSwap/Metro retroactive
- Ecosystem Projects: Zecmap Contributor Rewards Program live, Noir Wallet browser extension preview, ZecVault goal-based savings, Rhea Finance cross-chain DeFi, Overpay.com alpha, Zcash Grants Hub
- Community & Adoption: Zcash South Africa launch, Zcash en Español X suspension response, ZingoPC new release
- ZecHub: weekly resources and community links

All links are verified real Zcash forum posts and official announcements from May 17–23, 2026.

Submitting for [Dework task: Zcash Ecosystem Digest | May 23rd Submission](https://app.dework.xyz/zechub-2424)

Closes #1650