### PR TITLE
Add shielded privacy and ecosystem wiki guides

### DIFF
--- a/site/Privacy_Tools/Namada_Protocol.md
+++ b/site/Privacy_Tools/Namada_Protocol.md
@@ -22,6 +22,8 @@ Namada Protocol serves as a Layer 1 platform based on proof-of-stake consensus, 
 
 Namada prioritizes privacy by implementing an enhanced iteration of the Multi-Asset Shielded Pool (MASP) circuit. This upgraded version enables all types of assets, including both fungible and non-fungible tokens, to utilize a shared shielded set just exactly as that of Zcash. As a result, the act of transferring supported assets on Namada becomes distinct as it becomes difficult to identify due to the high level of privacy involved. Also, the latest update to the Multi Asset Shielded Pool circuit enables shielded set rewards which is a groundbreaking feature or incentive that allocates resources to promote privacy as a public good.
 
+For a practical walkthrough, see [Namada shielded transfers](/guides/namada-shielded-transfers). For a broader user-facing comparison, see [Shielded ecosystems comparison](/research/shielded-ecosystems-comparison).
+
 ## Ethereum Bridge + IBC Compatible
 
 The integration of the Ethereum bridge into Namada eliminates the need for a separate protocol, as it becomes an integral part of the Namada ecosystem. Validators within Namada are entrusted with running the bridge alongside the core Namada protocol. These validators also serve as relayers when it comes to transferring assets to Namada, making the involvement of additional actors unnecessary. On the other hand, when transferring assets to Ethereum, external parties (known as relayers) are involved, although they bear no responsibility for validating or securing the bridge.

--- a/site/Privacy_Tools/Penumbra.md
+++ b/site/Privacy_Tools/Penumbra.md
@@ -2,6 +2,8 @@
 
 Penumbra exists to be a cutting-edge, fully shielded layer-1 network vying in the Cosmos ecosystem. It enables its users to transact securely, stake and swap tokens, and market make without revealing their metadata on-chain. As a fully shielded blockchain, it also offers shielded transactions on the web without compromising on privacy or decentralization — Penumbra has privacy by default, with no transparent transactions or transparent value pool.
 
