### PR TITLE
Add ZecMap wiki page

### DIFF
--- a/site/Using_Zcash/zecmap.md
+++ b/site/Using_Zcash/zecmap.md
@@ -1,0 +1,240 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecMap
+
+## TL;DR
+
+ZecMap is a community merchant directory for finding businesses, services, and community campaigns connected to Zcash. Its main goal is simple: make it easier for people to discover where ZEC is accepted, submit new locations, verify existing listings, and help grow real-world Zcash usage.
+
+Useful links:
+
+- [ZecMap website](https://zecmap.com/)
+- [ZecMap GitHub](https://github.com/zecmap)
+- [ZecMap on X](https://twitter.com/zecmap)
+- [ZecMap Telegram](https://t.me/zecmap)
+- [Zcash Community Forum discussion](https://forum.zcashcommunity.com/t/seeking-ideas-and-feedback-for-zec-map/55505)
+
+---
+
+## What is ZecMap?
+
+ZecMap is a global map and directory for places that accept Zcash. It helps users find cafes, restaurants, retail shops, online services, VPN providers, charities, and other merchants that support ZEC payments.
+
+The project is designed around three practical needs:
+
+1. **Discovery:** users need a quick way to find where ZEC can be spent.
+2. **Verification:** community members need a way to confirm that listings are still accurate.
+3. **Contribution:** people who know local Zcash-friendly businesses need a simple way to add them.
+
+The live site describes itself as a "Global Zcash Directory" and focuses on businesses accepting Zcash, merchant browsing, map search, listing submission, location verification, reviews, contributor profiles, and charity campaigns.
+
+---
+
+## Why ZecMap matters
+
+Zcash is useful as private digital cash only if people can actually spend it. Wallets and payment processors are important, but users also need a social layer that answers everyday questions:
+
+- Where can I use ZEC near me?
+- Which online services accept ZEC?
+- Has anyone verified this listing recently?
+- How can I help add businesses in my city?
+- Which merchants are actively participating in the Zcash ecosystem?
+
+ZecMap gives the community a shared place to collect those answers.
+
+---
+
+## Main features
+
+### Global merchant map
+
+The map view lets users explore businesses by location. ZecMap uses OpenStreetMap-based map data and organizes listings into categories such as local merchants and privacy services.
+
+### Merchant directory
+
+The browse view lists merchants in a searchable format. This is useful when a user wants to find a business by name, category, or region without navigating the map first.
+
+### Business detail pages
+
+Each listing can include a business name, category, description, website, location, contact details, and optional Zcash address. Business pages can also show reviews, verification status, and directions.
+
+### Submit a business
+
+Community members can add a business through the **Add Listing** flow. The current form supports the business name, category, description, website, address or map pin, contact email, Twitter/X handle, optional logo, and optional Zcash address.
+
+### Reviews and verification
+
+Signed-in users can review businesses and verify locations. This matters because merchant directories go stale quickly unless people who visit the location can report whether the listing is still real.
+
+### Contributor profiles
+
+ZecMap includes profile and contributor features so community members can build a visible record of submitted listings, reviews, and verifications.
+
+### Charity campaigns
+
+The project also includes a charity campaign area. Campaigns are intended to be reviewed before going live, which helps keep fundraising listings safer and more trustworthy.
+
+---
+
+## How users can find Zcash-accepting businesses
+
+There are two basic workflows:
+
+### 1. Explore the map
+
+Use the map when location matters. This is the best fit for:
+
+- finding a nearby cafe, shop, restaurant, or service
+- seeing whether a city has any Zcash-friendly businesses
+- planning a trip around places that accept ZEC
+- checking whether a listing has enough location detail to visit in person
+
+### 2. Browse the directory
+
+Use the directory when the business type matters more than the exact location. This is better for:
+
+- finding online shops
+- finding VPN or privacy services
+- comparing merchants by category
+- looking for recently added listings
+
+---
+
+## Example use cases
+
+### Finding local merchants
+
+A user visiting a new city can open ZecMap, search the map, and look for local businesses that accept ZEC. If they pay with Zcash and the listing is accurate, they can help by leaving a review or verification.
+
+### Finding online shops and services
+
+Not every Zcash payment happens in person. ZecMap can also help users find online services that accept ZEC, such as privacy tools, e-commerce sites, or software services.
+
+### Helping businesses become discoverable
+
+If a business already accepts ZEC but is not listed, a community member can submit the listing with a description, website, category, and location. That makes the business easier to find for the next user.
+
+### Supporting community fundraising
+
+ZecMap's charity section gives the community a place to discover ZEC-based fundraising campaigns. Since campaigns require review, the goal is to balance openness with basic trust and safety.
+
+---
+
+## Adding a business
+
+To add a business:
+
+1. Go to [ZecMap](https://zecmap.com/).
+2. Choose **Add Listing**.
+3. Enter the business name and category.
+4. Add a short description explaining what the business offers.
+5. Add the website or contact information if available.
+6. Add an address, or pin the location on the map.
+7. Optionally add a Zcash address and logo.
+8. Submit the listing for review.
+
+Good submissions include enough detail for someone else to verify the listing later. A useful listing should answer:
+
+- What is the business?
+- Where is it?
+- Does it currently accept ZEC?
+- Is there a website, social account, or contact point?
+- Is the listing for a physical location, online service, or both?
+
+---
+
+## Verification and approval
+
+ZecMap is built around community-submitted information, so verification matters.
+
+The basic flow is:
+
+1. A contributor submits a listing.
+2. The listing is reviewed before it appears publicly.
+3. Other users can visit, review, or verify the business.
+4. If information changes, the community can help keep the listing accurate.
+
+The Zcash Community Forum discussion for ZecMap also describes a privacy-conscious approach to verification: the team wants to keep personal data sharing minimal while still reducing scams and low-quality submissions.
+
+---
+
+## Community contributor role
+
+ZecMap depends on people who know their local area. Contributors can help by:
+
+- adding businesses that already accept ZEC
+- checking whether existing listings are still accurate
+- leaving reviews after visiting a merchant
+- reporting stale or incorrect information
+- helping businesses understand how to accept Zcash
+- contributing code, translations, or documentation
+- sharing ZecMap with local Zcash communities
+
+This is especially useful in regions where Zcash adoption is happening through local communities rather than large payment processors.
+
+---
+
+## Contributor rewards and merchant incentives
+
+The ZecMap forum proposal describes several incentive ideas for growing real-world usage:
+
+- users may be rewarded for proving real-world ZEC payments at physical locations
+- merchants may earn ranking points when ZEC payments are reported with privacy protection
+- top merchants may receive monthly ZEC rewards
+- early listed businesses may receive a welcome reward
+
+These ideas should be treated as program plans rather than a guarantee for every listing. Reward mechanics can change as the project learns what prevents spam, protects user privacy, and creates real adoption rather than fake activity.
+
+---
+
+## Roadmap and future development
+
+The public discussion around ZecMap includes several planned or proposed directions:
+
+### Mobile apps
+
+The original project concept described Android and iOS apps. Mobile support matters because merchant discovery usually happens while people are out in the real world.
+
+### Multilingual support
+
+The forum discussion mentioned English as the primary language, with planned support for Spanish, German, French, and Turkish. More languages would help local Zcash communities keep their own merchant data accessible.
+
+### Payment integration
+
+Future payment integration could make it easier for users to move from "I found a merchant" to "I can pay this merchant with ZEC." This may include payment request links, wallet integrations, or merchant payment tools.
+
+### Contributor ranking
+
+Ranking contributors can help surface people who consistently add useful, verified listings. It also gives local community members visible credit for adoption work.
+
+### Directory expansion
+
+The directory can expand beyond local merchants into online shops, VPN services, charities, payment processors, and other ZEC-friendly services.
+
+### Open data and ecosystem integrations
+
+Community feedback has also encouraged open merchant data that wallets, websites, and other apps can reuse. This would make ZecMap more useful as infrastructure, not only as a standalone website.
+
+---
+
+## Practical tips for good listings
+
+- Prefer official business links over screenshots or hearsay.
+- Add the exact address when it is safe and relevant.
+- Use a clear category.
+- Keep descriptions short and factual.
+- Do not publish personal information that the business has not made public.
+- If a business accepts ZEC only through a specific payment flow, mention that.
+- Recheck older listings before relying on them for travel or payments.
+
+---
+
+## Related ZecHub pages
+
+- [Wallets](/using-zcash/wallets)
+- [Payment Processors](/using-zcash/payment-processors)
+- [Payment Request URIs](/using-zcash/payment-request-uris)
+- [Buying ZEC](/using-zcash/buying-zec)
+- [Zcash Community Projects](/zcash-community/community-projects)

--- a/site/Zcash_Community/Community_Projects.md
+++ b/site/Zcash_Community/Community_Projects.md
@@ -182,7 +182,7 @@ Zectastic.com is Launch the Zcash rocket, Play the memory game, and Follow the l
 
 Zecmap is The global map of businesses accepting Zcash. Discover, verify, and contribute to places that support privacy-focused payments.
 
-[Visit Site](https://zecmap.com/)
+[Visit Site](https://zecmap.com/) | [Full Wiki Page](/using-zcash/zecmap)
 
 
 ## ZODL


### PR DESCRIPTION
Closes #1654

Added a ZecMap page under Using Zcash. It covers the merchant directory, finding ZEC-accepting businesses, submitting listings, verification/review, contributor roles, rewards/incentive notes, and future roadmap items.

Also linked it from the existing ZecMap entry in Community Projects.

Checked:
- git diff --check