### PR TITLE
Add May 23 Zcash Ecosystem Digest

### DIFF
--- a/newsletter/Digest 05-23-2026.md
+++ b/newsletter/Digest 05-23-2026.md
@@ -1,0 +1,68 @@
+# Zcash Ecosystem Digest | May 23rd, 2026
+
+This week covers NU7 polling, ZCG election preparation, retroactive grant review, wallet and DeFi updates, and regional community activity across the Zcash ecosystem.
+
+Curated by [gshaowei6](https://github.com/gshaowei6)
+
+## Zcash Ecosystem Weekly Updates
+
+### Shielded Labs, Electric Coin Company, Zcash Foundation Updates
+
+- [Shielded Labs Crosslink deployment updates](https://forum.zcashcommunity.com/t/shielded-labs-crosslink-deployment-updates/49706) - The Crosslink thread continues to collect milestone and feature-net updates from Shielded Labs.
+- [Zcash Foundation assumes stewardship of core community assets](https://forum.zcashcommunity.com/t/zcash-foundation-assumes-stewardship-of-core-zcash-community-assets/55623) - ZF announced stewardship of the Zcash GitHub organization, z.cash, and the @Zcash handle, with ZecHub handling day-to-day community asset work.
+- [ZF Engineering Update: April 20th to May 3rd, 2026](https://forum.zcashcommunity.com/t/zf-engineering-update-april-20th-may-3rd-2026/55618) - ZF shared engineering updates across Zebra, FROST, benchmarking, infrastructure, and the Z3 repository.
+- [ECC blog posts restored](https://forum.zcashcommunity.com/t/ecc-blog-posts-restored/55665) - Community members noted that Electric Coin Company blog archives are available again.
+- [NU7 Sentiment Polling: Questions for Community Review and Coinholder Voting via Zodl](https://forum.zcashcommunity.com/t/nu7-sentiment-polling-questions-for-community-review-coinholder-voting-via-zodl/55713) - Community review opened for NU7 sentiment questions and Zodl-based coinholder voting.
+- [Zcash Z3 updates, formerly zcashd deprecation](https://forum.zcashcommunity.com/t/zcash-z3-updates-formerly-zcashd-deprecation/48965) - The Z3 infrastructure thread continues tracking work around the post-zcashd stack.
+- [Zcash Community Grants nominations are open for the June election](https://forum.zcashcommunity.com/t/zcash-community-grants-zcg-nominations-now-open-for-june-election/55720) - FPF posted the nomination process, deadlines, and ZCG election timeline.
+- [Coinholder-Directed Retroactive Grants Q2 review period is open](https://forum.zcashcommunity.com/t/coinholder-directed-retroactive-grants-program-q2-2026-30-day-review-period-now-open/55701) - The 30-day public review window is open before the June coinholder poll.
+- [ZODL Q1 2026 core protocol retroactive grant application](https://forum.zcashcommunity.com/t/retroactive-grant-application-zodl-q1-2026-core-protocol-development/55700) - ZODL summarized completed Q1 work across librustzcash, Zallet, SDKs, ZIPs, R&D, and protocol maintenance.
+
+---
+
+### Zcash Community Grants
+
+- [Zcash Community Grants Meeting Minutes 5/11/2026](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-5-11-2026/55677) - ZCG published the latest grant decisions and committee discussion notes.
+- [Zcash community: Hello from KeepKey](https://forum.zcashcommunity.com/t/zcash-community-hello-from-keepkey/55711) - KeepKey introduced its Zcash work and community-facing hardware wallet direction.
+- [Tachyon-Lite: Light-client SDK and sync/proof server for Zcash](https://forum.zcashcommunity.com/t/grant-proposal-tachyon-lite-light-client-sdk-and-sync-proof-server-for-zcash/55671) - A grant proposal describes a light-client SDK and sync infrastructure for Zcash apps.
+- [Rhea Finance - Zcash Gateway](https://forum.zcashcommunity.com/t/rhea-finance-zcash-gateway-browser-wallet-cross-chain-defi/55073) - Rhea continues discussion around a browser wallet and cross-chain DeFi gateway for ZEC.
+- [Rore - High-Performance Rust UI Engine for Zcash Desktop Clients](https://forum.zcashcommunity.com/t/rore-high-performance-rust-ui-engine-for-zcash-desktop-clients/55634) - The Rore proposal targets a Rust UI engine for privacy-focused Zcash desktop clients.
+- [Open-source Zcash hardware-wallet SDK](https://forum.zcashcommunity.com/t/application-for-coinholder-directed-retroactive-grants-program-q2-2026-open-source-zcash-hardware-wallet-sdk/55550) - A retroactive grant application covers a vendor-neutral Orchard hardware-wallet SDK.
+- [THORSwap/Metro retroactive grant application](https://forum.zcashcommunity.com/t/retroactive-grant-application-thorswap-metro/55675) - THORSwap and Metro requested retroactive recognition for ZEC cross-chain swap and wallet support.
+- [Cypherpunk Policy Dinner ZCG anchor sponsorship](https://forum.zcashcommunity.com/t/cypherpunk-policy-dinner-cpd-zcg-anchor-sponsorship/55592) - A sponsorship proposal would place Zcash and financial privacy in a policy-focused dinner program.
+- [Zcash Network School](https://forum.zcashcommunity.com/t/zcash-network-school/55269) - The Network School proposal continues gathering community feedback for a Zcash hub in Malaysia.
+- [Educational Campaign by Incrypted](https://forum.zcashcommunity.com/t/grant-application-educational-campaign-by-incrypted/55721) - Incrypted submitted a new education-focused application.
+- [Zcash CIS Educational Media Initiative 2026](https://forum.zcashcommunity.com/t/grant-application-zcash-cis-educational-media-initiative-2026-3-month/55718) - A CIS regional media initiative was posted for community review.
+
+---
+
+### Community Projects
+
+- [Zecmap Contributor Rewards Program is live](https://forum.zcashcommunity.com/t/zecmap-contributor-rewards-program-is-live/55714) - Zecmap opened rewards for verified business submissions that accept ZEC.
+- [ZecVault, a goal-based savings wallet built on shielded transactions](https://forum.zcashcommunity.com/t/zecvault-a-goal-based-savings-wallet-built-on-zcash-shielded-transactions/55464) - ZecVault is collecting feedback on shielded goal-based savings vaults.
+- [Introducing Overpay.com: Spend ZEC Anywhere alpha](https://forum.zcashcommunity.com/t/introducing-overpay-com-spend-zec-anywhere-alpha/54798) - Overpay shared an alpha for spending ZEC with broader merchant reach.
+- [Introducing Zcash Grants Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267) - Zcash Grants Hub aggregates ZCG, coinholder grants, and ZecHub DAO proposals in one interface.
+- [New Version of Zingo-PC](https://forum.zcashcommunity.com/t/new-version-of-zingo-pc/45359) - ZingoLabs continues posting updates for the Zingo-PC wallet.
+- [Zcash Espanol X account suspended](https://forum.zcashcommunity.com/t/zcash-en-espanol-x-account-suspended/55685) - Zcash en Espanol alerted other regional communities after its X account was suspended.
+- [Vizor wallet has launched, but needs community help](https://forum.zcashcommunity.com/t/vizor-wallet-has-launched-but-we-need-your-help/55719) - Vizor announced launch progress and asked the community for help.
+- [Teenagers in Blockchain Africa: Zcash youth privacy and developer education](https://forum.zcashcommunity.com/t/teenagers-in-blockchain-africa-tiba-zcash-teenage-and-youth-privacy-developer-education-initiative/55498) - TIBA is seeking support for youth privacy and developer education.
+- [Pesa Ya Siri: Making Zcash a household name in Tanzania](https://forum.zcashcommunity.com/t/pesa-ya-siri-making-zcash-a-household-name-in-tanzania/55558) - The Tanzania proposal focuses on WhatsApp-based onboarding, local agents, and everyday payments.
+- [ZcashArabia May to September 2026](https://forum.zcashcommunity.com/t/grant-zcasharabia-may-to-september-2026/55548) - The Arabic-speaking community proposal focused on education and regional engagement.
+- [Zcash Gold Sponsorship Kenya at KBCC 2026](https://forum.zcashcommunity.com/t/zcash-gold-sponsorship-kenya-kbcc-2026-activation-privacy-workshop/55520) - The Kenya proposal aims to place Zcash at KBCC 2026 and run a privacy workshop in Nairobi.
+- [Introducing Zcash to Kenyan Universities & Tech Communities 2026](https://forum.zcashcommunity.com/t/introducing-zcash-to-kenyan-universities-tech-communities-2026/55088) - The Zcash East Africa education proposal remains a useful reference for Zcash outreach across Kenyan universities and developer communities.
+- [Zcash University Outreach Initiative Mexico 2026](https://forum.zcashcommunity.com/t/zcash-university-outreach-initiative-mexico-2026-coderaiz-proposal/55506) - CodeRaiz proposed structured Zcash university outreach across Mexico.
+- [Zush: Quiet Money for Zcash, Phase 1](https://forum.zcashcommunity.com/t/grant-application-zush-quiet-money-for-zcash-phase-1/55458) - Zush is a proposal for a quiet-money product experience around Zcash.
+- [Zcash Korea Ambassador Proposal](https://forum.zcashcommunity.com/t/zechub-dao-zcash-korea-ambassador-proposal-approved/50498) - The Zcash Korea ambassador thread tracks Korean-language updates, social channels, and community engagement work.
+- [ruZcash community account](https://x.com/ruZCASH) - ruZcash continues serving Russian-language Zcash education and discussion on X.
+- [Zcash Community Media Infrastructure & Support | ZKAV Club 2026](https://forum.zcashcommunity.com/t/zcash-community-media-infrastructure-support-zk-av-club-2026/53913) - Zk Av Club continues its 2026 media infrastructure work for recordings, publishing workflows, and community media support.
+- [Zcast, the Zcash podcast in Spanish - A new phase](https://forum.zcashcommunity.com/t/zcast-the-zcash-podcast-in-spanish-a-new-phase/54291) - Zcast and Zcash en Espanol are expanding Spanish and English interview and livestream work.
+- [Zcash Brazil joining Ipe Village](https://forum.zcashcommunity.com/t/zcash-brazil-is-joining-ipe-village-brazils-largest-pop-up-city/54930) - Zcash Brazil continued regional work around Ipe Village and network-state style communities.
+- [Zcash Global Turkish 2026 Q1-Q2](https://forum.zcashcommunity.com/t/zcash-global-turkish-2026-q1-2/53945) - Zcash Turkey continued education and regional community activity for 2026.
+- [Zcash Ukraine Regional Community Initiative](https://forum.zcashcommunity.com/t/zcash-ukraine-regional-community-initiative/52330) - Zcash Ukraine continues regional education, local content, and offline meetup work.
+- [Zcash Nigeria 2026](https://forum.zcashcommunity.com/t/zcash-nigeria-2026/53654) - Zcash Nigeria shared continuing monthly activity reports and local onboarding plans.
+
+---
+
+### Meme of the week
+
+- [genzcash: Nothing More American](https://forum.zcashcommunity.com/t/nothing-more-american/55642) - genzcash shared a short Zcash meme that the community picked up on the forum this month.


### PR DESCRIPTION
Addresses #1650.

Summary:
- adds the May 23rd Zcash Ecosystem Digest in the requested newsletter directory
- includes 40+ public ecosystem links across Shielded Labs, ECC, ZF, ZCG, regional communities, ZecHub, Zecmap, ZKAV Club, Zcast, and meme coverage
- keeps descriptions short, in English, and matched to the linked activity for easier translation

Verification:
- checked the requested newsletter file path and markdown format
- checked all requested sections are present
- counted 20+ community/project links
- checked coverage for the issue's named communities and ecosystem sources
