### PR TITLE
Add May 30 Zcash ecosystem digest

### DIFF
--- a/newsletter/Digest 30-05-2026.md
+++ b/newsletter/Digest 30-05-2026.md
@@ -1,0 +1,71 @@
+# Zcash Ecosystem Digest | May 30th, 2026
+
+Zcash community activity this week centered on Orchard transparency discussions, Z3 migration work, ZODL coordination, June ZCG elections, new grant applications, and steady regional updates from Brazil, Turkey, East Africa, Korea, Ukraine, Nigeria, Spanish-speaking communities, and ruZcash.
+
+Curated by [gshaowei6](https://github.com/gshaowei6)
+
+## Shielded Labs, Electric Coin Company, Zcash Foundation Updates
+
+- [ZF Engineering Update - May 4th - May 17th, 2026](https://forum.zcashcommunity.com/t/zf-engineering-update-may-4th-may-17th-2026/55749) - The Foundation summarized Zebra, librustzcash, Zallet, and protocol engineering work from the first half of May.
+- [There Is No Orchard Backdoor - Zcash Office Hours Special Edition](https://forum.zcashcommunity.com/t/there-is-no-orchard-backdoor-zcash-office-hours-special-edition/55751) - ECC and ZF hosted a public Office Hours session on Orchard and the questions raised by recent community discussion.
+- [No Arborist Call This Week - Next Call May 28th](https://forum.zcashcommunity.com/t/no-arborist-call-this-week-next-call-may-28th/55659) - The Foundation noted the Arborist schedule change and pointed contributors to the next call.
+- [Zcash Z3 updates, formerly zcashd deprecation](https://forum.zcashcommunity.com/t/zcash-z3-updates-formerly-zcashd-deprecation/48965) - The Z3 thread continues to track wallet, SDK, and node migration work as the ecosystem moves beyond zcashd.
+- [Pacu joins ZODL](https://forum.zcashcommunity.com/t/pacu-joins-zodl/55782) - ZODL added protocol and developer-relations capacity through Pacu's new role.
+- [ZODL Summit July 8-10 in Prague](https://forum.zcashcommunity.com/t/zodl-summit-july-8-10-in-prague-czech-republic/55716) - The ZODL team opened community planning for a Prague summit focused on protocol coordination and ecosystem work.
+- [NU7 sentiment polling questions for community review](https://forum.zcashcommunity.com/t/nu7-sentiment-polling-questions-for-community-review-coinholder-voting-via-zodl/55713) - The community reviewed proposed NU7 sentiment questions ahead of coinholder voting through Zodl.
+
+---
+
+## Zcash Community Grants
+
+- [ZCG nominations now open for June election](https://forum.zcashcommunity.com/t/zcash-community-grants-zcg-nominations-now-open-for-june-election/55720) - Nominations opened for the June Zcash Community Grants election.
+- [Coinholder-Directed Retroactive Grants Program Q2 2026 review period](https://forum.zcashcommunity.com/t/coinholder-directed-retroactive-grants-program-q2-2026-30-day-review-period-now-open/55701) - The Q2 review window is open for community feedback on retroactive grant candidates.
+- [Zcash Community Grants Meeting Minutes 5/11/2026](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-5-11-2026/55677) - The minutes recap proposal status, committee decisions, and current ZCG priorities.
+- [Zcash CIS Educational Media Initiative 2026](https://forum.zcashcommunity.com/t/grant-application-zcash-cis-educational-media-initiative-2026-3-month/55718) - A three-month proposal focuses on Russian-language education and media for CIS audiences.
+- [Educational Campaign by Incrypted](https://forum.zcashcommunity.com/t/grant-application-educational-campaign-by-incrypted/55721) - Incrypted proposed a Zcash education campaign for a broader crypto audience.
+- [Zcash MCP Server for AI Agent Integration](https://forum.zcashcommunity.com/t/grant-application-zcash-mcp-server-for-ai-agent-integration/55756) - A new proposal explores an MCP server for Zcash data and agent workflows.
+- [Zcash Privacy Capsule](https://forum.zcashcommunity.com/t/grant-application-zcash-privacy-capsule/55801) - The proposal aims to package privacy education and onboarding into a compact Zcash learning experience.
+- [Khalani: Reducing ZEC Cross-Chain Dependency with a Second Intent-Based Rail](https://forum.zcashcommunity.com/t/khalani-reducing-zec-cross-chain-dependency-with-a-second-intent-based-rail/55776) - Khalani proposed another intent-based path for cross-chain ZEC liquidity.
+- [Zcash Arabia May to September 2026](https://forum.zcashcommunity.com/t/zcash-arabia-may-to-september-2026/55769) - Zcash Arabia outlined a new regional education and community-building plan.
+- [Zcash Name Service](https://forum.zcashcommunity.com/t/grant-proposal-zcash-name-service/55737) - The proposal discusses human-readable names for shielded Zcash use.
+
+---
+
+## Community Projects
+
+- [Zcash Brazil 2026](https://forum.zcashcommunity.com/t/zcash-brazil-2026/53702) - Zcash Brazil continues Portuguese-language education, local event work, and community updates.
+- [Zcash Global Turkish 2026 Q1-2](https://forum.zcashcommunity.com/t/zcash-global-turkish-2026-q1-2/53945) - The Turkish community thread tracks outreach, education, and Zcash-focused DeFi work.
+- [Zcash Turkiye - Sustainability and the ZBase Vision](https://forum.zcashcommunity.com/t/zcash-turkiye-sustainability-and-the-zbase-vision/54498/8) - Zcash Turkiye shared sustainability planning and ZBase direction.
+- [Zcash Ukraine Regional Community Initiative](https://forum.zcashcommunity.com/t/zcash-ukraine-regional-community-initiative/52330) - Zcash Ukraine continues regional education, translated materials, and local community growth.
+- [Zcash Korea Ambassador Proposal](https://forum.zcashcommunity.com/t/zechub-dao-zcash-korea-ambassador-proposal-approved/50498) - Zcash Korea remains active through Korean-language channels and community coordination.
+- [Zcash Nigeria 2026](https://forum.zcashcommunity.com/t/zcash-nigeria-2026/53654) - Zcash Nigeria continues local onboarding, contributor education, and regional language work.
+- [Zcash India 2026](https://forum.zcashcommunity.com/t/zcash-india-2026/54762) - Zcash India keeps collecting community feedback and education updates for 2026.
+- [Zcash Gold Sponsorship Kenya at KBCC 2026](https://forum.zcashcommunity.com/t/zcash-gold-sponsorship-kenya-kbcc-2026-activation-privacy-workshop/55520) - Zcash East Africa is preparing a Kenya Blockchain and Crypto Conference activation with a privacy workshop.
+- [Pesa Ya Siri: Making Zcash a Household Name in Tanzania](https://forum.zcashcommunity.com/t/pesa-ya-siri-making-zcash-a-household-name-in-tanzania/55558) - The Tanzania-focused proposal emphasizes practical Zcash education and local adoption.
+- [Zcast, the Zcash podcast in Spanish - a new phase](https://forum.zcashcommunity.com/t/zcast-the-zcash-podcast-in-spanish-a-new-phase/54291) - Zcast is entering a new phase of Spanish-language podcast and community work.
+- [Zcash en Espanol X account suspended](https://forum.zcashcommunity.com/t/zcash-en-espanol-x-account-suspended/55685) - The Spanish-speaking community discussed account recovery and backup channels.
+- [Berlin Blockchain Week and DWeb Camp 2026 by ZK AV Club](https://forum.zcashcommunity.com/t/berlin-blockchain-week-and-dweb-camp-2026-zk-av-club/55047) - ZK AV Club is preparing privacy and Zcash activity around Berlin Blockchain Week and DWeb Camp.
+- [ZK AV Club weekend watchparty](https://forum.zcashcommunity.com/t/zk-av-club-presents-zcash-weekend-watchparty/55770) - ZK AV Club announced a community watchparty for Zcash and privacy content.
+- [ZECMAP: a global map for businesses that accept Zcash](https://forum.zcashcommunity.com/t/zecmap-a-global-map-for-businesses-that-accept-zcash/55686) - ZecMap is building a searchable directory of ZEC-accepting businesses.
+- [Seeking ideas and feedback for Zec Map](https://forum.zcashcommunity.com/t/seeking-ideas-and-feedback-for-zec-map/55505) - Community members are shaping merchant discovery and map quality feedback.
+- [ZecVault](https://forum.zcashcommunity.com/t/zecvault-a-goal-based-savings-wallet-built-on-zcash-shielded-transactions/55464/18) - ZecVault continues work on goal-based savings with shielded Zcash transactions.
+- [BLINK Bluetooth-powered payment infrastructure](https://forum.zcashcommunity.com/t/grant-application-blink-bluetooth-powered-privacy-preserving-payment-infrastructure-for-emerging-markets/55662) - BLINK proposes Bluetooth payment flows for markets where connectivity can be unreliable.
+- [RHEA Roadmap 2026](https://forum.zcashcommunity.com/t/rhea-roadmap-2026-zcash-chrome-extension-wallet/54415) - RHEA shared its 2026 roadmap for a Zcash browser wallet and related DeFi work.
+- [Inevitable: ZODL Update](https://forum.zcashcommunity.com/t/inevitable-zodl-update/55058) - ZODL posted a broader update on AI-assisted development, strategy, and infrastructure direction.
+- [Nothing More American](https://forum.zcashcommunity.com/t/nothing-more-american/55642) - genzcash-related community discussion continued around messaging, culture, and privacy framing.
+- [ZecHub 2026](https://forum.zcashcommunity.com/t/zechub-2026/53686) - ZecHub continues newsletters, educational resources, videos, and contributor coordination.
+- [ruZcash May update](https://x.com/ruZCASH/status/2058497380727611428) - ruZcash kept Russian-language Zcash conversation active with market and ecosystem commentary.
+- [Zcash Shielded News Vol. 19](https://x.com/ZecHub/status/2057184923430359512) - ZecHub shared the latest Shielded News issue with the wider community.
+- [Zcash Foundation engineering update on X](https://x.com/ZcashFoundation/status/2057125774579085348) - The Foundation amplified its May engineering update for readers who follow X instead of the forum.
+
+---
+
+## Meme of the week
+
+- [Zcash Nigeria meme post](https://x.com/ZcashNigeria/status/2053925573185905013) - A community meme kept the week's privacy conversation light while still pointing people back to Zcash culture.
+
+---
+
+## Jobs in the Ecosystem
+
+- [ZODL is hiring](https://x.com/zodl_app/status/2057547051685274093) - ZODL shared open roles for contributors interested in Zcash wallet and ecosystem work.


### PR DESCRIPTION
Adds the May 30 Zcash Ecosystem Digest for #1691.

What changed:
- added `newsletter/Digest 30-05-2026.md` using the date format from the linked digest template
- kept descriptions in plain English for easier translation
- included 44 total source links, with 26 links in the Community Projects section
- covered the requested communities and sources: Zcash Brazil, Turkey, Ukraine, East Africa, Korea, Nigeria, ruZcash, genzcash, ZK AV Club, ECC, ZF, ZecHub, Zcast, and the Zcash Community Forum

Validation:
- checked the required sections are present
- checked the Community Projects section has more than 20 links
- checked for trailing whitespace

Closes #1691
