### PR TITLE
docs: add Zcash gaming privacy article

### DIFF
--- a/site/Zcash_Use_Cases/About.md
+++ b/site/Zcash_Use_Cases/About.md
@@ -40,6 +40,9 @@ Get paid in Zcash while keeping your clients and income private.
 ###  [Accept Payments as a Merchant](/zcash-use-cases/accept-payment-as-a-merchant)  
 Accept payments using a shielded address and avoid exposing customer transaction data
 
+###  [Privacy in Play: Zcash in Gaming](/zcash-use-cases/privacy-in-play-zcash-gaming)
+Use shielded ZEC for gaming payments, creator tips, tournament payouts, and private community economies.
+
 
 ###  [Run a Private Community Treasury](/zcash-use-cases/run-a-private-community-treasury)
 Use shielded addresses to hold shared funds and limit visibility of balances and transactions

--- a/site/Zcash_Use_Cases/Privacy_in_Play_Zcash_Gaming.md
+++ b/site/Zcash_Use_Cases/Privacy_in_Play_Zcash_Gaming.md
@@ -1,0 +1,279 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Use_Cases/Privacy_in_Play_Zcash_Gaming.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Privacy in Play: Zcash in the Global Gaming Ecosystem
+
+## TL;DR
+
+- Games create many small payments: skins, battle passes, server fees, tournament payouts, tips, and creator rewards.
+- Public blockchains can turn those payments into a visible player profile.
+- Zcash shielded transactions help hide sender, receiver, amount, and memo data when users stay inside shielded pools.
+- ZEC can support private gaming payments, but builders still need good wallet UX, refund flows, anti-fraud design, and compliance-aware operations.
+- The best gaming use cases are payments where privacy matters: player-to-player trades, creator tips, esports prizes, community treasuries, and agent-driven microtransactions.
+
+## Why Gaming Payments Leak Metadata
+
+Gaming payments are often small, frequent, and tied to identity.
+
+A single player may pay for:
+
+- A monthly subscription
+- A battle pass
+- Cosmetic items
+- Marketplace trades
+- Guild dues
+- Tournament entry
+- Streaming tips
+- In-game coaching
+- Mods, maps, or private servers
+
+On a transparent blockchain, those actions can create a public graph. If one address becomes linked to a gamer tag, streamer account, marketplace profile, Discord identity, or esports team, observers may infer spending habits, income, region, wealth, social groups, and play style.
+
+That is a problem because gaming communities are social. A player may want to support a creator, pay a teammate, or buy an item without making their wallet balance or transaction history public.
+
+## How Zcash Helps
+
+Zcash supports transparent and shielded transactions.
+
+Transparent transactions are public. They expose transaction amounts and address relationships in a way similar to Bitcoin.
+
+Shielded Zcash transactions are different. They use zero-knowledge proofs so the network can verify the transaction without revealing the sender, receiver, amount, or memo to the public blockchain.
+
+For gaming, this means Zcash can help with:
+
+- Private purchase history
+- Private player-to-player transfers
+- Private creator support
+- Private tournament payouts
+- Reduced public profiling of whales and high-value players
+- Less competitive intelligence for rival guilds, teams, or marketplaces
+
+The privacy benefit is strongest when both sides use shielded addresses and avoid unnecessary transparent hops.
+
+## Gaming Use Cases
+
+### Private Microtransactions
+
+Microtransactions are a natural fit for Zcash because they happen often and can reveal patterns.
+
+Examples:
+
+- A player buys cosmetic items without revealing total wallet balance.
+- A modded game server accepts small payments without publishing a list of paying users.
+- A game studio sells seasonal passes while limiting public payment graph analysis.
+
+Zcash memos can help attach private payment context, such as an order ID or server invoice reference. Builders should avoid putting sensitive personal information in memos, even though memos are encrypted for shielded transactions.
+
+### Creator Tips and Fan Support
+
+Gaming creators, streamers, speedrunners, modders, and tournament organizers often depend on tips.
+
+Zcash can help supporters send funds without exposing:
+
+- The supporter address
+- The tip amount
+- The creator's total received balance
+- The financial graph between fans and creators
+
+This is useful for creators who cover sensitive topics, operate in regions with financial surveillance, or simply do not want their revenue graph public.
+
+### Tournament and Esports Payouts
+
+Competitive gaming creates public leaderboards, prize pools, team contracts, and sponsorship payments.
+
+Transparent payouts can reveal:
+
+- Exact prize amounts
+- Team wallet balances
+- Sponsorship timing
+- Repeated payments to the same players
+- Player income patterns
+
+Shielded ZEC can support more private payouts while still allowing selective disclosure. For example, an organizer can keep public tournament results separate from private payment settlement, then share payment proof only with players, auditors, or sponsors who need it.
+
+### Player-to-Player Trades
+
+In-game economies often include item trades, coaching payments, account services, or community marketplace sales.
+
+A transparent chain can make it easy to trace who paid whom. That can expose high-value collectors, market makers, or players who prefer not to connect their gaming identity to their broader crypto wallet.
+
+With shielded Zcash, the payment layer can be separated from the public social layer.
+
+### Community Treasuries and Guilds
+
+Guilds, esports clubs, and server communities may hold shared funds for:
+
+- Hosting costs
+- Prize pools
+- Community rewards
+- Contributor payments
+- Emergency expenses
+
+Zcash can help a community treasury avoid publishing every inflow, outflow, and balance update. This matters when a public treasury balance could make a group a target or create social pressure around spending decisions.
+
+For shared custody, communities should also study threshold signing and multisig research such as FROST, because treasury privacy and treasury control are related but separate problems.
+
+### AI Agents and Game Economies
+
+Gaming is increasingly connected to agents: bots, non-player characters, automated marketplaces, moderation tools, recommendation systems, and creator tools.
+
+If agents make payments for API calls, generated assets, in-game services, or market actions, public payment rails can reveal usage patterns.
+
+Projects such as Zimppy explore shielded machine payments on Zcash, where a service can verify payment with a viewing key while the public chain does not reveal who paid or how much. That model is relevant for games where agents need to pay for small services without exposing strategy or player behavior.
+
+## Example Payment Flows
+
+### Buying an Item from a Game Server
+
+1. The player opens the game shop.
+2. The server creates an invoice with a shielded Zcash address and an order reference.
+3. The player sends ZEC from a shielded wallet.
+4. The server detects the incoming payment using its wallet or viewing-key workflow.
+5. The game unlocks the item.
+6. The public chain does not reveal the player, merchant, amount, or memo when the payment stays shielded.
+
+### Paying a Tournament Winner
+
+1. The organizer publishes public results.
+2. Each winner provides a shielded address.
+3. The organizer sends prize payments privately.
+4. Winners can selectively disclose proof if required by sponsors, tax professionals, or event rules.
+5. Other competitors do not need to see the winner's wallet balance or future spending.
+
+### Tipping a Streamer
+
+1. A streamer posts a shielded address or creator profile.
+2. A fan sends ZEC with an optional private memo.
+3. The streamer receives the tip without exposing their donor graph.
+4. The fan does not have to reveal their full wallet history to the public.
+
+## Practical Builder Checklist
+
+### Use Shielded-by-Default Payments
+
+Prefer shielded addresses and unified address flows where wallet support is available. Do not make transparent addresses the default for privacy-sensitive gaming payments.
+
+### Keep Game Identity Separate from Wallet Identity
+
+Avoid forcing players to publicly bind a wallet address to a gamer tag. If an account needs proof of payment, use a private order reference, a signed receipt, or selective disclosure instead of public address linking.
+
+### Design Refunds Carefully
+
+Refunds can leak information if they are sent back through a transparent path or reused address. Ask users for a refund address when needed and explain what privacy level the refund path supports.
+
+### Avoid Sensitive Memos
+
+Encrypted memos are useful, but they are not a place for passwords, seed phrases, legal names, or private account recovery data. Use short order references or payment context only.
+
+### Plan for Moderation and Abuse
+
+Privacy does not remove the need for safety. Game operators still need anti-fraud controls, refund rules, support workflows, and terms of service.
+
+Good patterns include:
+
+- Server-side order IDs
+- Rate limits for automated purchases
+- Proof-of-payment receipts
+- Manual review for high-risk flows
+- Clear dispute windows
+
+### Offer Selective Disclosure
+
+Some users may need records for accounting, sponsorship, compliance, or tournament verification. Zcash viewing keys and wallet exports can support selective disclosure without making every payment public by default.
+
+## Risks and Challenges
+
+### Wallet Support
+
+The payment experience must be simple. If players need to understand pools, fees, memo formats, and address types before buying a small item, the flow will fail.
+
+Builders should document which wallets support shielded sends and receives, and should test mobile flows.
+
+### Exchange Compatibility
+
+Many users still acquire crypto through exchanges that may only support transparent deposits or withdrawals. A gaming payment flow should explain how to shield funds before spending when privacy matters.
+
+### Small Payment Fees and UX
+
+Game purchases can be tiny. Fees, confirmation time, retry logic, and minimum purchase sizes need careful design. For instant in-game delivery, builders may need a risk model for pending payments or a deposit/session system.
+
+### Public Metadata Outside the Chain
+
+Even if the Zcash payment is shielded, the game can still leak metadata:
+
+- Public leaderboards
+- Discord roles
+- Store receipts
+- Email confirmations
+- IP logs
+- Marketplace listings
+- Support tickets
+
+Zcash protects the payment layer. Builders still need privacy-aware product design around it.
+
+## Where Zcash Fits Best
+
+Zcash is most useful in gaming when the payment has one or more of these properties:
+
+- The payer does not want to reveal spending behavior.
+- The recipient does not want to reveal income or balance.
+- The amount is socially sensitive.
+- The payment links to a public identity such as a gamer tag or creator profile.
+- The transaction pattern reveals strategy, popularity, or market position.
+- The community values self-custody and censorship resistance.
+
+It is less useful when a game only needs a centralized database credit and the users do not care about self-custody or financial privacy.
+
+## Future Directions
+
+### Private Game Marketplaces
+
+Marketplaces could use shielded ZEC for settlement while keeping item listings public. This separates "what is for sale" from "who bought what and how much they hold."
+
+### Shielded Creator Economies
+
+Creators could receive tips, subscriptions, and one-off support without exposing supporter lists or total income to the public.
+
+### Private Prize Pools
+
+Tournament organizers could publish prize rules and winners while keeping settlement private.
+
+### Agent-Native Payments
+
+Games and creator tools may use agents for art generation, asset hosting, moderation, market making, analytics, or non-player character services. Shielded machine payments can reduce usage fingerprinting when those agents pay for services.
+
+### Zcash Shielded Assets
+
+If Zcash Shielded Assets become available, game-specific assets may eventually inherit shielded transfer properties. That could matter for private in-game currencies, tickets, or collectibles. This is a future direction, not a live assumption for builders today.
+
+## Beginner Example
+
+Imagine Alice plays a game where guild membership costs 2 ZEC per season.
+
+If Alice pays from a public address, anyone who connects that address to her gamer tag may see her balance and other payments.
+
+If Alice pays from a shielded wallet to the guild's shielded address, the payment can settle without publishing Alice's address, the guild address, the amount, or the memo publicly.
+
+The guild still knows Alice paid because it receives the payment. The public does not need to know.
+
+That is the core idea: privacy for the payment graph, while still allowing the people involved to verify what they need.
+
+## Related ZecHub Pages
+
+- [Wallets](/wallets)
+- [Shielded Pools](/shielded-pools)
+- [Payment Request URIs](/payment-request-uris)
+- [Creators and Tips](/creators-and-tips)
+- [Accept Payments as a Merchant](/zcash-use-cases/accept-payment-as-a-merchant)
+- [Run a Private Community Treasury](/zcash-use-cases/run-a-private-community-treasury)
+- [FROST](/frost)
+
+## References
+
+- [Zcash: Is Zcash traceable?](https://z.cash/learn/is-zcash-traceable/)
+- [Zcash: What are Zcash unified addresses?](https://z.cash/learn/what-are-zcash-unified-addresses/)
+- [Zcash Documentation: Addresses and Value Pools](https://zcash.readthedocs.io/en/latest/rtd_pages/addresses.html)
+- [Zcash Documentation: Wallet UX Checklist](https://zcash.readthedocs.io/en/master/rtd_pages/ux_wallet_checklist.html)
+- [Zcash ecosystem: Free2Z](https://z.cash/ecosystem/free2z/)
+- [Zimppy: Private Machine Payments on Zcash](https://zimppy.xyz/)


### PR DESCRIPTION
Submitted for #1557.

This adds a new Zcash use-case article, `Privacy in Play: Zcash in the Global Gaming Ecosystem`, covering private gaming payments, creator tips, tournament payouts, player-to-player trades, community treasuries, and agent-native payment flows.

I also linked it from the Zcash Use Cases index so it is easier to find.

Checks:
- `git diff --check`
- `npx --yes markdownlint-cli@0.44.0 --disable MD013 MD033 MD041 -- site/Zcash_Use_Cases/Privacy_in_Play_Zcash_Gaming.md`