### PR TITLE
Add ZecMap wiki page

### DIFF
--- a/site/Using_Zcash/zecmap.md
+++ b/site/Using_Zcash/zecmap.md
@@ -1,0 +1,89 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecMap
+
+ZecMap is a community-focused map and directory for discovering businesses that accept Zcash. It helps ZEC users move from "where can I spend it?" to a concrete list of places, services, shops, and online businesses that can be checked from one map-based interface.
+
+The directory is useful for both sides of a payment. Customers can find merchants that already accept ZEC, and businesses can make themselves easier to discover by adding an accurate listing.
+
+## What ZecMap Does
+
+ZecMap organizes Zcash-accepting businesses on a global map. A listing can help users understand where a business is located, what category it belongs to, and how it can be contacted before they try to pay with ZEC.
+
+Typical use cases include:
+
+- Finding a nearby cafe, restaurant, hotel, local shop, or service provider that accepts ZEC.
+- Checking whether an online store, VPN provider, freelancer, or digital service accepts Zcash.
+- Discovering regional Zcash adoption by browsing a city, country, or travel route.
+- Helping community members keep merchant data current as new businesses begin accepting ZEC.
+
+## How Users Can Find Zcash Merchants
+
+Users can open [ZecMap](https://zecmap.com/) and search the map for businesses that accept Zcash. Map-based browsing is helpful when location matters, such as travel, local shopping, or finding a nearby service.
+
+For online merchants, ZecMap can still be useful as a directory. Users can browse listings by business type, check the business profile, and follow the listed website or contact details.
+
+Before paying, users should still confirm the payment method with the merchant. Some businesses may support transparent ZEC, shielded ZEC, third-party payment processors, or a manual payment flow.
+
+## Adding a Business
+
+Businesses and community contributors can add merchants to the directory through ZecMap. A good listing should include enough information for another user to verify it:
+
+- Business name.
+- Website or social profile.
+- Location for physical businesses, or service region for online businesses.
+- Business category.
+- Clear evidence that the business accepts Zcash.
+- Any payment notes that help users know how to pay.
+
+Accurate listings are more useful than large numbers of weak entries. Duplicate, fake, inactive, or unverifiable businesses should not be submitted.
+
+## Submission, Verification, and Approval
+
+ZecMap uses a review process before listings are treated as reliable. The exact review flow may change over time, but the goal is straightforward: keep the directory useful and reduce spam.
+
+A typical submission flow is:
+
+1. A user signs in or creates an account.
+2. The user submits a business listing with contact and payment details.
+3. The listing is reviewed for quality, duplicates, and evidence that the merchant accepts ZEC.
+4. Approved businesses become visible in the public directory.
+5. Listings can be updated as business details or payment support changes.
+
+This review process protects users from stale or misleading entries and gives businesses a cleaner way to be found by Zcash customers.
+
+## Role of Community Contributors
+
+ZecMap depends on local knowledge. Community contributors can help by adding merchants they personally know, checking older listings, reporting duplicates, and improving incomplete business profiles.
+
+Good contributors do more than add names to a map. They help answer practical questions:
+
+- Is the business still operating?
+- Does it still accept ZEC?
+- Is the payment flow clear to a new customer?
+- Are the website, address, and category accurate?
+
+This kind of maintenance makes the directory more valuable for everyday Zcash use.
+
+## Key Features
+
+- Global map-based merchant discovery.
+- Business listings for local and online ZEC-accepting merchants.
+- User accounts for submitting and maintaining entries.
+- Contributor profiles and community participation.
+- Searchable merchant data for people who want to spend ZEC.
+- A review process for improving listing quality.
+
+## Contributor Rewards Program
+
+The ZecMap Contributor Rewards Program rewards users for adding approved businesses that accept Zcash. The program announced rewards of $10 worth of ZEC per approved business, with a maximum of two rewarded submissions per user and a cap for the first 100 eligible users.
+
+Reward programs can change, so contributors should check the current ZecMap announcement or website before submitting. Quality still matters: duplicate, fake, or unverified listings may not qualify.
+
+## Future Development
+
+Future improvements may include mobile apps, multilingual support, payment integrations, contributor ranking, and a broader merchant directory. These additions would make ZecMap easier to use while helping the Zcash community track real-world adoption.
+
+The long-term value of ZecMap is practical: it gives users a place to find where ZEC is accepted and gives merchants a simple way to be discovered by people who want to pay with Zcash.


### PR DESCRIPTION
Addresses #1653 and #1654. 

Summary:
- adds a ZecMap wiki page under site/Using_Zcash
- explains merchant discovery, business submissions, verification, contributor maintenance, key features, rewards, and future development
- keeps the page practical for users who want to find or add ZEC-accepting businesses

Verification:
- checked the requested output path and file name
- checked the page covers every bullet in the issue description
- reviewed markdown locally for structure and link formatting