### PR TITLE
newsletter: add May 23 ecosystem digest

### DIFF
--- a/newsletter/Digest 23-05-2026.md
+++ b/newsletter/Digest 23-05-2026.md
@@ -1,0 +1,119 @@
+# Zcash Ecosystem Digest | May 23rd
+
+NU7 testnet is live, Zcash Foundation published new reports and engineering
+updates, ZCG nominations opened for the June election, and several community
+projects shared wallet, payments, education, map, and regional updates.
+
+Curated by [tim13246879](https://github.com/tim13246879)
+
+## Zcash Ecosystem Weekly Updates
+
+### Shielded Labs, Electric Coin Company, Zcash Foundation Updates
+
+- [NU7-rc0 Testnet is Live](https://forum.zcashcommunity.com/t/nu7-rc0-testnet-is-live/55783)
+  - The NU7 release-candidate testnet is available for ecosystem testing.
+- [ZF Engineering Update: May 4th to May 17th, 2026](https://forum.zcashcommunity.com/t/zf-engineering-update-may-4th-may-17th-2026/55749)
+  - Zcash Foundation shared recent engineering work and progress across its teams.
+- [Zcash Foundation Q1 2026 Report](https://forum.zcashcommunity.com/t/zcash-foundation-q1-2026-report/55732)
+  - ZF published its Q1 report for community review.
+- [Coinholder-Directed Retroactive Grants Program Q2 2026: 30 Day Review Period Now Open](https://forum.zcashcommunity.com/t/coinholder-directed-retroactive-grants-program-q2-2026-30-day-review-period-now-open/55701)
+  - The Q2 retroactive grants review period is open for coinholder review.
+- [NU7 Sentiment Polling: Questions for Community Review and Coinholder Voting via Zodl](https://forum.zcashcommunity.com/t/nu7-sentiment-polling-questions-for-community-review-coinholder-voting-via-zodl/55713)
+  - Community members are reviewing NU7 sentiment-polling questions before coinholder voting.
+- [ZIP 316: Unified Addresses and Unified Viewing Key Rev 2 Discussion](https://forum.zcashcommunity.com/t/zip-316-unified-addresses-and-unified-viewing-key-rev-2-discussion/55515)
+  - The ZIP 316 Rev 2 discussion continued with feedback on unified addresses and viewing keys.
+- [There Is No Orchard Backdoor: Zcash Office Hours Special Edition](https://forum.zcashcommunity.com/t/there-is-no-orchard-backdoor-zcash-office-hours-special-edition/55751)
+  - A special Office Hours session addressed questions about Orchard and Zcash privacy.
+- [FPF Q1 Report and Supplements](https://forum.zcashcommunity.com/t/fpf-q1-report-supplements/55722)
+  - FPF released its Q1 report covering support for ZCG and community operations.
+
+---
+
+### Zcash Community Grants
+
+- [Zcash Community Grants Nominations Now Open for June Election](https://forum.zcashcommunity.com/t/zcash-community-grants-zcg-nominations-now-open-for-june-election/55720)
+  - Nominations are open for the June ZCG election.
+- [Zcash Community Grants Meeting Minutes: May 11, 2026](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-5-11-2026/55677)
+  - ZCG published minutes from its May 11 meeting.
+- [Grant Application: Zcash MCP Server for AI Agent Integration](https://forum.zcashcommunity.com/t/grant-application-zcash-mcp-server-for-ai-agent-integration/55756)
+  - A new proposal asks for support to build a Zcash MCP server for AI-agent workflows.
+- [Grant Application: BLINK Bluetooth-Powered Privacy-Preserving Payment Infrastructure](https://forum.zcashcommunity.com/t/grant-application-blink-bluetooth-powered-privacy-preserving-payment-infrastructure-for-emerging-markets/55662)
+  - BLINK proposes offline-friendly Bluetooth payment infrastructure for emerging markets.
+- [Grant Proposal: Zcash Name Service](https://forum.zcashcommunity.com/t/grant-proposal-zcash-name-service/55737)
+  - The Zcash Name Service proposal focuses on easier naming for Zcash addresses.
+- [Grant Proposal: Tachyon-Lite Light-Client SDK and Sync/Proof Server](https://forum.zcashcommunity.com/t/grant-proposal-tachyon-lite-light-client-sdk-and-sync-proof-server-for-zcash/55671)
+  - Tachyon-Lite proposes light-client tooling and supporting sync/proof infrastructure.
+- [Grant Application: Educational Campaign by Incrypted](https://forum.zcashcommunity.com/t/grant-application-educational-campaign-by-incrypted/55721)
+  - Incrypted proposed an educational campaign for Zcash and privacy topics.
+- [Grant Application: Zcash CIS Educational Media Initiative 2026](https://forum.zcashcommunity.com/t/grant-application-zcash-cis-educational-media-initiative-2026-3-month/55718)
+  - The CIS community proposed a new three-month education and media plan.
+- [Zcash Arabia: May to September 2026](https://forum.zcashcommunity.com/t/zcash-arabia-may-to-september-2026/55769)
+  - Zcash Arabia shared a new proposal for regional education and outreach.
+- [Paul Brigner for ZCG June 2026](https://forum.zcashcommunity.com/t/paul-brigner-for-zcg-june-2026/55738)
+  - Paul Brigner published his ZCG candidate post for the June election.
+- [Victor Zscharnt for ZCG June 2026](https://forum.zcashcommunity.com/t/victor-zscharnt-for-zcg-june-2026/55744)
+  - Victor Zscharnt published his ZCG candidate post for the June election.
+- [Decentrathai for ZCG June 2026](https://forum.zcashcommunity.com/t/decentrathai-for-zcg-june-2026/55752)
+  - Decentrathai published a ZCG candidate post for the June election.
+- [Dontbeevil for ZCG 2026](https://forum.zcashcommunity.com/t/dontbeevil-for-zcg-2026/55723)
+  - Dontbeevil shared a candidate post for the 2026 ZCG election cycle.
+
+---
+
+### Community Projects
+
+- [Pacu joins ZODL](https://forum.zcashcommunity.com/t/pacu-joins-zodl/55782)
+  - Pacu joined ZODL to help advance Zcash wallet and ecosystem work.
+- [The Path to Billions: ZODL Update](https://forum.zcashcommunity.com/t/the-path-to-billions-zodl-update/55717)
+  - ZODL shared a new update on product direction and growth plans.
+- [ZShieldHer: Zcash Education Site for Domestic Violence Survivors](https://forum.zcashcommunity.com/t/zshieldher-a-zcash-education-site-for-domestic-violence-survivors-built-live-seeking-feedback-zcg-interest/55765)
+  - ZShieldHer launched a live education site and asked for community feedback.
+- [Zcash Club Queretaro-Mexico: Advancing Financial Privacy in Mexico](https://forum.zcashcommunity.com/t/zcash-club-queretaro-mexico-advancing-financial-privacy-in-mexico/55764)
+  - A new Mexico community effort shared its privacy education plans.
+- [ZecVault: Goal-Based Savings Wallet Built on Zcash Shielded Transactions](https://forum.zcashcommunity.com/t/zecvault-a-goal-based-savings-wallet-built-on-zcash-shielded-transactions/55464)
+  - ZecVault continued development of a shielded savings wallet concept.
+- [Khalani: Reducing ZEC Cross-Chain Dependency with a Second Intent-Based Rail](https://forum.zcashcommunity.com/t/khalani-reducing-zec-cross-chain-dependency-with-a-second-intent-based-rail/55776)
+  - Khalani introduced an intent-based rail for cross-chain ZEC activity.
+- [Zcash Weekend Watchparty: Now Streaming on X](https://forum.zcashcommunity.com/t/zcash-weekend-watchparty-now-streaming-on-x/55770)
+  - The community announced a Zcash weekend watchparty stream.
+- [New Version of Zingo-PC](https://forum.zcashcommunity.com/t/new-version-of-zingo-pc/45359)
+  - Zingo-PC received a new update in its ongoing release thread.
+- [Noir Wallet Private Beta is Now Live](https://forum.zcashcommunity.com/t/noir-wallet-private-beta-is-now-live/55745)
+  - Noir Wallet opened its private beta.
+- [Vizor Wallet Has Launched, But We Need Your Help](https://forum.zcashcommunity.com/t/vizor-wallet-has-launched-but-we-need-your-help/55719)
+  - Vizor Wallet launched and asked the community for feedback and testing.
+- [ZECMAP: A Global Map for Businesses That Accept Zcash](https://forum.zcashcommunity.com/t/zecmap-a-global-map-for-businesses-that-accept-zcash/55686)
+  - ZecMap shared progress on mapping Zcash-accepting businesses.
+- [Zecmap Contributor Rewards Program is Live](https://forum.zcashcommunity.com/t/zecmap-contributor-rewards-program-is-live/55714)
+  - ZecMap opened a contributor rewards program for map updates.
+- [Zcash en Espanol X Account Suspended](https://forum.zcashcommunity.com/t/zcash-en-espanol-x-account-suspended/55685)
+  - Zcash en Espanol reported an X account suspension and community impact.
+- [Zcash Global Turkish 2026 Q1-2](https://forum.zcashcommunity.com/t/zcash-global-turkish-2026-q1-2/53945)
+  - The Turkish community thread continued with Q1-Q2 updates.
+- [Zcash Nigeria 2026](https://forum.zcashcommunity.com/t/zcash-nigeria-2026/53654)
+  - The Zcash Nigeria thread continued reporting regional activity.
+- [Privacy Has Landed in South Africa](https://forum.zcashcommunity.com/t/privacy-has-landed-in-south-africa-join-in/55706)
+  - A South Africa community update invited people to join privacy education work.
+- [Zcash Developers Training](https://forum.zcashcommunity.com/t/zcash-developers-training/55360)
+  - Developer training activity continued for builders entering the Zcash ecosystem.
+- [Protocol Study Series: Guided Reading of the Zcash Protocol Specification](https://forum.zcashcommunity.com/t/protocol-study-series-12-session-guided-reading-of-the-zcash-protocol-specification-starting-april-21/55350)
+  - The protocol study series continued with guided reading sessions.
+- [Zcash Network School](https://forum.zcashcommunity.com/t/zcash-network-school/55269)
+  - Zcash Network School continued as an education path for new community members.
+- [Complete Zaino](https://forum.zcashcommunity.com/t/complete-zaino/50708)
+  - The Zaino thread continued tracking work on Zcash light-client infrastructure.
+- [CipherPay: Yes, Another Zcash Payment Processor](https://forum.zcashcommunity.com/t/cipherpay-yes-another-zcash-payment-processor-sorry-live/54830)
+  - CipherPay continued sharing updates on its Zcash payment processor.
+- [Introducing Overpay.com: Spend ZEC Anywhere Alpha](https://forum.zcashcommunity.com/t/introducing-overpay-com-spend-zec-anywhere-alpha/54798)
+  - Overpay.com continued discussion around spending ZEC through its alpha product.
+- [Rore: High-Performance Rust UI Engine for Zcash Desktop Clients](https://forum.zcashcommunity.com/t/rore-high-performance-rust-ui-engine-for-zcash-desktop-clients/55634)
+  - Rore shared work on a Rust UI engine for Zcash desktop applications.
+- [Zcash Community: Hello from KeepKey](https://forum.zcashcommunity.com/t/zcash-community-hello-from-keepkey/55711)
+  - KeepKey introduced itself to the Zcash community.
+
+---
+
+### Meme of the Week
+
+- [Nothing More American](https://forum.zcashcommunity.com/t/nothing-more-american/55642)
+  - A community post tied Zcash discussion to freedom, privacy, and American values.


### PR DESCRIPTION
Submitted for #1650.

This adds the May 23 Zcash Ecosystem Digest with current links from the Zcash forum covering NU7 testnet, ZF and FPF reports, ZCG nominations and proposals, wallet/project updates, regional community posts, ZecMap, ZODL, Zingo, and related community activity.

I kept the descriptions short and in plain English for easier translation, and included more than 20 source links.

Checks:
- `git diff --check`
- `npx --yes markdownlint-cli@0.44.0 --disable MD013 -- newsletter/Digest 23-05-2026.md`