### PR TITLE
docs(wiki): add ZecMap merchant directory wiki page

### DIFF
--- a/site/Using_Zcash/zecmap.md
+++ b/site/Using_Zcash/zecmap.md
@@ -1,0 +1,128 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecMap
+
+## TL;DR
+
+- **ZecMap** is a global, community-maintained directory of businesses and services that accept Zcash (ZEC) as payment
+- **Map-based discovery**: find ZEC-accepting merchants near you or anywhere in the world using an interactive geographic interface
+- **Anyone can contribute**: submit a new business listing, verify existing ones, and earn ZEC through the Contributor Rewards Program
+- **Free to list**: merchants pay nothing to be added — the directory grows entirely through community effort
+- **Built for the Zcash ecosystem**: direct integration with ZecHub Wiki and aligned with the goal of making shielded ZEC a practical everyday currency
+
+---
+
+## What Is ZecMap?
+
+[ZecMap](https://zecmap.com/) is an open, community-driven merchant directory for the Zcash ecosystem. It solves a simple but important problem: if you want to spend your ZEC, where can you actually use it?
+
+ZecMap aggregates businesses — local shops, online stores, freelancers, service providers — that have indicated they accept ZEC. Each listing is placed on an interactive world map so users can quickly locate Zcash-friendly businesses near them or while traveling.
+
+The project is community-maintained: there is no central company curating the directory. Instead, contributors submit, verify, and keep listings accurate through a structured rewards program that pays out ZEC for quality contributions.
+
+---
+
+## Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **Interactive Map** | Browse businesses geographically; filter by category or location |
+| **Business Listings** | Name, description, category, accepted payment methods, and contact info |
+| **User Accounts** | Create a profile to track your submissions and contribution history |
+| **Contributor Profiles** | Public reputation system showing your verified contributions |
+| **Contributor Rewards** | Earn ZEC for adding and verifying listings — see the rewards section below |
+| **Search & Filter** | Find merchants by name, category (food, services, retail, online), or location |
+
+---
+
+## Use Cases
+
+### Finding Merchants
+
+- **Local spending**: open ZecMap before visiting a new city to find cafes, shops, or services that accept ZEC
+- **Online shopping**: filter for "online" businesses to find stores where you can check out with ZEC from anywhere
+- **Services**: find freelancers, contractors, or professional services that invoice in ZEC — great for privacy-preserving business payments
+- **Community businesses**: discover Zcash-native projects (wallets, tools, services built around the ecosystem) that naturally accept ZEC
+
+### For Merchants
+
+ZecMap is a free, low-effort way to signal to the Zcash community that you accept ZEC. Being listed exposes your business to users actively looking to spend their ZEC, with no listing fees and no ongoing maintenance required beyond keeping your information accurate.
+
+---
+
+## How to Add a Business
+
+1. **Visit [zecmap.com](https://zecmap.com/)** and create a contributor account
+2. **Click "Add Business"** (or use the submission form)
+3. **Fill in the listing details:**
+   - Business name, category, and description
+   - Location (physical address or "online only")
+   - Contact information and website
+   - Payment methods accepted (ZEC transparent, ZEC shielded/unified address, etc.)
+4. **Submit for review** — the community verifies new submissions before they go live
+5. **Track your submission** via your contributor profile
+
+There is no cost to submit a listing. The directory is governed by community standards for accuracy and legitimacy.
+
+---
+
+## Listing Verification and Approval
+
+ZecMap uses a community-driven verification process to maintain directory quality:
+
+1. **Submission**: a contributor submits a new business with supporting details
+2. **Peer review**: other contributors check whether the business actually accepts ZEC (e.g., by visiting the website, checking payment options, or contacting the merchant)
+3. **Approval**: once verification passes, the listing goes live on the map
+4. **Ongoing accuracy**: listings can be flagged as outdated or incorrect; contributors earn rewards for keeping data current
+
+This process keeps the directory trustworthy without requiring a central authority to manually validate every entry.
+
+---
+
+## Contributor Rewards Program
+
+ZecMap's Contributor Rewards Program pays ZEC directly to contributors for useful work on the directory. This aligns economic incentives with directory quality: the more accurate and comprehensive the map, the more valuable it is to the ecosystem.
+
+**How to earn:**
+- Add new, verified business listings
+- Verify or update existing listings with stale information
+- Report incorrect entries so they can be corrected or removed
+
+Reward amounts and specific criteria are managed on the ZecMap platform. Check [zecmap.com](https://zecmap.com/) and the [Zcash forum announcement thread](https://forum.zcashcommunity.com/t/zecmap-contributor-rewards-program-is-live/55714) for the current reward schedule.
+
+---
+
+## Role of Community Contributors
+
+ZecMap is only as useful as its data. Because there is no paid team constantly adding listings, the directory depends on Zcash community members to:
+
+- **Discover and add** merchants who accept ZEC but aren't listed yet
+- **Verify** that existing listings are still accurate (businesses close, change payment methods, etc.)
+- **Expand** coverage to underrepresented regions and languages
+- **Flag** spam or listings for businesses that no longer accept ZEC
+
+This community-curation model mirrors how projects like OpenStreetMap work: a distributed network of contributors building something more complete than any single organization could maintain alone.
+
+---
+
+## Future Development Plans
+
+ZecMap's roadmap includes:
+
+- **Mobile apps** (iOS and Android) for on-the-go merchant discovery
+- **Multilingual support** to serve the global Zcash community in their native language
+- **Payment integration** — direct ZEC payment flows from within the app
+- **Contributor ranking** — a leaderboard system for top contributors
+- **Directory expansion** — campaigns to grow listings in undercovered regions, particularly in Africa, Latin America, and Southeast Asia where ZEC adoption is growing
+
+---
+
+## Related Pages
+
+- [Wallets](/using-zcash/wallets) — Download a Zcash wallet to spend ZEC at the merchants you find on ZecMap
+- [Payment Processors](/using-zcash/payment-processors) — Tools merchants use to accept ZEC payments
+- [Transactions](/using-zcash/transactions) — How Zcash transactions work when paying at a merchant
+- [Using ZEC Privately](/using-zcash/using-zec-privately) — Best practices for shielded payments at merchants
+- [What is ZEC and Zcash](/start-here/what-is-zec-and-zcash) — Introduction to Zcash and its use as a payment currency


### PR DESCRIPTION
## Summary

Adds `site/Using_Zcash/zecmap.md` — a comprehensive wiki page covering the ZecMap global Zcash merchant directory.

### Content covered

- **What ZecMap is**: community-driven global directory of ZEC-accepting businesses
- **Key features table**: interactive map, business listings, contributor profiles, rewards program, search/filter
- **Use cases**: local spending, online shopping, services, community businesses, and merchant listing benefits
- **How to add a business**: 5-step submission walkthrough
- **Listing verification**: community peer-review process for accuracy
- **Contributor Rewards Program**: earning ZEC for adding/verifying listings — links to the live forum announcement
- **Community contributor model**: OpenStreetMap-style distributed curation
- **Future roadmap**: mobile apps, multilingual support, payment integration, contributor ranking
- **Related Pages**: 5 cross-links to Wallets, Payment Processors, Transactions, Using ZEC Privately, What is ZEC

### Format

Follows ZecHub wiki conventions: edit badge, TL;DR bullets, section headers with `##`, feature table, step-by-step guide, and Related Pages.

Closes #1653
Closes #1654