### PR TITLE
Add requested Zcash wallet entries

### DIFF
--- a/site/Using_Zcash/Wallets.md
+++ b/site/Using_Zcash/Wallets.md
@@ -134,7 +134,27 @@
 - Operating System: macOS
 - Wallet Support: Seed Phrase | Unified Address | Hardware
 - Pools: Transparent | Sapling | Orchard
-- Features: Automatic Shielding | Shielded Memo | Testnet Support | FROST Multisig
+- Features: FROST Multisig | Keystone Support | Multi-Account Sync | Open Source | Shielded Transactions | Token Holder Voting
+
+---
+
+## [Noir Wallet](https://forum.zcashcommunity.com/t/first-look-at-noir-wallet/55667)
+![logo](https://global.discourse-cdn.com/zcash/optimized/3X/6/7/67dde4674230fb9adc04eec329d339d53e6b9602_2_1024x409.jpeg "Noir Wallet")
+- Devices: Web
+- Operating System: Browser Extension
+- Wallet Support: Seed Phrase | Unified Address
+- Pools: Transparent | Sapling | Orchard
+- Features: Browser Extension | Cross-Chain Swaps | NEAR Intents | Non-Custodial | Privacy-Preserving Intents | Shielded Transactions | ZECFi
+
+---
+
+## [LeoDex](https://leodex.io/)
+![logo](https://z.cash/wp-content/uploads/2025/10/leodex.png "LeoDex")
+- Devices: Web
+- Operating System: Browser
+- Wallet Support: External Wallet | Keystore | QR Code
+- Pools: Transparent | Sapling | Orchard
+- Features: Cross-Chain Swaps | DEX Swaps | Maya Protocol | Multi Coin | Non-Custodial | Portfolio Dashboard | QR Code Swaps
 
 ---
 
@@ -155,6 +175,26 @@
 - Wallet Support: Seed Phrase | Unified Address
 - Pools: Transparent | Sapling | Orchard
 - Features: Multi Coin
+
+---
+
+## [ChainSafe WebZjs](https://webzjs.chainsafe.dev/)
+![logo](https://avatars.githubusercontent.com/u/49853980?s=200&v=4 "ChainSafe WebZjs")
+- Devices: Web
+- Operating System: Browser
+- Wallet Support: Seed Phrase | MetaMask Snap | Unified Address
+- Pools: Transparent | Sapling | Orchard
+- Features: Browser Wallet | Client-Side Sync | MetaMask Snap | Open Source | Shielded Transactions | WebAssembly
+
+---
+
+## [Zcash Web Wallet](https://leakix.github.io/zcash-web-wallet/)
+![logo](https://avatars.githubusercontent.com/u/167028110?s=200&v=4 "Zcash Web Wallet")
+- Devices: Web
+- Operating System: Browser
+- Wallet Support: Seed Phrase | Viewing Key
+- Pools: Transparent | Sapling | Orchard
+- Features: Address Book | Client-Side Crypto | No Backend | No Tracking | Open Source | Testnet Support
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds wallet entries for Noir Wallet, LeoDex, ChainSafe WebZjs, and Zcash Web Wallet to `site/Using_Zcash/Wallets.md`.
- Refreshes the existing Vizor entry with current feature metadata.
- Keeps each entry in the page's existing Devices, Operating System, Wallet Support, Pools, and Features format.

## Source checks

- Vizor: https://vizor.cash/
- Noir Wallet: https://forum.zcashcommunity.com/t/first-look-at-noir-wallet/55667
- LeoDex: https://leodex.io/ and https://leodex.io/blog/zcash-zec-is-live-on-leodex-trade-native-zec-with-other-l1-assets-j2c
- ChainSafe WebZjs: https://webzjs.chainsafe.dev/ and https://github.com/ChainSafe/WebZjs
- Zcash Web Wallet: https://leakix.github.io/zcash-web-wallet/ and https://forum.zcashcommunity.com/t/zcash-web-wallet-a-privacy-preserving-browser-wallet/54048

## Checks

- `npx --yes markdownlint-cli@0.44.0 --disable MD013 MD033 MD041 MD022 MD032 MD009 -- site/Using_Zcash/Wallets.md`
- `git diff --check`
- Checked the added source and image URLs return HTTP 200.

Closes #1659