### PR TITLE
Add ZecMap guide

### DIFF
--- a/site/Using_Zcash/zecmap.md
+++ b/site/Using_Zcash/zecmap.md
@@ -1,0 +1,116 @@
+# ZecMap
+
+ZecMap is a global directory for finding businesses and services that accept Zcash (ZEC). It is built around a map-based experience so users can discover where ZEC can be spent in person or online, and so contributors can help keep merchant information useful for the wider Zcash community.
+
+Website: [https://zecmap.com/](https://zecmap.com/)
+
+## What ZecMap Does
+
+ZecMap helps users answer a practical question: "Where can I spend ZEC?"
+
+The directory is intended to cover:
+
+- Local businesses such as cafes, restaurants, shops, and service providers.
+- Online stores and services that accept ZEC.
+- Zcash-friendly tools, wallets, and payment resources.
+- Community-submitted listings that expand merchant discovery over time.
+
+Each listing should help users understand what the business offers, where it is located or how it can be reached online, and how ZEC is accepted.
+
+## Why It Matters
+
+Zcash is strongest when people can use it in real transactions. A merchant directory makes adoption easier by reducing the work needed to find places that accept ZEC.
+
+For users, ZecMap can make it easier to:
+
+- Find nearby merchants that accept ZEC.
+- Discover online services that support Zcash payments.
+- Plan travel or errands around ZEC-friendly locations.
+- Share useful merchant discoveries with the community.
+
+For businesses, ZecMap can provide visibility to Zcash users who want to support merchants that accept privacy-preserving digital cash.
+
+## Common Use Cases
+
+### Finding Local Merchants
+
+A user can search the map for local businesses that accept ZEC, such as a coffee shop, restaurant, or retail store. Before visiting, the user should still confirm with the merchant that ZEC is currently accepted and ask which wallet or payment flow the business prefers.
+
+### Discovering Online Shops and Services
+
+ZecMap can also help users find online merchants, VPN providers, hosting services, stores, or other digital businesses that support ZEC payments.
+
+### Supporting Community-Added Listings
+
+Community contributors can help grow the directory by adding businesses they know accept ZEC. This is especially useful for local adoption, where merchant information can change quickly and may not appear in larger crypto directories.
+
+### Helping New Zcash Users
+
+New users often learn how to buy or store ZEC before they learn where it can be spent. ZecMap gives them a practical next step: finding real-world or online places where ZEC has utility.
+
+## Adding a Business
+
+If a business accepts ZEC and is missing from ZecMap, a contributor can submit it for inclusion. A good submission should include:
+
+- Business name.
+- Website or public contact page.
+- Physical address, if it is a local business.
+- Category, such as cafe, restaurant, store, service, or online shop.
+- Evidence that the business accepts ZEC, such as a public payments page, merchant announcement, or direct confirmation.
+- Notes about whether payments are accepted in person, online, or both.
+
+Submissions should avoid private customer information. If proof is needed, remove personal details, order numbers, addresses, or other sensitive data before sharing it.
+
+## Verification and Approval
+
+The quality of the map depends on accurate listings. A practical verification flow is:
+
+1. A contributor submits a business with enough public information to review it.
+2. The listing is checked for duplicate entries and basic accuracy.
+3. Acceptance of ZEC is verified through a public source or merchant confirmation.
+4. The listing is approved and added to the directory.
+5. Community members can report stale or incorrect listings so the map stays current.
+
+Because merchant payment options can change, listings should be treated as community-maintained information rather than a guarantee. Users should confirm payment support before relying on a listing for an important purchase.
+
+## User Accounts and Contributor Profiles
+
+ZecMap can support community growth by letting contributors maintain profiles and build reputation around useful submissions. Contributor profiles can help show who added or updated listings, while user accounts can support features such as saved places, submitted listings, verification status, and contribution history.
+
+This kind of reputation layer is useful because merchant directories depend on repeated maintenance, not only one-time submissions.
+
+## Contributor Rewards Program
+
+The ZecMap Contributor Rewards Program is intended to encourage people to add useful merchant data and help keep the directory accurate. Reward programs can be especially helpful for:
+
+- Adding new businesses that accept ZEC.
+- Verifying existing listings.
+- Updating stale merchant information.
+- Expanding coverage in underrepresented cities, regions, or online categories.
+
+Contributors should follow the current ZecMap reward rules and submit high-quality evidence for each claimed contribution. The best submissions are accurate, easy to verify, and respectful of privacy.
+
+## Future Development
+
+Future ZecMap improvements may include:
+
+- Mobile apps for Android and iOS.
+- Multilingual support for local communities.
+- Payment integration or better payment-flow guidance for merchants.
+- Contributor rankings or reputation features.
+- Expanded directory categories for online shops, services, and community-verified businesses.
+- Better tools for reporting stale listings and confirming active ZEC acceptance.
+
+## Tips for Using ZecMap Safely
+
+- Confirm with the merchant before making a trip or placing an order.
+- Prefer current, publicly verifiable merchant information.
+- Do not share private transaction details when submitting proof.
+- Remember that transparent Zcash payments are publicly visible on-chain; use a wallet and address type appropriate for your privacy needs.
+- Help the community by reporting outdated listings.
+
+## Related Resources
+
+- [ZecMap](https://zecmap.com/)
+- [Zcash: How to use Zcash](https://z.cash/learn/how-to-use-zcash/)
+- [ZecHub Wiki](https://zechub.wiki/)


### PR DESCRIPTION
Addresses #1653.

## Summary
- Adds `site/Using_Zcash/zecmap.md` as the requested ZecMap wiki page.
- Covers what ZecMap is, how it helps users find ZEC-accepting businesses, listing submission and verification flow, contributor profiles, rewards program notes, future roadmap items, and safe-use tips.
- Includes links to ZecMap, Zcash usage docs, and ZecHub Wiki.

## Validation
- Markdown-only documentation change.
- Verified the requested target path did not already contain `zecmap.md` before submission.
- Checked recent/open PR metadata for obvious ZecMap duplicates before opening this PR.

## Notes
This is submitted for the `0.2 ZEC` ZecMap wiki page bounty in #1653.