### PR TITLE
Add Beginner_Roadmap.md — visual knowledge map sorted by experience level

### DIFF
--- a/site/guides/Beginner_Roadmap.md
+++ b/site/guides/Beginner_Roadmap.md
@@ -1,0 +1,173 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Beginner_Roadmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecHub Beginner Roadmap
+
+A visual map of the ZecHub wiki sorted by experience level. If you are new and
+not sure where to start, use **Level 1**. If you already hold ZEC and want to
+use it well, move to **Level 2**. Builders and researchers start at **Level 3**.
+
+---
+
+## Visual Map
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         ZECHUB KNOWLEDGE MAP                            │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  🟢 LEVEL 1 — BEGINNER  (start here)                                   │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │ What is Zcash │  │ New User Guide│  │  Glossary &   │               │
+│  │  & ZEC?       │→ │ (buy, wallet, │→ │  FAQs         │               │
+│  │               │  │  first tx)    │  │               │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│                              ↓                                          │
+│  🔵 LEVEL 2 — INTERMEDIATE                                              │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │  Wallets      │  │  Using ZEC    │  │  Privacy      │               │
+│  │  (Zashi,      │→ │  Privately    │→ │  Tools        │               │
+│  │  YWallet…)    │  │               │  │  (Tor, VPN…)  │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│         ↓                                      ↓                        │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │  Exchanges    │  │  Spend ZEC    │  │  Memos &      │               │
+│  │  (custodial / │  │  (merchants,  │  │  Encrypted    │               │
+│  │  non-custod.) │  │   tipping)    │  │  Messages     │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│                              ↓                                          │
+│  🔴 LEVEL 3 — ADVANCED / DEVELOPER                                      │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │  Zcash Tech   │  │  Full Nodes   │  │  Developer    │               │
+│  │  (zk-SNARKs,  │→ │  (Zebra, Pi)  │→ │  Resources    │               │
+│  │  Halo 2, FROST│  │               │  │  & ZIPs       │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│                                                                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│  📚 ECOSYSTEM  →  Organizations · Community · ZecHub Global Ambassadors │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Level 1 — Beginner
+
+> **Goal:** understand what Zcash is and make your first shielded transaction.
+
+| Step | Page | What you will learn |
+|------|------|---------------------|
+| 1 | [What is ZEC and Zcash?](/start-here/what-is-zec-and-zcash) | Digital cash with privacy built in; why it matters |
+| 2 | [What is ZecHub?](/start-here/what-is-zechub) | How to use this wiki and where to find help |
+| 3 | [New User Guide](/start-here/new-user-guide) | Buy ZEC → pick a wallet → first shielded transaction |
+| 4 | [Glossary & FAQs](/glossary-and-faqs/faq) | Shielded, transparent, memo, viewing key… |
+| 5 | [My First Zcash Workbook](/guides/my-first-zcash-workbook) | Hands-on workbook for complete beginners |
+
+**After Level 1 you will:** own ZEC in a shielded wallet and know the difference between a `z`-address and a `t`-address.
+
+---
+
+## Level 2 — Intermediate
+
+> **Goal:** use ZEC privately and confidently in everyday situations.
+
+### Wallets
+
+| Page | What you will learn |
+|------|---------------------|
+| [Wallets overview](/using-zcash/wallets) | Compare Zashi, YWallet, Unstoppable, ZODL, and more |
+| [Shielded Pools](/using-zcash/shielded-pools) | Sapling vs. Orchard — which pool to use and why |
+| [Wallet Syncing](/zcash-tech/zcash-wallet-syncing) | Why sync takes time and how to speed it up |
+
+### Transacting
+
+| Page | What you will learn |
+|------|---------------------|
+| [Using ZEC Privately](/guides/using-zec-privately) | Step-by-step: always stay shielded |
+| [Transactions](/using-zcash/transactions) | Fees, confirmations, memo fields |
+| [Memos](/using-zcash/memos) | Send encrypted notes inside a transaction |
+| [Custodial Exchanges](/using-zcash/custodial-exchanges) | Which exchanges support shielded withdrawals |
+| [Non-Custodial Exchanges](/using-zcash/non-custodial-exchanges) | Swap without KYC |
+| [Spend ZEC](/using-zcash/spend-zcash) | Merchants, tips, and online stores that accept ZEC |
+
+### Privacy tools
+
+| Page | What you will learn |
+|------|---------------------|
+| [Tor & I2P](/privacy-tools/tor-and-i2p) | Route your traffic to protect your IP |
+| [VPN & dVPN](/privacy-tools/vpn-and-dvpn) | When a VPN complements Zcash |
+| [Secure Messengers](/privacy-tools/secure-messengers) | Apps that pair well with Zcash |
+
+**After Level 2 you will:** send and receive ZEC privately, shop with ZEC, and understand the privacy model.
+
+---
+
+## Level 3 — Advanced & Developer
+
+> **Goal:** understand how Zcash works under the hood and start building.
+
+### Zcash Technology
+
+| Page | What you will learn |
+|------|---------------------|
+| [zk-SNARKs](/zcash-tech/zk-snarks) | The zero-knowledge proof system behind shielded transactions |
+| [Halo 2](/zcash-tech/halo) | The proving system that removed the trusted setup |
+| [FROST Multisig](/zcash-tech/frost) | Threshold signatures for shared custody |
+| [Post-Quantum Security](/zcash-tech/post-quantum-security) | How Zcash prepares for quantum computers |
+| [Zero-Knowledge vs. Decoys](/guides/zero-knowledge-vs-decoys) | How Zcash privacy compares to Monero's approach |
+
+### Running Infrastructure
+
+| Page | What you will learn |
+|------|---------------------|
+| [Zebra Full Node](/zcash-tech/zebra-full-node) | The Rust-based Zcash node |
+| [Raspberry Pi 4 Full Node](/guides/raspberry-pi-4-full-node) | Run a node on cheap hardware |
+| [Hardened Zebrad](/guides/hardened-zebrad) | Production-grade node hardening |
+| [Migration: Zcashd → Zebrad](/guides/migration-guide-zcashd-to-zebrad-zallet) | Upgrade your node |
+
+### Building on Zcash
+
+| Page | What you will learn |
+|------|---------------------|
+| [Developer Resources](/start-here/developer-resources) | SDKs, RPC docs, grant programmes |
+| [Zcash Improvement Proposals (ZIPs)](/guides/zcash-improvement-proposals) | How protocol changes are proposed and approved |
+| [Viewing Keys](/zcash-tech/viewing-keys) | Grant selective disclosure without losing privacy |
+| [Zcash Devtool](/guides/zcash-devtool) | CLI toolkit for testing transactions |
+
+**After Level 3 you will:** be able to run a node, read ZIPs, and integrate ZEC into an application.
+
+---
+
+## Ecosystem
+
+These pages give context on who builds and funds Zcash.
+
+| Page | What it covers |
+|------|----------------|
+| [Zcash Organizations](/zcash-community/zcash-organizations) | ECC, ZF, ZCG, and ZecHub |
+| [Zcash Community](/zcash-community) | Forum, Discord, X, and regional channels |
+| [ZecHub Global Ambassadors](/zechubglobal) | Community educators around the world |
+| [Development Fund](/start-here/development-fund) | How protocol funding works |
+| [Network Upgrades](/start-here/network-upgrades) | History of Zcash upgrades (Sapling → NU6…) |
+
+---
+
+## How to use this map as a contributor
+
+Spots marked with a link go to a live page. If you notice a topic that is missing or
+thinly covered, open an issue on [GitHub](https://github.com/ZecHub/zechub/issues)
+and propose a new page. The roadmap itself can be updated to reflect new sections
+as the wiki grows.
+
+---
+
+## Related Pages
+
+- [What is ZEC and Zcash?](/start-here/what-is-zec-and-zcash)
+- [New User Guide](/start-here/new-user-guide)
+- [Wallets](/using-zcash/wallets)
+- [Glossary & FAQs](/glossary-and-faqs/faq)
+- [My First Zcash Workbook](/guides/my-first-zcash-workbook)
+- [Using ZEC Privately](/guides/using-zec-privately)
+- [zk-SNARKs](/zcash-tech/zk-snarks)
+- [Raspberry Pi 4 Full Node](/guides/raspberry-pi-4-full-node)

--- a/site/guides/Beginner_Roadmap.md
+++ b/site/guides/Beginner_Roadmap.md
@@ -8,6 +8,8 @@ A visual map of the ZecHub wiki sorted by experience level. If you are new and
 not sure where to start, use **Level 1**. If you already hold ZEC and want to
 use it well, move to **Level 2**. Builders and researchers start at **Level 3**.
 
+> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/guides/mapa-iniciantes)
+
 ---
 
 ## Visual Map

--- a/site/zechubglobal/zcashbrasil/guides/Mapa_Iniciantes.md
+++ b/site/zechubglobal/zcashbrasil/guides/Mapa_Iniciantes.md
@@ -1,0 +1,175 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/guides/Mapa_Iniciantes.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
+
+# Mapa de Conhecimento ZecHub
+
+Um mapa visual do wiki ZecHub organizado por nível de experiência. Se você é novo
+e não sabe por onde começar, use o **Nível 1**. Se já tem ZEC e quer usá-lo bem,
+vá para o **Nível 2**. Desenvolvedores e pesquisadores começam pelo **Nível 3**.
+
+> 🇺🇸 [English version](/guides/beginner-roadmap)
+
+---
+
+## Mapa Visual
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     MAPA DE CONHECIMENTO ZECHUB                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  🟢 NÍVEL 1 — INICIANTE  (comece aqui)                                  │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │ O que é Zcash │  │ Guia para     │  │  Glossário &  │               │
+│  │ e ZEC?        │→ │ Novos Usuários│→ │  Perguntas    │               │
+│  │               │  │               │  │  Frequentes   │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│                              ↓                                          │
+│  🔵 NÍVEL 2 — INTERMEDIÁRIO                                             │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │  Carteiras    │  │  Usando ZEC   │  │  Ferramentas  │               │
+│  │  (Zashi,      │→ │  com          │→ │  de Privacidade│              │
+│  │  YWallet…)    │  │  Privacidade  │  │  (Tor, VPN…)  │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│         ↓                                      ↓                        │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │  Exchanges    │  │  Gastar ZEC   │  │  Memos &      │               │
+│  │  (custodial / │  │  (comerciantes│  │  Mensagens    │               │
+│  │  não-custodial│  │   gorjetas)   │  │  Criptografadas│              │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│                              ↓                                          │
+│  🔴 NÍVEL 3 — AVANÇADO / DESENVOLVEDOR                                  │
+│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
+│  │  Tecnologia   │  │  Nós Completos│  │  Recursos para│               │
+│  │  Zcash        │→ │  (Zebra, Pi)  │→ │  Desenvolvedores│             │
+│  │  (zk-SNARKs…) │  │               │  │  & ZIPs       │               │
+│  └───────────────┘  └───────────────┘  └───────────────┘               │
+│                                                                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│  📚 ECOSSISTEMA  →  Organizações · Comunidade · Embaixadores ZecHub     │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Nível 1 — Iniciante
+
+> **Objetivo:** entender o que é Zcash e realizar sua primeira transação blindada.
+
+| Passo | Página | O que você vai aprender |
+|-------|--------|--------------------------|
+| 1 | [O que é ZEC e Zcash?](/start-here/what-is-zec-and-zcash) | Dinheiro digital com privacidade nativa; por que isso importa |
+| 2 | [O que é o ZecHub?](/start-here/what-is-zechub) | Como usar este wiki e onde encontrar ajuda |
+| 3 | [Guia para Novos Usuários](/zechubglobal/zcashbrasil/guides/guianovosusuarioszcash) | Comprar ZEC → escolher carteira → primeira transação blindada |
+| 4 | [Glossário & Perguntas Frequentes](/glossary-and-faqs/faq) | Blindado, transparente, memo, chave de visualização… |
+| 5 | [Meu Primeiro Caderno Zcash](/guides/my-first-zcash-workbook) | Caderno prático para iniciantes absolutos |
+
+**Após o Nível 1 você vai:** ter ZEC em uma carteira blindada e entender a diferença entre um endereço `z` e um endereço `t`.
+
+---
+
+## Nível 2 — Intermediário
+
+> **Objetivo:** usar ZEC com privacidade e confiança no dia a dia.
+
+### Carteiras
+
+| Página | O que você vai aprender |
+|--------|--------------------------|
+| [Visão geral de carteiras](/using-zcash/wallets) | Compare Zashi, YWallet, Unstoppable, ZODL e outras |
+| [Pools Blindadas](/using-zcash/shielded-pools) | Sapling vs. Orchard — qual pool usar e por quê |
+| [Sincronização de Carteiras](/zcash-tech/zcash-wallet-syncing) | Por que a sincronização leva tempo e como acelerar |
+
+### Transações
+
+| Página | O que você vai aprender |
+|--------|--------------------------|
+| [Usando ZEC com Privacidade](/zechubglobal/zcashbrasil/guides/usandozecdemaneiraprivada) | Passo a passo: sempre fique blindado |
+| [Transações](/using-zcash/transactions) | Taxas, confirmações, campos de memo |
+| [Memos](/using-zcash/memos) | Envie notas criptografadas dentro de uma transação |
+| [Exchanges Custodiais](/using-zcash/custodial-exchanges) | Quais exchanges suportam saques blindados |
+| [Exchanges Não-Custodiais](/using-zcash/non-custodial-exchanges) | Troque sem KYC |
+| [Gastar ZEC](/using-zcash/spend-zcash) | Comerciantes, gorjetas e lojas online que aceitam ZEC |
+
+### Ferramentas de Privacidade
+
+| Página | O que você vai aprender |
+|--------|--------------------------|
+| [Tor & I2P](/privacy-tools/tor-and-i2p) | Roteie seu tráfego para proteger seu IP |
+| [VPN & dVPN](/privacy-tools/vpn-and-dvpn) | Quando uma VPN complementa o Zcash |
+| [Mensageiros Seguros](/privacy-tools/secure-messengers) | Apps que combinam bem com Zcash |
+
+**Após o Nível 2 você vai:** enviar e receber ZEC com privacidade, pagar com ZEC e entender o modelo de privacidade.
+
+---
+
+## Nível 3 — Avançado e Desenvolvedor
+
+> **Objetivo:** entender como o Zcash funciona por dentro e começar a desenvolver.
+
+### Tecnologia Zcash
+
+| Página | O que você vai aprender |
+|--------|--------------------------|
+| [zk-SNARKs](/zcash-tech/zk-snarks) | O sistema de prova de conhecimento zero das transações blindadas |
+| [Halo 2](/zcash-tech/halo) | O sistema de prova que eliminou o trusted setup |
+| [FROST Multisig](/zcash-tech/frost) | Assinaturas de limiar para custódia compartilhada |
+| [Segurança Pós-Quântica](/zcash-tech/post-quantum-security) | Como o Zcash se prepara para computadores quânticos |
+| [Zero-Knowledge vs. Decoys](/guides/zero-knowledge-vs-decoys) | Como a privacidade do Zcash se compara à abordagem do Monero |
+
+### Infraestrutura
+
+| Página | O que você vai aprender |
+|--------|--------------------------|
+| [Nó Completo Zebra](/zcash-tech/zebra-full-node) | O nó Zcash em Rust |
+| [Nó Completo no Raspberry Pi 4](/guides/raspberry-pi-4-full-node) | Rodar um nó em hardware barato |
+| [Zebrad Hardened](/guides/hardened-zebrad) | Configuração robusta de nó para produção |
+| [Migração: Zcashd → Zebrad](/guides/migration-guide-zcashd-to-zebrad-zallet) | Atualize seu nó |
+
+### Desenvolvendo no Zcash
+
+| Página | O que você vai aprender |
+|--------|--------------------------|
+| [Recursos para Desenvolvedores](/start-here/developer-resources) | SDKs, docs RPC, programas de grants |
+| [Propostas de Melhoria Zcash (ZIPs)](/guides/zcash-improvement-proposals) | Como mudanças no protocolo são propostas e aprovadas |
+| [Chaves de Visualização](/zcash-tech/viewing-keys) | Conceda divulgação seletiva sem perder privacidade |
+| [Zcash Devtool](/guides/zcash-devtool) | Ferramenta CLI para testar transações |
+
+**Após o Nível 3 você vai:** conseguir rodar um nó, ler ZIPs e integrar ZEC em uma aplicação.
+
+---
+
+## Ecossistema
+
+Estas páginas dão contexto sobre quem constrói e financia o Zcash.
+
+| Página | O que cobre |
+|--------|-------------|
+| [Organizações Zcash](/zcash-community/zcash-organizations) | ECC, ZF, ZCG e ZecHub |
+| [Comunidade Zcash](/zcash-community) | Fórum, Discord, X e canais regionais |
+| [Embaixadores Globais ZecHub](/zechubglobal) | Educadores da comunidade ao redor do mundo |
+| [Fundo de Desenvolvimento](/start-here/development-fund) | Como funciona o financiamento do protocolo |
+| [Atualizações de Rede](/start-here/network-upgrades) | Histórico de upgrades Zcash (Sapling → NU6…) |
+
+---
+
+## Como usar este mapa como contribuidor
+
+Os links marcados levam a páginas existentes. Se você notar um tópico ausente ou
+pouco desenvolvido, abra uma issue no [GitHub](https://github.com/ZecHub/zechub/issues)
+e proponha uma nova página. O próprio roadmap pode ser atualizado para refletir
+novas seções à medida que o wiki cresce.
+
+---
+
+## Páginas Relacionadas
+
+- [O que é ZEC e Zcash?](/start-here/what-is-zec-and-zcash)
+- [Guia para Novos Usuários](/zechubglobal/zcashbrasil/guides/guianovosusuarioszcash)
+- [Carteiras](/using-zcash/wallets)
+- [Glossário & Perguntas Frequentes](/glossary-and-faqs/faq)
+- [Meu Primeiro Caderno Zcash](/guides/my-first-zcash-workbook)
+- [Usando ZEC com Privacidade](/zechubglobal/zcashbrasil/guides/usandozecdemaneiraprivada)
+- [zk-SNARKs](/zcash-tech/zk-snarks)
+- [Nó Completo no Raspberry Pi 4](/guides/raspberry-pi-4-full-node)


### PR DESCRIPTION
## Summary

- Adds `site/guides/Beginner_Roadmap.md`: a three-level visual roadmap of the entire ZecHub wiki
- Uses native markdown only (ASCII diagram + tables) — no external image dependency, no broken links if an asset is deleted
- Each level has a clear **goal statement** and a table of pages with a one-line description of what the reader will learn
- Covers all major sections: Start Here, Wallets, Using ZEC, Privacy Tools, Zcash Tech, Full Nodes, Developer Resources, and Ecosystem

## Structure

| Level | Audience | Goal |
|-------|----------|------|
| 1 — Beginner | Brand-new users | Understand Zcash, buy ZEC, first shielded tx |
| 2 — Intermediate | Active users | Use ZEC privately, exchanges, privacy tools, spending |
| 3 — Advanced | Builders & researchers | Zcash tech internals, run a node, develop on Zcash |

## Why native markdown over an external image

The existing PR #1711 embeds a PNG hosted on GitHub's CDN. That link can
break if the asset is ever deleted or the PR is closed. A plain ASCII diagram
and markdown tables render everywhere (GitHub, the ZecHub wiki, raw view)
and are trivially editable by any contributor.

## Related

Closes #1712

🤖 Generated with [Claude Code](https://claude.com/claude-code)