### PR TITLE
docs: standardize Halo and Viewing Keys pages

### DIFF
--- a/site/Zcash_Tech/Halo.md
+++ b/site/Zcash_Tech/Halo.md
@@ -4,127 +4,152 @@
 
 # Halo
 
-
-## What is Halo?
-
-Halo is a trustless, recursive zero-knowledge proof (ZKP) discovered by Sean Bowe at Electric Coin Co. It eliminates the trusted setup and allows greater scalability of the Zcash blockchain. Halo was the first zero-knowledge proof system that is both efficient & recursive widely regarded as a scientific breakthrough.
+Halo is a trustless, recursive zero-knowledge proof system discovered by Sean Bowe at Electric Coin Co. It removed the need for a trusted setup and made recursive proof composition practical enough to become part of Zcash's long-term scalability and privacy roadmap. Halo was widely regarded as a scientific breakthrough because it was the first zero-knowledge proof system to combine efficient recursion with no trusted setup.
 
 ![halo](https://electriccoin.co/wp-content/uploads/2021/01/Halo-on-Z-1440x720.png "halo")
 
+## TL;DR
 
-**Components**
+- Halo is a zero-knowledge proof breakthrough that lets proofs verify other proofs efficiently.
+- It eliminates the trusted setup requirement used by earlier Zcash shielded pools such as Sprout and Sapling.
+- Recursive proofs make it possible to compress large amounts of computation into a small proof.
+- Halo 2 is the Rust implementation and proving system used by Zcash Orchard, which activated with Network Upgrade 5 (NU5) in 2022.
+- The same research has influenced Filecoin, Ethereum research, zkRollups, and other zero-knowledge systems.
 
-Succinct Polynomial Commitment Scheme: Allows a committer to commit to a polynomial with a short string that can be used by a verifier to confirm claimed evaluations of the committed polynomial.
+## Core Explanation
 
-Polynomial Interactive Oracle Proof: Verifier asks prover (algorithm) to open all commitments at various points of their choosing using polynomial commitment scheme & checks identity holds true between them. 
+Zcash uses zero-knowledge proofs so that shielded transactions can prove they are valid without revealing sender, receiver, amount, or note details to the public blockchain. Earlier Zcash proof systems were secure, but they depended on setup ceremonies that produced public proving and verification parameters.
 
+Halo changed that design. Instead of relying on a trusted setup for each application, Halo uses recursive proof composition and polynomial commitment techniques to let proofs reason about earlier proofs. This means a verifier can check the latest proof or accumulator state and gain confidence that all previous linked proofs were valid.
 
-### No Trusted Setup
+The practical result for Zcash is simpler trust assumptions, stronger long-term upgradeability, and a foundation for scaling shielded computation beyond one-off transaction proofs.
 
-zkSNARKs rely on a common reference string (CRS) as a public parameter for proving & verifying. This CRS must be generated in advance by a trusted party. Until recently, elaborate secure multi-party computations (MPC) as those performed by Aztec network & Zcash were necessary to mitigate the risk involved during this [trusted setup ceremony](https://zkproof.org/2021/06/30/setup-ceremonies/amp/). 
+### Key Components
 
-Previously Zcash's Sprout & Sapling shielded pools utilised the BCTV14 & Groth 16 zk-proving systems. While these were secure there were limitations. They were not scalable as they were tied to a single application, the "toxic waste" (remnants from cryptographic material generated during the genesis ceremony) could persist, and there was an element of trust (albeit minute) for users to deem the ceremony acceptable.
+**Succinct polynomial commitment scheme.** A prover commits to a polynomial with a short value. Later, a verifier can check claimed evaluations of that committed polynomial without seeing every detail of the original computation.
 
-By repeatedly collapsing multiple instances of hard problems together over cycles of elliptic curves so that computational proofs can be used to reason about themselves efficiently (Nested amortization) the need for a trusted setup is eliminated. This also means that the structured reference string (output from ceremony) is upgradeable enabling applications such as smart contracts.
+**Polynomial interactive oracle proof.** The verifier asks the prover to open commitments at selected points, then checks that the expected identities hold between those openings.
 
-Halo provides users with two important assurances regarding the security of the large-scale zero-knowledge proof system. Firstly, it enables users to prove that no one who was involved in the genesis ceremony has created a secret backdoor to execute fraudulent transactions. Secondly, it allows users to demonstrate that the system has remained secure over time, even as it has undergone updates and changes.
+**Nested amortization.** Halo repeatedly collapses multiple instances of hard problems together over cycles of elliptic curves. In plain terms, it lets proof work be folded into smaller objects that can themselves be checked by later proofs.
 
-[Sean Bowes Explainer on Dystopia Labs](https://www.youtube.com/watch?v=KdkVTEHUxgo) 
- 
+**Accumulation scheme.** Halo 2 generalizes the recursive approach by adding proofs to an accumulator. Each new proof reasons about the previous accumulator state, so checking the current accumulator gives confidence in the whole chain of earlier proofs.
 
+## No Trusted Setup
 
-### Recursive Proofs
+Traditional zk-SNARK systems rely on a common reference string (CRS) as a public proving and verification parameter. That CRS must be generated in advance. If secret randomness from the ceremony, often called "toxic waste," were retained by a malicious participant, it could create systemic risk.
 
-Recursive proof composition allows a single proof to attest to the correctness of practically unlimited other proofs, allowing a large amount of computation (and information) to be compressed. This is an essential component for scalablilty, not least because it allows us to horizontally scale the network while still allowing pockets of participants to trust the integrity of the remainder of the network.
+Zcash's Sprout and Sapling shielded pools used BCTV14 and Groth16 proof systems. These systems were secured through elaborate multi-party computation ceremonies, similar to ceremonies used by other projects such as Aztec and Zcash itself. Those ceremonies greatly reduce trust, but users still need confidence that at least one participant destroyed their secret material. For background, see this overview of [trusted setup ceremonies](https://zkproof.org/2021/06/30/setup-ceremonies/amp/).
 
-Prior to Halo, achieving recursive proof composition required large computational expense and a trusted setup. One of the main discoveries was a technique called **nested amortization**. This technique allows for recursive composition using the polynomial commitment scheme based on inner product argument, massively improving on performance and avoiding the trusted setup.
+Halo removes that recurring ceremony requirement. This matters because:
 
-In the [Halo paper](https://eprint.iacr.org/2019/1021.pdf), we fully described this polynomial commitment scheme and discovered a new aggregation technique existed in it. The technique allows a large number of independently created proofs to be verified nearly as quickly as verifying a single proof. This alone would offer a better alternative to the earlier zk-SNARKs used in Zcash.
+- protocol upgrades no longer need a new trusted setup ceremony for each major proof-system change;
+- applications can be upgraded more safely because the structured reference string is not tied to one fixed circuit;
+- users gain stronger assurance that no ceremony participant can use leftover toxic waste to create fraudulent shielded value.
 
+[Sean Bowe's explainer on Dystopia Labs](https://www.youtube.com/watch?v=KdkVTEHUxgo) is a useful non-paper introduction to the trust model.
 
-### Halo 2
+## Recursive Proofs
 
-Halo 2, is a high-performance zk-SNARK implementation written in Rust which eliminates the need for a trusted setup while setting the stage for scalability in Zcash. 
+Recursive proof composition allows one proof to attest to the correctness of other proofs. Instead of every participant independently rechecking a long sequence of computations, the system can compress that history into a proof or accumulator that is much cheaper to verify.
+
+For Zcash, recursion is important because it opens the door to:
+
+- horizontal scaling while preserving confidence in the rest of the network;
+- compression of large batches of shielded computation;
+- future distributed systems where the integrity of many proofs can be checked through a smaller verification object;
+- higher Layer 1 capacity for full-node users at the upper end of network usage.
+
+Before Halo, recursive proof composition usually required high computational expense and a trusted setup. Halo's nested amortization technique made recursion more practical by using an inner-product-argument-based polynomial commitment scheme. The [Halo paper](https://eprint.iacr.org/2019/1021.pdf) describes the commitment scheme and the aggregation technique that allows many independently created proofs to be verified nearly as quickly as one proof.
+
+## Halo 2 and Orchard
+
+Halo 2 is a high-performance zk-SNARK implementation written in Rust. It eliminates trusted setup requirements while preparing Zcash for future scaling work.
 
 <a href="">
-    <img src="https://electriccoin.co/wp-content/uploads/2020/09/Halo-puzzle-03-1024x517.jpg" alt="" width="500" height="300"/>
+    <img src="https://electriccoin.co/wp-content/uploads/2020/09/Halo-puzzle-03-1024x517.jpg" alt="Halo puzzle illustration" width="500" height="300"/>
 </a>
 
-It includes a generalization of our approach called an **accumulation scheme**. This new formalization exposes how our nested amortization technique actually works; by adding proofs to an object called an **accumulator,** where the proofs reason about the previous state of the accumulator, we can check that all previous proofs were correct (by induction) simply by checking the current state of the accumulator.
+Halo 2 introduced an accumulation-scheme framing for nested amortization. Proofs are added to an accumulator, and later proofs reason about the accumulator's previous state. By induction, checking the current state establishes that the earlier proof chain was correct.
 
 <a href="">
-    <img src="https://i.imgur.com/l4HrYgE.png" alt="" width="500" height="300"/>
+    <img src="https://i.imgur.com/l4HrYgE.png" alt="Halo 2 accumulator diagram" width="500" height="300"/>
 </a>
 
+Halo 2 also benefited from advances in polynomial IOPs. As teams discovered protocols more efficient than Sonic, such as Marlin, PLONK became especially important because it gives developers flexible ways to design efficient application-specific implementations and can provide about 5x better prover time than Sonic in the relevant benchmark context. See this [overview of PLONK](https://www.youtube.com/watch?v=P1JeN30RdwQ) for more context.
 
+Zcash's Orchard shielded pool, activated with NU5 in mid-2022, is the Zcash Network implementation built on this proof-system direction. Orchard uses a turnstile-style migration design similar to the Sprout-to-Sapling transition, encouraging funds to move toward the newer trustless pool while older pools can be retired over time.
 
-In parallel, many other teams were discovering new Polynomial IOPs that were more efficient than Sonic (used in Halo 1), such as Marlin. 
+Orchard also introduced "Actions" as a replacement for the older input/output framing. Actions reduce transaction metadata and support the privacy improvements that came with the new pool.
 
-The most efficient of these new protocols is PLONK, which grants enormous flexibility in designing efficient implementations based on application-specific needs and providing 5x better prover time from Sonic.
+## Practical Implications
 
-[Overview of PLONK](https://www.youtube.com/watch?v=P1JeN30RdwQ)
+**Stronger monetary soundness.** Removing trusted setup reduces the risk that hidden ceremony material could ever be used to create counterfeit shielded value.
 
+**Cleaner protocol upgrades.** Future upgrades do not need to coordinate a new ceremony every time a major proof-system change is introduced.
 
-### How does this benefit Zcash?
+**Lower long-term attack surface.** Retiring older shielded pools and consolidating around newer proof systems reduces implementation complexity.
 
-The Orchard Shielded pool activated with NU5 & is the implementation of this new proof system on the Zcash Network. Guarded by the same turnstile design as used between Sprout and Sapling with the intent to gradually retire the older shielded pools. This encourages migration to a fully trustless proof system, reinforcing confidence in the soundness of the monetary base, and reducing the implementation complexity and attack surface of Zcash overall. Following the activation of NU5 mid 2022, integration of recursive proofs became possible (although this is not complete). Several privacy enhancements were also made tangentially. The introduction of 'Actions' to replace inputs/outputs helped reducing the amount of transaction metadata. 
+**Better scalability path.** Recursive proofs can compress very large amounts of computation. This is useful for Zcash scalability, Proof of Stake research, Zcash Shielded Assets, and other future extensions.
 
-Trusted setups are generally difficult to coordinate & presented a systemic risk. It would be necessary to repeat them for each major protocol upgrade. Removing them presents a substantial improvement for safely implementing new protocol upgrades. 
+## Common Mistakes
 
-Recursive proof composition holds the potential for compressing unlimited amounts of computation, creating auditable distributed systems, making Zcash highly capable particularly with the shift to Proof of Stake. This is also useful for extensions such as Zcash Shielded Assets and improving Layer 1 capacity at the higher end of full node usage in the coming years for Zcash.
+**Thinking Halo is only an optimization.** Halo is not just a faster proof system. Its main breakthrough is eliminating trusted setup while making recursive proof composition practical.
 
+**Assuming Orchard and Sapling share the same trust model.** Sapling remains important, but it used a trusted setup. Orchard uses the Halo 2 proof system and removes that ceremony requirement.
 
-## Halo in the wider ecosystem 
+**Confusing Halo 1, Halo 2, and Orchard.** Halo is the original proof-system breakthrough. Halo 2 is the Rust implementation and proof-system framework. Orchard is the Zcash shielded pool that uses this technology.
 
-The Electric Coin Company has entered into an agreement with Protocol Labs, the Filecoin Foundation, and the Ethereum Foundation to explore Halo R&D, including how the technology might be used in their respective networks. The agreement aims to provide better scalability, interoperability and privacy across ecosystems and for Web 3.0.
+**Treating recursion as already fully deployed everywhere in Zcash.** NU5 made recursive-proof integration possible, but broader recursive scaling work is still an ongoing area of development.
 
-Additionally, Halo 2 is under the [MIT and Apache 2.0 open-source licenses](https://github.com/zcash/halo2#readme), meaning anyone in the ecosystem can build with the proving system.
+## Halo in the Wider Ecosystem
+
+Electric Coin Co. entered into an agreement with Protocol Labs, the Filecoin Foundation, and the Ethereum Foundation to explore Halo research and development. The shared goal was to investigate how Halo-style technology could improve scalability, interoperability, and privacy across Web3 systems.
+
+Halo 2 is available under the [MIT and Apache 2.0 open-source licenses](https://github.com/zcash/halo2#readme), so projects outside Zcash can build with the proving system.
 
 ### Filecoin
 
-Since its deployment, the halo2 library has been adopted in projects like the zkEVM, there is potential integration of Halo 2 into the proof system for the Filecoin Virtual Machine. Filecoin requires numerous costly proofs of spacetime / proofs of replication. Halo2 will be pivotal in compressing the space usage, better scaling the network.
+The halo2 library has been adopted in projects such as zkEVM work, and there has been potential integration of Halo 2 into proof systems for the Filecoin Virtual Machine. Filecoin uses many costly proofs of spacetime and proofs of replication, so proof compression can help the network scale.
 
-[Filecoin Foundation video with Zooko](https://www.youtube.com/watch?v=t4XOdagc9xw)
+- [Filecoin Foundation video with Zooko](https://www.youtube.com/watch?v=t4XOdagc9xw)
+- [ECC x Filecoin blog post](https://electriccoin.co/blog/ethereum-zcash-filecoin-collab/)
 
-Additionally, it would be highly beneficial to both the Filecoin and Zcash ecosystems if Filecoin storage payments could be made in ZEC, affording the same level of privacy for storage purchases that exists in Zcash shielded transfers. This support would add the ability to encrypt files in Filecoin storage and add support to mobile clients so that they could **attach** media or files to a Zcash encrypted memo. 
-
-[ECC x Filecoin Blog Post](https://electriccoin.co/blog/ethereum-zcash-filecoin-collab/)
+Zcash and Filecoin could also benefit from private storage payments. If Filecoin storage purchases could be paid in ZEC, users could retain shielded-payment privacy while paying for encrypted file storage and attaching media or files to Zcash encrypted memos.
 
 ### Ethereum
 
-Implementation of a Halo 2 proof for the efficient Verifiable Delay Function (VDF) being developed. A VDF is a cryptographic primitive that has many potential use cases. 
+Halo 2 research has also been explored for efficient verifiable delay functions (VDFs). A VDF is a cryptographic primitive that can provide general-purpose randomness for applications such as smart contracts and Proof of Stake leader election.
 
-It can be used as a source of general purpose randomness including use in smart contract applications as well as leader election in Proof of Stake on Ethereum & other protocols.
+ECC, the Filecoin Foundation, Protocol Labs, and the Ethereum Foundation have worked with [Supranational](https://www.supranational.net/), a vendor focused on hardware-accelerated cryptography, for potential GPU and ASIC VDF design and development.
 
-ECC, the Filecoin Foundation, Protocol Labs, and the Ethereum Foundation will also be working with [SupraNational](https://www.supranational.net/), a vendor specializing in hardware-accelerated cryptography, for potential GPU and ASIC design and development of the VDF.
+The [Privacy and Scaling Exploration group](https://appliedzkp.org/) also researches ways Halo 2 proofs can improve privacy and scalability in the Ethereum ecosystem. The group rolls up to the Ethereum Foundation and focuses broadly on zero-knowledge proofs and cryptographic primitives.
 
-The [Privacy and Scaling Exploration group](https://appliedzkp.org/) is also researching different ways Halo 2 proofs can improve privacy and scalability for the Ethereum ecosystem. This group rolls up to the Ethereum foundation, and has a broad focus on zero-knowledge proofs and cryptographic primitives. 
+### Other Projects Using Halo
 
-## Other projects using Halo
+- [Anoma, a privacy-preserving multichain atomic swap protocol](https://anoma.net/blog/an-introduction-to-zk-snark-plonkup)
+- [Orbis, an L2 zkRollup on Cardano](https://docs.orbisprotocol.com/orbis/technology/halo-2)
+- [DarkFi, a private L1 zkEVM blockchain](https://darkrenaissance.github.io/darkfi/architecture/architecture.html)
+- [Scroll, an L2 zkRollup on Ethereum](https://scroll.mirror.xyz/nDAbJbSIJdQIWqp9kn8J0MVS4s6pYBwHmK7keidQs-k)
 
-+ [Anoma, a privacy preserving multichain atomic swap protocol](https://anoma.net/blog/an-introduction-to-zk-snark-plonkup)
+## Related Pages
 
-+ [Oribis, an L2 zkRollup on Cardano](https://docs.orbisprotocol.com/orbis/technology/halo-2)
+- [zk-SNARKS](/site/Zcash_Tech/zk_SNARKS)
+- [Shielded Pools](/site/Using_Zcash/Shielded_Pools)
+- [Zcash Shielded Assets](/site/Zcash_Tech/Zcash_Shielded_Assets)
+- [What is ZEC and Zcash?](/site/Start_Here/What_is_ZEC_and_Zcash)
+- [Dash Integration of Zcash Orchard](/site/Research/Dash_Zcash_Orchard_Integration)
 
-+ [Darkfi, a private L1 zkEVM blockchain](https://darkrenaissance.github.io/darkfi/architecture/architecture.html)
+## Resources
 
-+ [Scroll, an L2 zkRollup on Ethereum](https://scroll.mirror.xyz/nDAbJbSIJdQIWqp9kn8J0MVS4s6pYBwHmK7keidQs-k)
+### Further Learning
 
+- [An introduction to ZKP and Halo 2 - Hanh Huynh Huu](https://www.youtube.com/watch?v=jDHWJLjQ9oA)
+- [Halo 2 with Daira and Str4d - ZKPodcast](https://www.youtube.com/watch?v=-lZH8T5i-K4)
+- [Technical explainer blog](https://electriccoin.co/blog/technical-explainer-halo-on-zcash/)
+- [Halo 2 Community Showcase - Ying Tong at Zcon3](https://www.youtube.com/watch?v=JJi2TT2Ahp0)
 
-**Further Learning**:
+### Documentation
 
-[An introduction to zkp and halo 2 - Hanh Huynh Huu](https://www.youtube.com/watch?v=jDHWJLjQ9oA)
-
-[Halo 2 with Daira & Str4d - ZKPodcast](https://www.youtube.com/watch?v=-lZH8T5i-K4)
-
-[Technical Explainer Blog](https://electriccoin.co/blog/technical-explainer-halo-on-zcash/)
-
-[Halo 2 Community Showcase - Ying Tong @Zcon3](https://www.youtube.com/watch?v=JJi2TT2Ahp0)
-
-**Documentation**
-
-[Halo 2 resources](https://github.com/adria0/awesome-halo2)
-
-[Halo 2 docs](https://zcash.github.io/halo2/)
-
-[Halo 2 github](https://github.com/zcash/halo2)
+- [Halo 2 resources](https://github.com/adria0/awesome-halo2)
+- [Halo 2 docs](https://zcash.github.io/halo2/)
+- [Halo 2 GitHub](https://github.com/zcash/halo2)

--- a/site/Zcash_Tech/Viewing_Keys.md
+++ b/site/Zcash_Tech/Viewing_Keys.md
@@ -4,58 +4,117 @@
 
 # Viewing Keys
 
-Shielded addresses enable users to transact while revealing as little information as possible on the Zcash blockchain. What happens when you need to disclose sensitive information around a shielded Zcash transaction to a specific party? Every shielded address includes a viewing key. Viewing keys were introduced in [ZIP 310](https://zips.z.cash/zip-0310) and added to the protocol in the Sapling network upgrade. Viewing keys are a crucial part of Zcash as they allow users to selectively disclose information about transactions.
+Viewing keys let a Zcash user selectively disclose shielded transaction information without handing over spending authority. They are one of the main tools that make Zcash privacy practical for exchanges, custodians, auditors, businesses, and users who need limited transparency for a specific purpose.
 
-### Why use a viewing key?
+## TL;DR
 
-Why would a user ever want to do this? From Electric Coin Co.'s blog on the matter...
+- A viewing key gives read access to shielded activity for an address or account.
+- A viewing key does not allow anyone to spend funds.
+- Viewing keys support selective disclosure: a user can reveal transaction history to a chosen party without making it public to everyone.
+- Incoming viewing keys are useful for detecting received payments while keeping spend keys offline.
+- Full viewing keys can reveal broader activity and should only be shared with trusted parties when needed.
 
-*- An exchange wants to detect when a customer deposits ZEC to a shielded address, while keeping the **spend authority** keys on secure hardware. The exchange could generate an incoming viewing key and load it onto an Internet-connected **detection** node, while the spending key remains on the more secure system.*
+## Core Explanation
 
-*- A custodian needs to provide visibility of their Zcash holdings to auditors. The custodian may generate a full viewing key for each of their shielded addresses and share that key with their auditor. The auditor will be able to verify the balance of those addresses and review past transaction activity to and from those addresses.* 
+Shielded Zcash addresses hide transaction details on-chain. That privacy is useful by default, but sometimes a user needs to prove something about shielded activity to another party. Examples include confirming deposits, providing audit visibility, or supporting enhanced due diligence.
 
-*- An exchange may need to conduct due diligence checks on a customer who makes deposits from a shielded address. The exchange could request the customers viewing key for their shielded address and use it to review the customers shielded transaction activity as part of these enhanced due diligence procedures.*
+Viewing keys solve this by separating read access from spend authority. A party with the right viewing key can scan the blockchain and see the shielded information that key is authorized to reveal, but cannot create transactions or move funds.
 
-### How to find your viewing key
+Viewing keys became a core part of Zcash's selective disclosure model through Sapling-era shielded addresses, and [ZIP 310](https://zips.z.cash/zip-0310) defines unified viewing keys for Unified Addresses.
 
-#### zcashd
+## Why Use a Viewing Key?
 
-* List all known addresses using *./zcash-cli listaddresses*
+Electric Coin Co. describes several common use cases:
 
-* Then issue the following command for either UA's or Sapling shielded addresses
+**Exchange deposit detection.** An exchange can keep spend authority on secure hardware while loading an incoming viewing key onto an Internet-connected detection node. The node can detect customer deposits to a shielded address without being able to spend the funds.
 
-  *./zcash-cli z_exportviewingkey "<UA or Z address>"*
+**Custodian audits.** A custodian can give an auditor a full viewing key for each relevant shielded address. The auditor can verify balances and review past transaction activity without taking control of the funds.
 
-#### Ywallet
+**Customer due diligence.** An exchange or regulated service may ask a customer to provide a viewing key for a shielded address so the service can review shielded transaction activity for a specific compliance workflow.
 
-* On the top right corner select "Backup", Authenticate your phone, then simply copy your viewing key that is displayed.
+The key tradeoff is scope. Viewing keys are powerful disclosure tools. Share them only when the recipient needs that information and you understand what the key reveals.
 
-### How to use your viewing key
+## How to Find Your Viewing Key
 
-#### zcashd
+### zcashd
 
-* Use the following with any vkey or ukey: 
+First list all known addresses:
 
-*./zcash-cli z_importviewingkey "vkey/ukey" whenkeyisnew 30000*
+```bash
+./zcash-cli listaddresses
+```
 
-#### ywallet
+Then export the viewing key for a Unified Address or Sapling shielded address:
 
-* In the top right corner, select "Account", click on "+" in the bottom right corner to add and import your viewing key to add your 'read-only' account.
+```bash
+./zcash-cli z_exportviewingkey "<UA or Z address>"
+```
+
+### YWallet
+
+1. Open the account in YWallet.
+2. Select **Backup** in the top-right corner.
+3. Authenticate on the device.
+4. Copy the viewing key shown by the wallet.
+
+## How to Use Your Viewing Key
+
+### zcashd
+
+Import a viewing key with:
+
+```bash
+./zcash-cli z_importviewingkey "vkey/ukey" whenkeyisnew 30000
+```
+
+The `whenkeyisnew` option tells `zcashd` how far back to rescan. The example block height `30000` comes from the original command example; choose a height that fits the age of the wallet or address you are importing.
+
+### YWallet
+
+1. Select **Account** in the top-right corner.
+2. Click **+** in the bottom-right corner.
+3. Choose the option to import a viewing key.
+4. Add the viewing key as a read-only account.
 
 <a href="">
-    <img src="https://i.ibb.co/C0b002N/image-2024-01-13-175554676.png" alt="" width="200" height="280"/>
+    <img src="https://i.ibb.co/C0b002N/image-2024-01-13-175554676.png" alt="YWallet viewing key import screen" width="200" height="280"/>
 </a>
 
+### zcashblockexplorer.com
 
-#### zcashblockexplorer.com
+You can also use the viewing-key tool at [zcashblockexplorer.com/vk](https://zcashblockexplorer.com/vk).
 
-* Simply point your browser to [here](https://zcashblockexplorer.com/vk) and wait for the results! note: this result is now on the zcashblockexplorer node and thus you're trusting this info with the owners of zcashblockexplorer.com
+This is convenient, but it changes the trust model. When a viewing key is entered into a third-party explorer, that service can see the information revealed by the key. Use this only when you are comfortable trusting the operator with that disclosure.
 
-### Resources
+## Practical Implications
 
-While a great technology, it's recommended that you use viewing keys on an as needed basis.
+**Viewing keys are for transparency, not custody.** They allow someone to see authorized shielded activity, but they do not move ZEC.
 
-Check out this tutorial on viewing keys. A list of resources on the subject is below if you want to dive deeper:
+**They are useful for operational separation.** A business can run online monitoring infrastructure with viewing-key access while keeping spend keys offline or on more secure hardware.
+
+**They can satisfy targeted disclosure needs.** A user can prove information to one counterparty without publishing transaction details to the whole blockchain.
+
+**They should be rotated or limited by account design when possible.** If a viewing key is no longer needed by a third party, stop relying on that address or account for new activity where that party should not retain visibility.
+
+## Common Mistakes
+
+**Sharing a viewing key publicly.** Anyone with the key can see the information it reveals. Treat it as sensitive data.
+
+**Confusing viewing keys with spending keys.** A viewing key cannot spend funds. A spending key or seed phrase can. Never share the seed phrase or spending key for audit or deposit detection use cases.
+
+**Using a web explorer without considering trust.** A third-party explorer may be useful for quick checks, but entering a viewing key gives that service access to the disclosed information.
+
+**Sharing more scope than needed.** If a party only needs incoming payment detection, do not provide broader viewing access unless that broader disclosure is intentional.
+
+## Related Pages
+
+- [Shielded Pools](/site/Using_Zcash/Shielded_Pools)
+- [Wallets](/site/Using_Zcash/Wallets)
+- [Zcash Wallet Syncing](/site/Zcash_Tech/Zcash_Wallet_Syncing)
+- [What is ZEC and Zcash?](/site/Start_Here/What_is_ZEC_and_Zcash)
+- [Halo](/site/Zcash_Tech/Halo)
+
+## Resources
 
 - [ECC, Explaining Viewing Keys](https://electriccoin.co/blog/explaining-viewing-keys/)
 - [ECC, Selective Disclosure and Viewing Keys](https://electriccoin.co/blog/viewing-keys-selective-disclosure/)


### PR DESCRIPTION
## Summary

- Standardizes the Halo page with a TL;DR, core explanation, no-trusted-setup section, recursive-proof explanation, Halo 2 / Orchard context, practical implications, common mistakes, related pages, and resources.
- Standardizes the Viewing Keys page with a TL;DR, core explanation, use cases, zcashd and YWallet steps, third-party explorer caution, practical implications, common mistakes, related pages, and resources.
- Preserves the existing external links and images from both pages while adding internal related-page navigation.

Closes #1674

## Validation

- `git diff --check`
- Compared original and updated external URL lists for both files to confirm the existing links/images are preserved.
- Verified every new internal related-page target exists in the repository.
