### PR TITLE
Add ZecMap wiki page (closes #1654)

### DIFF
--- a/site/Using_Zcash/zecmap.md
+++ b/site/Using_Zcash/zecmap.md
@@ -1,0 +1,175 @@
+<a href="https://github.com/ZecHub/zechub/edit/main/site/Using_Zcash/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecMap
+
+<img width="1396" height="676" alt="ZecMap Interface" src="https://global.discourse-cdn.com/zcash/original/3X/6/8/68988d5b11f3716dd9c066a05af512911b0a2299.jpeg"/>
+
+ZecMap is a global, map-based directory that helps users discover businesses accepting Zcash (ZEC). The platform is designed to make real-world Zcash adoption accessible by allowing anyone to find and verify merchants that support privacy-focused payments.
+
+**Website**: [zecmap.com](https://zecmap.com/)
+
+---
+
+## What is ZecMap?
+
+ZecMap is a community-verified global directory of merchants, service providers, and businesses that accept Zcash. Unlike centralized databases, ZecMap relies on crowd-sourced submissions and community verification to maintain accurate, up-to-date listings.
+
+The platform serves two main purposes:
+- **For users**: Find real-world locations and online businesses where you can spend your ZEC
+- **For businesses**: Get listed in a growing directory of Zcash-accepting merchants
+
+---
+
+## Finding Zcash Merchants
+
+ZecMap provides an intuitive interface to search for businesses by location or category. Here's how to use it:
+
+1. Visit [zecmap.com](https://zecmap.com/) and allow location access (or search manually)
+2. Browse the interactive map for nearby merchants
+3. Click on business markers to view details including:
+   - Business name and category
+   - Address and distance from your location
+   - Verification status (Verified/Unverified)
+   - Contact information if available
+
+### Supported Business Categories
+
+You can find the following types of businesses on ZecMap:
+
+| Category | Examples |
+|----------|----------|
+| Restaurants & Cafés | Coffee shops, bistros, food stands |
+| Hotels & Travel | Accommodation, tour operators |
+| VPN & Privacy Services | Security tools, privacy-focused services |
+| Online Stores | E-commerce sites, digital goods vendors |
+| Local Shops | Retail stores, service providers |
+| Freelance/Digital Services | Contractors, consultants, developers |
+
+---
+
+## Adding a Business
+
+Adding a business to ZecMap takes approximately one minute. Here's the process:
+
+### Step 1: Create an Account
+1. Visit [zecmap.com](https://zecmap.com/)
+2. Register with a unique username and password
+3. Note: Usernames are one-time only and will be important for future payment integrations
+
+### Step 2: Submit Business Details
+When adding a listing, you'll provide:
+- Business name and type
+- Physical address or website URL
+- Category selection
+- Contact information
+- Any relevant notes about Zcash payment options
+
+### Step 3: Submission Review
+- All submissions are reviewed by the ZecMap team before going live
+- Duplicate, fake, or unverified submissions will be rejected
+- High-quality, accurate listings are prioritized
+
+---
+
+## Verification Process
+
+ZecMap uses a community verification system to maintain data quality:
+
+1. **User submissions** - Community members add new businesses
+2. **Team review** - Submissions are checked for accuracy
+3. **Verification badge** - Approved businesses receive a "Verified" mark
+4. **Community feedback** - Users can report outdated or incorrect listings
+
+Verified listings display a badge on the map, helping users identify trustworthy merchants.
+
+---
+
+## Contributor Rewards Program
+
+ZecMap actively rewards community contributors who help expand the merchant network.
+
+### Reward Structure
+- **$10 worth of ZEC** per approved business listing
+- Maximum **2 rewarded submissions per user**
+- Limited to the **first 100 eligible users**
+
+### Eligibility Requirements
+To qualify for rewards:
+- Business must be successfully approved and live on ZecMap
+- Each user can earn rewards for maximum 2 businesses
+- Submissions must be legitimate (no duplicates, fake entries, or unverified claims)
+- Spam or low-quality submissions will not be rewarded
+
+### How to Participate
+1. Register at [zecmap.com](https://zecmap.com/)
+2. Add a verified business that accepts Zcash
+3. Wait for approval
+4. Receive your ZEC reward
+
+---
+
+## User Accounts and Profiles
+
+Registered users on ZecMap can:
+
+- **Track contributions**: View all businesses you've added
+- **Build reputation**: Establish yourself as a Zcash ecosystem contributor
+- **Earn recognition**: Higher contribution scores unlock future benefits
+
+After approval, your submitted businesses appear on your public profile, showcasing your impact on the Zcash community.
+
+---
+
+## Future Development
+
+ZecMap has an active development roadmap targeting Q4 2026:
+
+### Mobile Apps
+- **Android app** - Coming soon
+- **iOS app** - Coming soon
+
+### Multilingual Support
+Currently available in:
+- English
+- Turkish
+
+Additional language integrations are planned for upcoming releases.
+
+### Payment Integration
+Future versions will enable direct Zcash payments through user accounts, making usernames increasingly valuable.
+
+### Contributor Features
+- **Ranking system**: Contributors will be ranked by the number of approved listings
+- **Top contributor rewards**: Planned distribution of rewards to active community members
+
+### Growth Target
+The project aims to list **1,000+ businesses** by Q4 2026.
+
+---
+
+## Key Features Summary
+
+| Feature | Description |
+|---------|-------------|
+| Global Map Directory | Interactive map showing Zcash merchants worldwide |
+| Business Listings | Detailed info including address, category, verification status |
+| User Accounts | Register, track contributions, build contributor profile |
+| Community Verification | Multi-step review process ensures data accuracy |
+| Contributor Rewards | Earn ZEC for approved business submissions |
+| Mobile-Ready | Web app accessible on all devices |
+| Privacy-First | Community-driven, no tracking |
+
+---
+
+## Related Links
+
+- **ZecMap Website**: [https://zecmap.com/](https://zecmap.com/)
+- **Zcash Official Site**: [https://z.cash/](https://z.cash/)
+- **Zcash Forum Discussion**: [ZECMAP Announcement](https://forum.zcashcommunity.com/t/zecmap-global-zcash-merchant-directory/55686)
+- **Contributor Rewards Announcement**: [ZecMap Rewards Program](https://forum.zcashcommunity.com/t/zecmap-contributor-rewards-program/55714)
+
+---
+
+*Help grow the Zcash economy by adding businesses you know that accept ZEC!*


### PR DESCRIPTION
## Summary

This PR adds a comprehensive ZecMap wiki page to the ZecHub documentation.

### Content covers:
- What ZecMap is and its core functionality
- How to find Zcash merchants on the platform
- Supported business categories
- Step-by-step guide to adding businesses
- Verification and approval process
- Community contributor roles
- **Contributor Rewards Program details** ($10 ZEC per approved business, max 2 per user, first 100 users)
- Future development roadmap (mobile apps, multilingual support, payment integration)
- Key features summary

### Verification:
- [x] File location: `site/Using_Zcash/zecmap.md`
- [x] All required topics from issue #1654 covered
- [x] Links verified and working
- [x] Format matches existing wiki pages (Faucets.md, Payment_Processors.md)

Closes #1654