+For command-line wallet setup, see the [Penumbra `pcli` beginner guide](/guides/penumbra-pcli-beginner-guide). For a user-facing comparison with Zcash and Namada, see [Shielded ecosystems comparison](/research/shielded-ecosystems-comparison).
+
 ![image.png](https://drive.google.com/file/d/16CcFQ1ZhG_pi4ENQuhFKPwN-J1diELRX/view?usp=drive_link)
 
 ## Technology used in Penumbra IBC 

--- a/site/Privacy_Tools/Ycash.md
+++ b/site/Privacy_Tools/Ycash.md
@@ -1,0 +1,83 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Privacy_Tools/Ycash.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Ycash for Zcash Users
+
+Ycash (YEC) is a digital currency whose software and early chain history come from Zcash. It is a separate network with a separate coin, separate wallets, separate addresses, and separate infrastructure.
+
+## Relationship to Zcash
+
+Ycash forked from Zcash at Zcash block height 570,000 on July 18, 2019. Coins and transactions after that point live on different chains.
+
+This matters for users because YEC is not ZEC. A Zcash wallet is not automatically a Ycash wallet, and a Zcash address is not a Ycash address. Treat the two networks as related but separate systems.
+
+## Main differences
+
+At launch, Ycash changed several network details from Zcash:
+
+- Mining changed from Equihash(200,9) to Equihash(192,7).
+- The Zcash Founders Reward design was replaced with a Ycash Development Fund.
+- Ycash uses different address prefixes to reduce accidental cross-chain sends.
+- Ycash uses two-way replay protection from the Zcash upgrade mechanism.
+
+Ycash address prefixes are different from Zcash address prefixes:
+
+| Ycash address type | Prefix |
+| --- | --- |
+| Transparent | `s1` |
+| Multisig | `s3` |
+| Sprout shielded | `yc` |
+| Sapling shielded | `ys` |
+
+Do not send ZEC to a Ycash address or YEC to a Zcash address.
+
+## Wallets
+
+The Ycash wallet page lists both light-wallet and full-node options.
+
+YWallet is a shielded wallet available on Android, iOS, and desktop. It is usually the simplest starting point for everyday users who want shielded Ycash support.
+
+YecWallet is a full-node wallet. It includes `ycashd`, the node software that powers the Ycash network, and downloads the Ycash blockchain from the peer-to-peer network.
+
+YecPaperWallet is a paper-wallet option for users who understand offline key handling. Paper wallets require extra care because losing or exposing the secret material can permanently lose funds.
+
+## Accessing fork coins
+
+Users who controlled Zcash private keys at the fork height may have corresponding YEC on the Ycash chain. Accessing those coins requires importing private keys into Ycash software.
+
+Be careful with this workflow:
+
+- Confirm that the software is from an official Ycash source.
+- Move current ZEC to a fresh Zcash wallet before exposing old keys to another wallet environment.
+- Import only keys you understand.
+- Expect a rescan to find historical transactions.
+- Test with a low-value key first when possible.
+
+## Practical notes
+
+Ycash can be interesting to Zcash users because it shares history and technology roots with Zcash, but it should not be treated as the same asset or same privacy ecosystem.
+
+For normal users, the safest mental model is simple:
+
+- Use Zcash wallets for ZEC.
+- Use Ycash wallets for YEC.
+- Use current official releases.
+- Back up keys before receiving funds.
+- Check address prefixes before sending.
+
+## Related pages
+
+- [Zcash wallet privacy decision tree](/using-zcash/zcash-wallet-privacy-decision-tree)
+- [Wallet backup checklist](/using-zcash/wallet-backup-checklist)
+- [Shielded pools](/using-zcash/shielded-pools)
+- [Shielded ecosystems comparison](/research/shielded-ecosystems-comparison)
+
+## Resources
+
+- [Ycash: What is Ycash?](https://y.cash/what-is-ycash/)
+- [Ycash: Wallets](https://y.cash/wallets/)
+- [Ycash Foundation: 2019 Fork](https://www.ycash.xyz/docs/the_fork/)
+- [Ycash Foundation: Importing Private Keys](https://www.ycash.xyz/docs/privkey_import/)
+- [Ycash Foundation: Full Node](https://www.ycash.xyz/full_node/)
+- [Ycash GitHub releases](https://github.com/ycashfoundation/ycash/releases)

--- a/site/Research/Shielded_Ecosystems_Comparison.md
+++ b/site/Research/Shielded_Ecosystems_Comparison.md
@@ -1,0 +1,88 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Research/Shielded_Ecosystems_Comparison.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Shielded Ecosystems Comparison
+
+Zcash, Namada, and Penumbra all use zero-knowledge cryptography to reduce public transaction metadata, but they are built for different user stories.
+
+Zcash is mature private digital cash centered on ZEC. Namada is a multichain shielded asset layer built around a Multi-Asset Shielded Pool. Penumbra is a private Cosmos appchain and DEX where transfers, swaps, staking, and governance are designed around private state.
+
+## Quick comparison
+
+| Ecosystem | Main user story | Privacy model | Assets | Typical interface |
+| --- | --- | --- | --- | --- |
+| Zcash | Private digital cash | Optional transparent or shielded transactions | ZEC today | Shielded-capable Zcash wallets |
+| Namada | Multichain asset shielding | MASP for supported assets | NAM and supported IBC assets | Namadillo, Namada Keychain, CLI |
+| Penumbra | Private Cosmos DeFi | Single multi-asset shielded pool | IBC-compatible assets | Prax, Penumbra web app, `pcli` |
+
+## Zcash
+
+Zcash is a layer-1 cryptocurrency launched in 2016. It supports transparent addresses and shielded addresses. Transparent activity is visible on-chain, while shielded activity uses zero-knowledge proofs to hide transaction details from public observers.
+
+Zcash has evolved through several shielded protocols. Sapling improved shielded transaction performance, especially for mobile wallets. Orchard and Unified Addresses make it easier for wallets to route funds to modern shielded pools without forcing users to manage multiple address formats manually.
+
+Zcash is a strong fit when the main goal is private payments using one mature native asset. The tradeoff is that privacy is optional at the protocol level. Wallets, exchanges, and users can still choose transparent flows.
+
+## Namada
+
+Namada is a proof-of-stake network designed as a shielded asset layer for the multichain ecosystem. Its core privacy mechanism is the Multi-Asset Shielded Pool, or MASP.
+
+For users, the basic idea is to bring an asset into Namada, shield it, and then use shielded transfers or other shielded actions while inside Namada's privacy system.
+
+Namada is a strong fit when the goal is multi-asset privacy across supported assets. The tradeoff is that users may need to understand both Namada and the source-chain wallet flow. Privacy at the edges still depends on deposits, withdrawals, timing, and amounts.
+
+## Penumbra
+
+Penumbra is a privacy-focused proof-of-stake appchain and decentralized exchange for the Cosmos ecosystem. It uses a single multi-asset shielded pool.
+
+Penumbra is designed so that value is shielded when it enters the zone, remains shielded during transfers, swaps, staking, and governance, and becomes public again when it exits through IBC.
+
+Penumbra is a strong fit when the goal is private DeFi. The tradeoff is that users must bridge into a specialized ecosystem, and entry or exit behavior can still leak metadata.
+
+## Practical differences
+
+### Private payments
+
+Zcash is the most direct fit when the user wants private payments in ZEC. The user experience is strongest when both sender and receiver use shielded-capable wallets and shielded addresses.
+
+Namada and Penumbra can also support private payments, but users first need to bring assets into those systems.
+
+### Private multi-asset activity
+
+Namada and Penumbra are designed around multi-asset privacy. Namada focuses on shielding supported assets. Penumbra focuses on private DeFi activity inside its appchain.
+
+Zcash is more mature for private ZEC transfers, while broader private asset support depends on future upgrades.
+
+### Maturity
+
+Zcash has the longest production history and the broadest surrounding wallet and exchange ecosystem.
+
+Namada and Penumbra are newer. They may offer broader multi-asset or DeFi-oriented privacy designs, but users should expect faster-changing tooling and a smaller support surface.
+
+## Summary
+
+These systems are not interchangeable.
+
+Zcash is best understood as mature private digital cash for ZEC. Namada is a multichain shielded asset layer. Penumbra is a private appchain and DEX for Cosmos assets.
+
+The main question is not simply which system has better privacy. It is whether the user wants mature private money, cross-chain asset shielding, or private DeFi.
+
+## Related pages
+
+- [Ycash for Zcash users](/privacy-tools/ycash)
+- [Namada Protocol](/privacy-tools/namada-protocol)
+- [Penumbra](/privacy-tools/penumbra)
+- [Namada shielded transfers](/guides/namada-shielded-transfers)
+- [Penumbra `pcli` beginner guide](/guides/penumbra-pcli-beginner-guide)
+
+## Resources
+
+- [Zcash basics](https://zcash.readthedocs.io/en/latest/rtd_pages/basics.html)
+- [Zcash Unified Addresses](https://z.cash/learn/what-are-zcash-unified-addresses/)
+- [Zcash ecosystem and wallets](https://z.cash/ecosystem/)
+- [Namada privacy overview](https://docs.namada.net/introduction/privacy)
+- [Namada shielded transfers](https://docs.namada.net/users/shielded-accounts/shielded-transfers)
+- [Penumbra protocol overview](https://protocol.penumbra.zone/main/index.html)
+- [Penumbra shielded pool](https://protocol.penumbra.zone/main/shielded_pool.html)
+- [Penumbra interchain privacy](https://guide.penumbra.zone/interchain-privacy)

--- a/site/Research/ZK_Shielded_Asset_Platforms.md
+++ b/site/Research/ZK_Shielded_Asset_Platforms.md
@@ -9,6 +9,8 @@ published: 2024-01-12
 
 # Zero Knowledge Asset Platforms
 
+For a focused comparison of Zcash, Namada, and Penumbra from a user perspective, see [Shielded ecosystems comparison](/research/shielded-ecosystems-comparison).
+
 
 
 **[Firn Protocol](https://app.firn.cash/)**: Firn is the first-ever zero-knowledge privacy platform in the account-based model, and introduces pluggable, flexible privacy to Ethereum-based chains.Using zero-knowledge proofs, Firn delivers secure, efficient funds privacy for users of Ethereum and Ethereum-based L2s. **HOW IT WORKS?**

--- a/site/Using_Zcash/Memos.md
+++ b/site/Using_Zcash/Memos.md
@@ -8,6 +8,8 @@
 
 When sending a Z2Z (shielded-to-shielded) transaction, you're able to include a memo (message) in the transaction. This memo can be used for a number of different things.
 
+For practical memo hygiene, merchant references, and what not to put in a memo, see [shielded memo practices](/using-zcash/shielded-memo-practices).
+
 #### Signing Transactions
 
 Memos are primarily used for singing payments. Since shielded transactions encrypt your data, you're not able to see who sent you ZEC, and what the ZEC might've been for. Users can use the memo field to sign their name or pseudonym to let their counterpart know who the transaction was from. They can also describe what the transaction was for.
@@ -38,5 +40,4 @@ Here is how to use Zcash Shielded Memos with the Magic-Wormhole CLI and zcashd t
 #### Resources
 
 [The Encrypted Memo Field](https://electriccoin.co/blog/encrypted-memo-field/)
-
 

--- a/site/Using_Zcash/Payment_Processors.md
+++ b/site/Using_Zcash/Payment_Processors.md
@@ -1,5 +1,7 @@
 # Zcash Payment Processors
 
+For help designing a checkout flow around shielded ZEC, see the [shielded merchant checklist](/using-zcash/shielded-merchant-checklist).
+
 ## CoinPayments
 - **Support Type**: Transparent   
 - **Description**: A global cryptocurrency payment gateway that supports over 100 cryptocurrencies, including Zcash. Offers simple integration for online stores.  
@@ -69,7 +71,6 @@
 - **Description**: Plisio is a cryptocurrency payment gateway that allows businesses to accept Zcash payments.  
 - **URL**: [Plisio](https://plisio.net/accept-zcash)  
 <img src="https://plisio.net/v2/images/logo-color.svg" alt="Plisio Logo" width="200"/>
-
 
 
 

--- a/site/Using_Zcash/Shielded_Memo_Practices.md
+++ b/site/Using_Zcash/Shielded_Memo_Practices.md
@@ -1,0 +1,101 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/Shielded_Memo_Practices.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Shielded memo practices
+
+Zcash shielded transactions can include encrypted memos. A memo is a short message attached to a shielded payment.
+
+Memos are useful, but they should be treated like payment notes, not like a private chat app.
+
+## TL;DR
+
+1. Memos are encrypted on-chain.
+2. The recipient can read the memo.
+3. Anyone with the relevant viewing key may also be able to read it.
+4. Use memos for payment context, not unnecessary personal data.
+5. Keep memos short and clear.
+
+## What a memo is for
+
+Use a memo when the recipient needs context for a payment.
+
+Good examples:
+
+1. Invoice number
+2. Order number
+3. Refund address
+4. Grant or donation reference
+5. Short note to the recipient
+
+Memos help because shielded payments do not publicly reveal sender, receiver, or amount. Without a memo or private record, a recipient may not know which customer, invoice, or campaign a payment belongs to.
+
+## What not to put in a memo
+
+Avoid putting sensitive personal data in a memo unless the recipient truly needs it.
+
+Avoid:
+
+1. Full legal names
+2. Home addresses
+3. Phone numbers
+4. Passwords or seed phrases
+5. Private keys
+6. Medical, legal, or employment details
+7. Anything you would not want visible to a future holder of the viewing key
+
+If a merchant needs shipping information, send it through the merchant's normal checkout or support system instead.
+
+## Who can see a memo
+
+The memo is not public chain data.
+
+The memo can be visible to:
+
+1. The recipient wallet.
+2. A wallet or service that has the recipient's relevant viewing key.
+3. The sender wallet, depending on wallet support and outgoing viewing data.
+4. Anyone who later gets access to wallet backups, exports, or viewing keys.
+
+This is why memos should be useful but minimal.
+
+## Memo size
+
+Zcash memos are fixed-size encrypted fields. In `zcash-cli`, memo text is handled as hexadecimal data, and the memo field is 512 bytes.
+
+Most user wallets hide the hex conversion and show a normal text field. If you use command-line tools, you may need to convert text to hex before sending.
+
+## Merchant use
+
+For merchants, the safest pattern is:
+
+1. Put the order or invoice ID in the memo.
+2. Keep customer details in your private order system.
+3. Use a fresh receiving address or payment request for each order.
+4. Keep a backup of the wallet and order database.
+
+This lets the payment identify the order without putting unnecessary customer data in the memo itself.
+
+## Sender checklist
+
+Before sending a memo:
+
+1. Ask whether the memo is needed.
+2. Keep it short.
+3. Check spelling and addresses before sending.
+4. Avoid sensitive personal data.
+5. Remember that the recipient may keep the memo permanently.
+
+## Related pages
+
+- [Memos](/using-zcash/memos)
+- [Transactions](/using-zcash/transactions)
+- [Payment request URIs](/using-zcash/payment-request-uris)
+- [Shielded merchant checklist](/using-zcash/shielded-merchant-checklist)
+- [Viewing keys](/zcash-tech/viewing-keys)
+
+## Resources
+
+- [Zcash memos documentation](https://zcash.readthedocs.io/en/latest/rtd_pages/memos.html)
+- [Zcash RPC: z_sendmany](https://zcash.github.io/rpc/z_sendmany.html)
+- [ZIP 321: Payment Request URIs](https://zips.z.cash/zip-0321)

--- a/site/Using_Zcash/Shielded_Merchant_Checklist.md
+++ b/site/Using_Zcash/Shielded_Merchant_Checklist.md
@@ -1,0 +1,101 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/Shielded_Merchant_Checklist.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Shielded merchant checklist
+
+Accepting ZEC is simple, but accepting it privately takes a little planning.
+
+Use this checklist when you want to receive Zcash payments for a shop, donation page, invoice, event, or service without reusing one public address for every customer.
+
+## TL;DR
+
+1. Prefer a wallet or payment processor that supports shielded Zcash.
+2. Use a fresh receiving address or invoice for each order.
+3. Keep private order records separate from public addresses.
+4. Use memos carefully, and only for information the recipient needs.
+5. Test with a small payment before accepting larger amounts.
+6. Keep backups of your seed phrase, viewing keys, and payment records.
+
+## Choose your receiving setup
+
+Start by deciding who needs to detect payments.
+
+For a small tip jar, a shielded wallet may be enough. Generate a receiving address, test it, and keep records manually.
+
+For an online shop, use a payment processor or invoice system. A processor can create a new payment request for each order and match incoming funds to the right customer.
+
+For an accounting or audit workflow, consider whether you need a viewing key. A viewing key can let a server or auditor detect incoming payments without holding spending authority.
+
+## Address practice
+
+Avoid using one address for everything.
+
+Better options include:
+
+1. Create a fresh shielded address for each customer or invoice.
+2. Use a payment request URI when you need to include an amount or memo.
+3. Keep labels in your private records so you know which address belongs to which order.
+4. Do not post your operational receiving address in unrelated public places.
+
+If your wallet supports diversified addresses or address rotation, use it. This lets one account generate many receiving addresses while keeping backup simple.
+
+## Memo practice
+
+Memos are useful for order IDs, refund instructions, or short notes. They are encrypted on-chain, but they are visible to the recipient and to anyone with the relevant viewing key.
+
+Good memo contents:
+
+1. Order number
+2. Invoice reference
+3. Refund address if required by the workflow
+4. Short customer note
+
+Avoid putting sensitive personal data in a memo unless it is really needed. Use your own order system for names, shipping addresses, email addresses, and support tickets.
+
+## Payment flow
+
+For each payment:
+
+1. Create a unique invoice or receiving address.
+2. Show the amount in ZEC and, if useful, the fiat reference amount.
+3. Let the customer scan a QR code or copy the payment request.
+4. Wait for the confirmation policy your business uses.
+5. Mark the order paid only after your wallet or processor detects the payment.
+6. Reconcile the payment against your private order record.
+
+Many wallets use different confirmation policies for trusted and untrusted funds. Be clear about your own policy before shipping goods or delivering a service.
+
+## Operational safety
+
+1. Back up wallet seeds before taking payments.
+2. Keep spending keys offline or on a secure device when possible.
+3. Use viewing keys for detection-only systems.
+4. Test refunds before you need to process one under pressure.
+5. Keep software updated.
+6. Document who can spend funds and who can only view payments.
+7. Separate personal funds from business funds.
+
+## Common mistakes
+
+1. Reusing one address for every order.
+2. Accepting transparent-only payments when privacy is the goal.
+3. Putting too much customer information in memos.
+4. Forgetting to back up the wallet before receiving funds.
+5. Letting the web server hold spending authority when a viewing key would be enough.
+6. Treating a payment as final before it has enough confirmations for your risk level.
+
+## Related pages
+
+- [Wallets](/using-zcash/wallets)
+- [Payment processors](/using-zcash/payment-processors)
+- [Payment request URIs](/using-zcash/payment-request-uris)
+- [Memos](/using-zcash/memos)
+- [Viewing keys](/zcash-tech/viewing-keys)
+
+## Resources
+
+- [ZIP 315: Best Practices for Wallet Implementations](https://zips.z.cash/zip-0315)
+- [ZIP 321: Payment Request URIs](https://zips.z.cash/zip-0321)
+- [Zcash memos documentation](https://zcash.readthedocs.io/en/latest/rtd_pages/memos.html)
+- [Zcash RPC: z_sendmany](https://zcash.github.io/rpc/z_sendmany.html)

--- a/site/Using_Zcash/Transactions.md
+++ b/site/Using_Zcash/Transactions.md
@@ -7,6 +7,8 @@
 
 ZEC is a widely-used digital asset for payments, offering strong privacy features that make it suitable for various transactions like paying friends, making purchases, or donating. To maximize privacy and security, it is essential to understand how different types of transactions work within Zcash.
 
+For a focused explanation of transaction fees, ZIP 317, and stuck-payment troubleshooting, see [Zcash transaction fees](/using-zcash/zcash-transaction-fees).
+
 ## Shielded Transactions
 
 <div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">

--- a/site/Using_Zcash/Wallet_Backup_Checklist.md
+++ b/site/Using_Zcash/Wallet_Backup_Checklist.md
@@ -1,0 +1,100 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/Wallet_Backup_Checklist.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Wallet backup checklist
+
+Back up your Zcash wallet before you receive funds.
+
+Zcash wallets may support seed phrases, viewing keys, hardware devices, full-node wallet files, or wallet-specific exports. The exact backup method depends on the wallet.
+
+## TL;DR
+
+1. Write down your seed phrase before receiving funds.
+2. Store backups offline.
+3. Do not share your seed phrase or spending key.
+4. Understand the difference between spending keys and viewing keys.
+5. Test recovery with a small wallet before trusting a large balance.
+6. Keep wallet software and recovery instructions together.
+
+## What to back up
+
+Your wallet may use one or more of these:
+
+1. Seed phrase
+2. Spending key
+3. Viewing key
+4. Wallet file
+5. Hardware wallet recovery phrase
+6. Password for encrypted local storage
+7. Notes about the wallet version and account structure
+
+The seed phrase or spending key controls funds. Anyone who gets it can spend your ZEC.
+
+A viewing key does not spend funds, but it can reveal transaction history. Treat it as sensitive.
+
+## Seed phrase safety
+
+1. Write the seed phrase on paper or metal.
+2. Store it somewhere private and durable.
+3. Do not put it in cloud notes, screenshots, email, or chat.
+4. Do not type it into a website.
+5. Do not share it with support staff.
+6. Make more than one backup if loss would be serious.
+
+If someone asks for your seed phrase, assume it is a scam.
+
+## Full-node wallet files
+
+Some full-node wallets may use local wallet files in addition to seed-based accounts.
+
+If you use `zcashd` or another full-node wallet, read the wallet's current backup instructions. Older wallets and imported keys may need extra care.
+
+Do not assume that a seed phrase alone backs up every imported key, watch-only address, label, or wallet record.
+
+## Viewing key backups
+
+Viewing keys are useful for accounting, audits, merchant detection, and watch-only wallets.
+
+Back them up if your workflow depends on them, but do not publish them casually. A full viewing key can reveal more than one payment.
+
+Use separate accounts when you need to share visibility for one activity but not another.
+
+## Test recovery
+
+The best backup is one you have tested.
+
+Before storing serious funds:
+
+1. Create a small wallet.
+2. Back it up.
+3. Restore it on another device or profile.
+4. Confirm the restored wallet finds the same address.
+5. Send a small test payment.
+6. Confirm you can receive and spend.
+
+Testing takes time, but it prevents painful surprises later.
+
+## Common mistakes
+
+1. Receiving funds before backing up.
+2. Storing the seed phrase only on the same phone or laptop as the wallet.
+3. Confusing a viewing key with a spending key.
+4. Forgetting the password for an encrypted wallet file.
+5. Assuming every wallet uses the same recovery format.
+6. Importing old keys and forgetting to back them up.
+
+## Related pages
+
+- [Wallets](/using-zcash/wallets)
+- [Recovering funds](/using-zcash/recovering-funds)
+- [Viewing keys](/zcash-tech/viewing-keys)
+- [Zcash wallet privacy decision tree](/using-zcash/zcash-wallet-privacy-decision-tree)
+- [Shielded pools](/using-zcash/shielded-pools)
+
+## Resources
+
+- [ZIP 315: Best Practices for Wallet Implementations](https://zips.z.cash/zip-0315)
+- [Zcash RPC: z_getnewaccount](https://zcash.github.io/rpc/z_getnewaccount.html)
+- [Zcash RPC: backupwallet](https://zcash.github.io/rpc/backupwallet.html)
+- [Zcash RPC: z_exportwallet](https://zcash.github.io/rpc/z_exportwallet.html)

--- a/site/Using_Zcash/Wallets.md
+++ b/site/Using_Zcash/Wallets.md
@@ -1,3 +1,10 @@
+## Wallet planning guides
+
+- [Zcash wallet privacy decision tree](/using-zcash/zcash-wallet-privacy-decision-tree)
+- [Wallet backup checklist](/using-zcash/wallet-backup-checklist)
+
+---
+
 ## [ZODL](https://zodl.com)
 ![logo](https://github.com/user-attachments/assets/198608b2-9059-4cb7-aeb8-9354971376fd "ZODL")
 - Devices: Mobile

--- a/site/Using_Zcash/Zcash_Transaction_Fees.md
+++ b/site/Using_Zcash/Zcash_Transaction_Fees.md
@@ -1,0 +1,90 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/Zcash_Transaction_Fees.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zcash transaction fees
+
+Zcash fees are small compared with many payment networks, but they still matter. Fees help transactions get mined and prevent the network from being filled with low-value spam.
+
+Most users should let their wallet choose the fee. This page explains what the wallet is doing and why some transactions cost more than others.
+
+## TL;DR
+
+1. Let your wallet choose the fee unless you know what you are doing.
+2. Zcash uses ZIP 317 as the conventional fee rule for modern wallets.
+3. More complex transactions may require a higher fee.
+4. Tiny notes can become uneconomic if they cost more to spend than they are worth.
+5. If a transaction fails, check wallet support, confirmations, and fee settings before retrying.
+
+## What pays the fee
+
+The sender pays the network fee.
+
+When a wallet creates a transaction, it chooses inputs, outputs, change, and a fee. The fee is the difference between the value spent and the value sent back to recipients or change.
+
+For shielded transactions, your wallet does this without revealing the sender, receiver, and amount to the public chain.
+
+## Why fees vary
+
+Fees depend on transaction structure, not just the amount sent.
+
+A transaction may become more complex when it:
+
+1. Spends many notes or UTXOs.
+2. Sends to multiple recipients.
+3. Crosses between transparent and shielded pools.
+4. Includes both transparent and shielded components.
+5. Needs extra actions to preserve privacy.
+
+Sending 1 ZEC can be cheaper or more expensive than sending 0.01 ZEC depending on how many pieces the wallet has to spend.
+
+## ZIP 317
+
+ZIP 317 defines a proportional transfer fee mechanism for Zcash. The goal is to make fees depend on transaction resources while keeping ordinary use simple.
+
+Modern wallets and `zcashd` can calculate a ZIP 317 fee automatically. In the `z_sendmany` RPC, the default behavior is to use a fee calculated according to ZIP 317.
+
+This is why manual fee settings can be risky. A fee that worked for a simple transaction may fail for a more complex one.
+
+## Tiny notes and dust
+
+If you receive many tiny payments, your wallet may hold many small notes.
+
+Each note can add cost when it is later spent. If a note is smaller than the marginal fee needed to spend it, a wallet may treat it as uneconomic. Some wallets may hide it from spendable balance or wait to combine it with other actions.
+
+For users, the lesson is simple: avoid creating lots of tiny payments unless your wallet is designed for that workflow.
+
+## What to do if a transaction fails
+
+1. Wait for your wallet to finish syncing.
+2. Check that the funds have enough confirmations.
+3. Let the wallet use its default fee.
+4. Try a smaller or simpler transaction.
+5. Avoid spending from transparent addresses unless you understand the privacy effect.
+6. Update the wallet if you are using old software.
+7. Contact the wallet team if the same transaction keeps failing.
+
+Do not keep rebroadcasting the same payment with random settings. You may leak more information or create confusing wallet state.
+
+## Best practices
+
+1. Use modern wallets that support ZIP 317 fee calculation.
+2. Prefer shielded-to-shielded transactions when privacy matters.
+3. Avoid sending many tiny outputs.
+4. Shield transparent funds before long-term storage.
+5. Keep a little extra ZEC available for fees.
+6. Test new services with a small payment first.
+
+## Related pages
+
+- [Transactions](/using-zcash/transactions)
+- [Shielded pools](/using-zcash/shielded-pools)
+- [Wallets](/using-zcash/wallets)
+- [Buying ZEC](/using-zcash/buying-zec)
+- [Transparent exchange addresses](/using-zcash/transparent-exchange-addresses)
+
+## Resources
+
+- [ZIP 317: Proportional Transfer Fee Mechanism](https://zips.z.cash/zip-0317)
+- [ZIP 315: Best Practices for Wallet Implementations](https://zips.z.cash/zip-0315)
+- [Zcash RPC: z_sendmany](https://zcash.github.io/rpc/z_sendmany.html)

--- a/site/Using_Zcash/Zcash_Wallet_Privacy_Decision_Tree.md
+++ b/site/Using_Zcash/Zcash_Wallet_Privacy_Decision_Tree.md
@@ -1,0 +1,105 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/Zcash_Wallet_Privacy_Decision_Tree.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zcash wallet privacy decision tree
+
+Different wallets support different Zcash features. Use this page to choose the safest workflow for what you are trying to do.
+
+This is not financial advice. It is a privacy checklist for everyday wallet decisions.
+
+## Start here
+
+Ask one question first:
+
+**Do I need privacy for this payment?**
+
+If yes, prefer a wallet that supports shielded ZEC, especially Orchard or Unified Addresses.
+
+If no, a transparent wallet may work, but remember that transparent Zcash transactions are public like Bitcoin transactions.
+
+## I am receiving ZEC
+
+Choose this path when someone is paying you.
+
+1. If your wallet supports Unified Addresses, share your Unified Address.
+2. If your wallet supports address rotation, create a fresh address for this payer or invoice.
+3. If the payer can send shielded ZEC, receive shielded.
+4. If the payer can only send transparent ZEC, receive it and shield it as soon as your wallet allows.
+5. If this is a public donation address, consider using a separate account or campaign address.
+
+Avoid reusing one personal address across unrelated identities.
+
+## I am sending ZEC
+
+Choose this path when you are paying someone else.
+
+1. Prefer shielded-to-shielded transactions.
+2. Check whether the recipient gave you a Unified Address, Sapling address, TEX address, or transparent address.
+3. If the recipient gives you a transparent address, understand that the recipient address and amount may be public.
+4. If your wallet warns about privacy leakage, read the warning before sending.
+5. Test with a small amount when sending to a new wallet or service.
+
+Some advanced wallets expose privacy policies for transactions. The safest policy is the one that only allows fully shielded transfers.
+
+## I am withdrawing from an exchange
+
+Choose this path when moving ZEC from a centralized exchange to your wallet.
+
+1. Check whether the exchange supports shielded withdrawals.
+2. If shielded withdrawals are supported, withdraw to a shielded or Unified Address.
+3. If only transparent withdrawals are supported, withdraw to a wallet that can shield funds.
+4. Shield the funds after enough confirmations.
+5. Avoid combining unrelated transparent withdrawals in one shielding transaction if your wallet gives you control over this.
+
+The act of shielding from a transparent address is visible on-chain. Shielding still improves privacy for later spending.
+
+## I am storing ZEC
+
+Choose this path for savings or long-term holding.
+
+1. Prefer shielded storage for long-term funds.
+2. Back up your seed phrase before receiving funds.
+3. Keep the seed phrase offline.
+4. Use hardware wallet support if your wallet and threat model require it.
+5. Keep a separate account for funds you may audit or disclose.
+6. Do not share viewing keys casually.
+
+If you need separate balances, use separate accounts. If you only need fresh receiving addresses, diversified addresses may be enough.
+
+## I need to prove a payment
+
+Choose this path for audits, refunds, grants, or support.
+
+1. First ask what proof is actually needed.
+2. If a transaction ID is enough, share only that.
+3. If the counterparty needs to see payment details, consider a viewing key or payment disclosure feature if your wallet supports it.
+4. Share the narrowest proof that solves the problem.
+5. Remember that viewing keys can reveal more than a single payment depending on the key type.
+
+## Quick choices
+
+| Goal | Better choice |
+| --- | --- |
+| Best everyday privacy | Shielded wallet with Unified Addresses |
+| Public tip jar | Separate address or account |
+| Business invoices | Unique address or payment request per invoice |
+| Exchange withdrawal | Shielded withdrawal if supported |
+| Transparent-only exchange | Withdraw, then shield |
+| Audit or accounting | Viewing key, not spending key |
+| Separate identity | Separate account or wallet |
+
+## Related pages
+
+- [Wallets](/using-zcash/wallets)
+- [Shielded pools](/using-zcash/shielded-pools)
+- [Transparent exchange addresses](/using-zcash/transparent-exchange-addresses)
+- [Viewing keys](/zcash-tech/viewing-keys)
+- [Recovering funds](/using-zcash/recovering-funds)
+
+## Resources
+
+- [ZIP 315: Best Practices for Wallet Implementations](https://zips.z.cash/zip-0315)
+- [ZIP 316: Unified Addresses and Unified Viewing Keys](https://zips.z.cash/zip-0316)
+- [Zcash RPC: z_sendmany privacy policies](https://zcash.github.io/rpc/z_sendmany.html)
+- [Zcash value pools](https://zcash.readthedocs.io/en/latest/rtd_pages/addresses.html)

--- a/site/guides/Namada_Shielded_Transfers.md
+++ b/site/guides/Namada_Shielded_Transfers.md
@@ -1,0 +1,110 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Namada_Shielded_Transfers.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Namada Shielded Transfers
+
+Namada supports shielded transfers through the Multi-Asset Shielded Pool, or MASP. A shielded transfer moves already-shielded assets from one shielded payment address to another without publicly exposing the sender, receiver, or amount.
+
+Commands, chain IDs, and wallet details can change. Check the current Namada docs before using real funds.
+
+## Address types
+
+Namada addresses and keys use different prefixes:
+
+| Prefix | Meaning |
+| --- | --- |
+| `tnam` | Transparent address |
+| `zsknam` | Shielded spending key |
+| `zvknam` | Shielded viewing key |
+| `znam` | Shielded payment address |
+
+A shielded account can have many `znam` payment addresses. Using a fresh payment address for different counterparties can reduce unnecessary linkage.
+
+## Transfer types
+
+| Action | Direction | Command |
+| --- | --- | --- |
+| Shield | Transparent to shielded | `namadac shield` |
+| Shielded transfer | Shielded to shielded | `namadac transfer` |
+| Unshield | Shielded to transparent | `namadac unshield` |
+
+## Sync before sending
+
+Before checking shielded balances or creating shielded transactions, sync the local shielded wallet:
+
+```sh
+namadac shielded-sync
+```
+
+When syncing a key for the first time, provide the spending or viewing key:
+
+```sh
+namadac shielded-sync --spending-keys $SPENDING_KEY
+```
+
+or:
+
+```sh
+namadac shielded-sync --viewing-keys $VIEWING_KEY
+```
+
+Shielded sync processes MASP notes locally so the wallet can detect notes belonging to your keys and build valid zero-knowledge proofs.
+
+## Make a shielded transfer
+
+To send shielded funds to another `znam` address:
+
+```sh
+namadac transfer \
+  --source $SPENDING_KEY \
+  --target $PAYMENT_ADDRESS \
+  --token $TOKEN \
+  --amount $AMOUNT \
+  --gas-payer $IMPLICIT_ACCOUNT
+```
+
+The `--source` is the shielded spending key that controls the funds. The `--target` is the recipient's shielded payment address.
+
+A transparent implicit account is still needed for transaction fees.
+
+## Check shielded balance
+
+After syncing, query the balance for a spending key:
+
+```sh
+namadac balance --owner $SPENDING_KEY --token $TOKEN
+```
+
+A viewing key can also be used:
+
+```sh
+namadac balance --owner $VIEWING_KEY --token $TOKEN
+```
+
+This shows the combined balance for shielded addresses associated with that spending or viewing key.
+
+## Privacy notes
+
+- Shielded transfers protect sender, receiver, and amount inside the MASP.
+- Shielding and unshielding are boundary events. Timing, token type, amount, and transparent addresses can still leak metadata.
+- Use separate transparent accounts for unrelated activity.
+- Prefer liquid assets when entering or exiting a shielded pool.
+- Run shielded sync after failed or interrupted shielded actions.
+- Test with small amounts before moving meaningful funds.
+
+## Related pages
+
+- [Namada Protocol](/privacy-tools/namada-protocol)
+- [Namada Privacy Best Practices](/research/namada-privacy-and-best-practices)
+- [Shielded ecosystems comparison](/research/shielded-ecosystems-comparison)
+- [Shielded pools](/using-zcash/shielded-pools)
+
+## Resources
+
+- [Namada Docs: Shielded Transfers](https://docs.namada.net/users/shielded-accounts/shielded-transfers)
+- [Namada Docs: Shielding Assets](https://docs.namada.net/users/shielded-accounts/shielding)
+- [Namada Docs: Unshielding Assets](https://docs.namada.net/users/shielded-accounts/unshielding)
+- [Namada Docs: Shielded Sync](https://docs.namada.net/users/shielded-accounts/shielded-sync)
+- [Namada Docs: Addresses on Namada](https://docs.namada.net/users/addresses)
+- [Namada Specs: MASP ledger integration](https://specs.namada.net/modules/masp/ledger-integration)

--- a/site/guides/Penumbra_pcli_Beginner_Guide.md
+++ b/site/guides/Penumbra_pcli_Beginner_Guide.md
@@ -1,0 +1,169 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Penumbra_pcli_Beginner_Guide.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Penumbra `pcli` Beginner Guide
+
+`pcli` is Penumbra's command-line wallet. It can create a wallet, sync private wallet state, show balances, send assets, stake, vote, swap, and withdraw over IBC.
+
+Penumbra commands and network details can change. Compare this guide with the current Penumbra docs before using real funds.
+
+## What you need
+
+- Linux or macOS.
+- A current `pcli` release.
+- A Penumbra RPC endpoint or your own Penumbra node.
+- A safe place to store your seed phrase.
+
+Penumbra is private by default. `pcli` includes a view service that syncs with the chain and scans with your viewing key so your wallet can detect notes that belong to you.
+
+## Install `pcli`
+
+Download current binaries from the Penumbra releases page, or use the install script:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/penumbra-zone/penumbra/releases/latest/download/pcli-installer.sh | sh
+pcli --version
+```
+
+The installer places the binary in `$HOME/.cargo/bin/`. If your shell cannot find `pcli`, add that directory to your `PATH`.
+
+## Create a wallet
+
+For a local software wallet:
+
+```sh
+pcli init soft-kms generate
+```
+
+To import an existing seed phrase:
+
+```sh
+pcli init soft-kms import-phrase
+```
+
+The `soft-kms` backend is convenient, but it stores key material locally. For better safety, use encryption:
+
+```sh
+pcli init --encrypted soft-kms generate
+```
+
+or re-encrypt an existing config:
+
+```sh
+pcli init re-encrypt
+```
+
+Save your seed phrase offline. Never share it.
+
+## Get an address
+
+Penumbra wallets control many numbered accounts. To show the address for account `0`:
+
+```sh
+pcli view address 0
+```
+
+Give this address to someone who wants to send you funds.
+
+## Sync wallet state
+
+After receiving funds, sync your local wallet view:
+
+```sh
+pcli view sync
+```
+
+Syncing also happens automatically, but running `sync` first can make later commands faster.
+
+## Check balances
+
+```sh
+pcli view balance
+```
+
+For staking-related balances:
+
+```sh
+pcli view staked
+```
+
+## Send funds
+
+Check your balance first:
+
+```sh
+pcli view balance
+```
+
+Then send an asset:
+
+```sh
+pcli tx send 10 penumbra --to penumbrav2t...
+```
+
+Confirm the recipient address and asset before approving the transaction.
+
+## Stake
+
+List validators:
+
+```sh
+pcli query validator list
+```
+
+Delegate:
+
+```sh
+pcli tx delegate 10 penumbra --to penumbravalid...
+```
+
+To undelegate, use `pcli tx undelegate` with the delegation-token amount. After the waiting period, claim the undelegated funds:
+
+```sh
+pcli tx undelegate-claim
+```
+
+## Swap
+
+To swap one asset into another:
+
+```sh
+pcli tx swap --into gm 1 penumbra
+```
+
+Only swap assets you understand. Liquidity and pricing can change.
+
+## IBC withdrawals
+
+View available IBC channels:
+
+```sh
+pcli query ibc channels
+```
+
+Use only channels you trust. Incorrect or unsupported IBC routes may fail or send assets somewhere unexpected.
+
+## Safety notes
+
+- Keep your seed phrase offline.
+- Keep `pcli` updated to the version expected by the network.
+- Use encrypted custody for real funds.
+- Test with small amounts first.
+- Confirm addresses and IBC channels before sending.
+- Consider Prax if you prefer a browser-wallet flow.
+
+## Related pages
+
+- [Penumbra](/privacy-tools/penumbra)
+- [Shielded ecosystems comparison](/research/shielded-ecosystems-comparison)
+- [Zcash wallet privacy decision tree](/using-zcash/zcash-wallet-privacy-decision-tree)
+
+## Resources
+
+- [Penumbra Guide: Using `pcli`](https://guide.penumbra.zone/usage/pcli)
+- [Penumbra Guide: Installing `pcli`](https://guide.penumbra.zone/usage/pcli/install)
+- [Penumbra Guide: Generating a wallet](https://guide.penumbra.zone/usage/pcli/wallet)
+- [Penumbra Guide: Software custody backend](https://guide.penumbra.zone/usage/pcli/wallet/softkms)
+- [Penumbra Guide: Viewing balances](https://guide.penumbra.zone/usage/pcli/balance)
+- [Penumbra Guide: Sending transactions](https://guide.penumbra.zone/usage/pcli/transaction)

--- a/site/guides/Ycash_Wallet_and_Node.md
+++ b/site/guides/Ycash_Wallet_and_Node.md
@@ -1,0 +1,131 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Ycash_Wallet_and_Node.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Ycash Wallet and Node Quickstart
+
+This guide gives Zcash users a practical starting point for using Ycash wallets and running `ycashd`.
+
+Ycash is a separate chain from Zcash. Use Ycash software for YEC and Zcash software for ZEC.
+
+## Choose a wallet
+
+### YWallet
+
+YWallet is a light wallet for Android, iOS, and desktop. The Ycash wallet page describes it as a shielded wallet with Warp Sync support.
+
+Basic setup:
+
+1. Download YWallet from the official YWallet installation page.
+2. Create a new wallet or restore an existing wallet.
+3. Back up the seed or keys before receiving funds.
+4. Confirm the wallet is set to Ycash, not another coin.
+5. Let the wallet finish syncing before relying on the displayed balance.
+
+### YecWallet
+
+YecWallet is a full-node Ycash wallet. It includes `ycashd`, configures it for the user, and downloads the Ycash blockchain.
+
+Basic setup:
+
+1. Download YecWallet from the official Ycash wallet page or GitHub releases.
+2. Install the release for your operating system.
+3. Start YecWallet and let it sync.
+4. Back up wallet data before receiving funds.
+5. Keep the wallet updated when new Ycash releases are published.
+
+### Paper wallets
+
+YecPaperWallet is also listed by Ycash. Only use a paper wallet if you understand offline generation, safe printing, storage, and recovery. Paper wallets can be fragile if the paper is lost, damaged, photographed, or generated on an unsafe device.
+
+## Run `ycashd`
+
+`ycashd` is the Ycash full node implementation. A full node downloads and verifies the Ycash chain and exposes RPC commands through `ycash-cli`.
+
+### 1. Download the release
+
+Download the current `ycashd` release from the official Ycash GitHub releases page. Choose the correct package for your operating system and architecture.
+
+If release signatures or checksums are provided, verify them before running the binaries.
+
+### 2. Check the binaries
+
+After unpacking the release, check that the binaries run:
+
+```sh
+./ycashd --version
+./ycash-cli --version
+```
+
+### 3. Start the node
+
+Start `ycashd` and allow it to connect to peers:
+
+```sh
+./ycashd -daemon
+```
+
+Initial sync can take a long time because the node stores the Ycash transaction history.
+
+### 4. Check sync status
+
+Use `ycash-cli` to query the node:
+
+```sh
+./ycash-cli getblockchaininfo
+```
+
+Useful fields include the current block height and sync progress.
+
+To inspect network status:
+
+```sh
+./ycash-cli getnetworkinfo
+```
+
+To list available RPC commands:
+
+```sh
+./ycash-cli help
+```
+
+To stop the node cleanly:
+
+```sh
+./ycash-cli stop
+```
+
+## Import keys carefully
+
+Ycash documents `importprivkey` for transparent keys and `z_importkey` for shielded keys. Importing keys can trigger a blockchain rescan so the wallet can find transactions for those keys.
+
+If you are importing keys from the 2019 Zcash fork period:
+
+- Understand which keys you are importing.
+- Move any current ZEC away from old keys first.
+- Use official Ycash software.
+- Expect rescanning to take time.
+- Use `getrescaninfo` to check rescan progress when available.
+
+## Safety checklist
+
+- Back up seed phrases and wallet files before receiving funds.
+- Keep ZEC and YEC workflows separate.
+- Confirm address prefixes before sending.
+- Keep node and wallet software updated.
+- Test with small amounts before moving meaningful funds.
+- Never paste private keys into websites or chat apps.
+
+## Related pages
+
+- [Ycash for Zcash users](/privacy-tools/ycash)
+- [Wallet backup checklist](/using-zcash/wallet-backup-checklist)
+- [Zcash wallet privacy decision tree](/using-zcash/zcash-wallet-privacy-decision-tree)
+
+## Resources
+
+- [Ycash wallets](https://y.cash/wallets/)
+- [Ycash Foundation: Full Node](https://www.ycash.xyz/full_node/)
+- [Ycash Foundation: ycashd and YecWallet](https://www.ycash.xyz/docs/yecwallet_and_ycashd/)
+- [Ycash Foundation: Importing Private Keys](https://www.ycash.xyz/docs/privkey_import/)
+- [Ycash GitHub releases](https://github.com/ycashfoundation/ycash/releases)


### PR DESCRIPTION
## Summary

Adds a 10-page ZecHub wiki guide pack focused on shielded Zcash usage and adjacent privacy ecosystems:

- Shielded merchant checklist
- Zcash wallet privacy decision tree
- Zcash transaction fees
- Shielded memo practices
- Wallet backup checklist
- Ycash for Zcash users
- Ycash wallet and node quickstart
- Penumbra `pcli` beginner guide
- Namada shielded transfers
- Shielded ecosystems comparison

Also adds contextual links from existing wallet, transaction, memo, payment processor, Namada, Penumbra, and shielded asset pages so readers can discover the new material.

## Validation

- `git diff --check`
- Local route check for all new/modified wiki links
- External link check for 48 source/resource URLs