### PR TITLE
docs: explain post-quantum security in Zcash

### DIFF
--- a/site/Research/Understanding_Post_Quantum_Security_in_Zcash.md
+++ b/site/Research/Understanding_Post_Quantum_Security_in_Zcash.md
@@ -1,0 +1,234 @@
+---
+published: 2026-05-19
+---
+
+<a href="https://github.com/ZecHub/zechub/edit/main/site/Research/Understanding_Post_Quantum_Security_in_Zcash.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Understanding Post-Quantum Security in Zcash
+
+Quantum computing sounds distant and complicated, but the basic security question is simple:
+
+> What happens to today's cryptography if future computers become powerful enough to solve problems that normal computers cannot solve?
+
+For blockchains, this matters because coins, addresses, signatures, privacy systems, and wallets all depend on cryptography. Zcash is especially interesting because it is built around privacy-focused cryptography, including zero-knowledge proofs.
+
+This article explains the topic in beginner-friendly terms.
+
+---
+
+## What is quantum computing?
+
+A normal computer stores information as bits: `0` or `1`.
+
+A quantum computer uses quantum bits, usually called qubits. A qubit can behave in ways that let some calculations be explored very differently from a normal computer.
+
+That does not mean a quantum computer is automatically faster for everything. It means that for some special math problems, a large enough quantum computer could be much faster than the computers we use today.
+
+The important part for crypto users is this:
+
+- Some cryptography is believed to remain safe against quantum computers.
+- Some public-key cryptography could be broken by a large enough quantum computer.
+- Today's practical quantum computers are not powerful enough to break major blockchains, but serious projects plan ahead because protocol upgrades take time.
+
+---
+
+## Why blockchains care about quantum computers
+
+Blockchains depend on cryptography for several jobs:
+
+- **Signatures** prove that the owner of a coin approved a transaction.
+- **Addresses and keys** let people receive and spend funds.
+- **Hash functions** help secure transaction history and commitments.
+- **Zero-knowledge proofs** let Zcash verify private transactions without revealing private details.
+
+A future quantum computer could affect these parts in different ways.
+
+### Signatures
+
+Many blockchains use signatures based on elliptic curve cryptography. If a future quantum computer can solve the elliptic curve discrete logarithm problem at practical scale, it could threaten those signatures.
+
+In simple terms, a public key is like a public lock, and a private key is like the secret key that opens it. Some older public-key systems rely on math where normal computers cannot easily reverse the public lock back into the secret key. A powerful enough quantum computer could change that assumption.
+
+### Hashes
+
+Hash functions are usually less directly threatened. Quantum algorithms can give attackers a speedup against some hash searches, but this is not the same as instantly breaking every hash. Systems can often respond by using larger security margins.
+
+### Privacy systems
+
+Zcash adds another important layer: shielded transactions. These use zero-knowledge proofs and encrypted note data so the network can check that a transaction is valid without publicly showing the sender, receiver, or amount.
+
+Because privacy systems use several cryptographic building blocks together, post-quantum planning for Zcash is more complex than just replacing one signature algorithm.
+
+---
+
+## What is post-quantum cryptography?
+
+Post-quantum cryptography means cryptography designed to resist attacks from both normal computers and future quantum computers.
+
+It does not mean "magic unbreakable cryptography." It means researchers choose math problems that are not known to be efficiently solved by quantum computers.
+
+In 2024, NIST approved the first three federal post-quantum cryptography standards:
+
+- **FIPS 203: ML-KEM**, for key establishment.
+- **FIPS 204: ML-DSA**, for digital signatures.
+- **FIPS 205: SLH-DSA**, also for digital signatures.
+
+These standards are important because they give governments, companies, and open-source projects concrete algorithms to study and implement. For blockchains, however, using post-quantum cryptography is not always a simple drop-in replacement. Bigger keys, bigger signatures, wallet changes, hardware-wallet support, consensus rules, and user migration all matter.
+
+---
+
+## Is Zcash post-quantum today?
+
+The safest simple answer is:
+
+**Zcash is not fully post-quantum today.**
+
+That does not mean Zcash is broken today. It means that Zcash, like most major blockchains, still uses cryptographic assumptions that could be affected by future large-scale quantum computers.
+
+Zcash research has discussed post-quantum security for years. A long-running Zcash ZIPs issue describes three broad pieces needed for a fully post-quantum Zcash:
+
+1. A plausibly post-quantum public-key encryption scheme.
+2. A fresh look at symmetric cryptography and hash security margins.
+3. A practical post-quantum zero-knowledge proof system.
+
+That third point is one reason this is difficult. Zcash is not just a payment chain with signatures. It is a privacy protocol, so any future upgrade must preserve privacy, correctness, and supply integrity at the same time.
+
+---
+
+## How Zcash is preparing
+
+One current research direction is **Orchard Quantum Recoverability**, described in draft ZIP 2005.
+
+The wording is important:
+
+- It is **quantum recoverability**, not full quantum resistance.
+- It focuses on making Orchard funds easier to recover into a future post-quantum protocol if the current Orchard protocol ever had to be disabled.
+- It does not, by itself, make Zcash fully secure against quantum attackers.
+- It does not solve every privacy question.
+
+The idea is to prepare today's Orchard notes so that, if a future post-quantum transition is needed, users have a better path to recover funds safely.
+
+Think of it like packing a suitcase before a storm arrives. Packing the suitcase does not stop the storm. It makes it easier to move when moving becomes necessary.
+
+---
+
+## Why privacy-focused cryptography matters
+
+Most blockchains reveal a lot of information by default. People can often see addresses, amounts, transaction timing, and transaction links.
+
+Zcash was created to give users stronger financial privacy. Shielded Zcash transactions can hide sender, receiver, and amount while still letting the network verify that no one is cheating.
+
+That privacy is not only a nice feature. It protects people from:
+
+- public financial surveillance,
+- address profiling,
+- business payment leaks,
+- personal safety risks,
+- and long-term chain analysis.
+
+Post-quantum planning matters for Zcash because privacy should not only work today. The goal is to keep privacy and funds safe across many years of future technology changes.
+
+---
+
+## Possible future upgrade approaches
+
+There is no single button that makes a blockchain post-quantum. A realistic Zcash transition may involve several parts:
+
+### 1. Post-quantum signatures
+
+Zcash could use signature schemes that are designed to resist quantum attacks. This would help protect transaction authorization.
+
+The challenge is that post-quantum signatures can be larger than today's signatures. Larger signatures can increase transaction size, bandwidth, storage, and wallet complexity.
+
+### 2. Post-quantum key agreement or encryption
+
+Shielded payments use encrypted note data so the receiver can detect and spend their funds. Future designs may need post-quantum-safe ways to protect this encrypted information.
+
+### 3. Post-quantum zero-knowledge proofs
+
+Zcash needs proof systems that can verify private transactions without revealing private data. A future post-quantum Zcash would need practical proof systems with the right security assumptions and performance.
+
+### 4. Recovery paths for old funds
+
+If users already have funds in older pools, the network needs a safe way to move value forward. Orchard Quantum Recoverability is one example of planning ahead for that problem.
+
+### 5. Gradual migration
+
+Most real upgrades happen gradually. Wallets need updates. Exchanges need support. Hardware wallets need testing. Users need clear instructions. The safest path is usually staged and well-reviewed.
+
+---
+
+## Simple examples
+
+### Example 1: A signature is like a seal
+
+When you send ZEC, your wallet creates a signature. It is like sealing a letter with a stamp only you can make.
+
+If the signature system became weak, someone might be able to fake the seal. Post-quantum signatures try to make a seal that future quantum computers cannot fake.
+
+### Example 2: Shielded privacy is like a sealed envelope
+
+A shielded Zcash transaction is like putting payment details inside a sealed envelope, then proving to the network that the envelope follows the rules without opening it.
+
+Post-quantum planning asks: can this sealed-envelope system remain safe if future computers become much stronger?
+
+### Example 3: Migration is like changing locks
+
+If a building needs stronger locks, people need time to replace old locks, copy keys, and make sure every door still works.
+
+Blockchains face a similar problem. It is not enough to invent better cryptography. The ecosystem must migrate safely.
+
+---
+
+## Main challenges
+
+Post-quantum upgrades are hard because they affect the whole system.
+
+Important challenges include:
+
+- **Bigger data sizes:** post-quantum keys and signatures may be larger.
+- **Wallet support:** users need wallets that understand the new rules.
+- **Hardware wallets:** secure devices must support new algorithms safely.
+- **Consensus changes:** network upgrades must be carefully reviewed.
+- **Privacy analysis:** Zcash must preserve privacy, not only spendability.
+- **Old funds:** users need a safe path from older pools to newer pools.
+- **Education:** users need simple explanations so they do not panic or fall for scams.
+
+---
+
+## What users should do now
+
+For normal users, the best approach is calm preparation:
+
+- Keep wallets updated.
+- Follow official Zcash upgrade information.
+- Prefer modern shielded wallet practices.
+- Do not trust anyone who says you must urgently send funds to a new address because of "quantum risk."
+- Learn the difference between full quantum resistance and quantum recoverability.
+
+Quantum risk is a long-term planning problem, not a reason to panic today.
+
+---
+
+## Key takeaways
+
+- Quantum computers could eventually threaten some public-key cryptography used by blockchains.
+- Post-quantum cryptography is designed to resist those future attacks.
+- Zcash is not fully post-quantum today.
+- Zcash research has identified several pieces needed for a post-quantum future, including post-quantum encryption, security-margin review, and practical post-quantum zero-knowledge proofs.
+- Draft ZIP 2005, Orchard Quantum Recoverability, is a concrete step toward making Orchard funds easier to recover in a future transition.
+- Full post-quantum Zcash will require careful engineering, wallet support, privacy review, and user migration.
+
+---
+
+## References and further reading
+
+- [NIST: Post-Quantum Cryptography standards approved](https://csrc.nist.gov/News/2024/postquantum-cryptography-fips-approved)
+- [NIST Post-Quantum Cryptography project](https://csrc.nist.gov/Projects/post-quantum-cryptography)
+- [ZIP 2005: Orchard Quantum Recoverability](https://zips.z.cash/zip-2005)
+- [Zcash ZIPs issue: Fully post-quantum Zcash](https://github.com/zcash/zips/issues/1134)
+- [Zcash Community Forum: Quantum Recoverability](https://forum.zcashcommunity.com/t/quantum-recoverability/54478)
+- [Zcash documentation](https://zcash.github.io/)
+- [What is Zcash?](https://z.cash/learn/what-is-zcash/)


### PR DESCRIPTION
## Summary

- Add a beginner-friendly ZecHub Research article for issue #1665.
- Explain quantum computing, post-quantum cryptography, blockchain risks, and why privacy-focused cryptography matters for Zcash.
- Cover Zcash-specific research, including the long-running fully post-quantum Zcash discussion and draft ZIP 2005: Orchard Quantum Recoverability.

## Why

This addresses the requested deliverable: a wiki/published article that explains post-quantum security in simple language for the Zcash community.

The article avoids overstating the current state of Zcash. It clearly says Zcash is not fully post-quantum today and explains that Orchard Quantum Recoverability is not the same thing as full quantum resistance.

## Sources used

- NIST post-quantum cryptography standards announcement
- NIST Post-Quantum Cryptography project page
- ZIP 2005: Orchard Quantum Recoverability
- Zcash ZIPs issue: Fully post-quantum Zcash
- Zcash Community Forum: Quantum Recoverability
- Zcash documentation
- Zcash "What is Zcash?" page

Closes ZecHub/zechub#1665.
