### PR TITLE
Standardize Halo.md and Viewing_Keys.md to content template (EN + PT-BR)

### DIFF
--- a/site/Zcash_Tech/Halo.md
+++ b/site/Zcash_Tech/Halo.md
@@ -4,127 +4,124 @@
 
 # Halo
 
+Halo is a trustless, recursive zero-knowledge proof system discovered by Sean Bowe at Electric Coin Co. It eliminates the need for a trusted setup and makes recursive proof composition practical. Halo was the first zero-knowledge proof system to combine both properties efficiently, and is widely regarded as a scientific breakthrough. Zcash's Orchard shielded pool, activated with Network Upgrade 5 (NU5), uses the Halo 2 proving system.
 
-## What is Halo?
+![Halo overview](https://electriccoin.co/wp-content/uploads/2021/01/Halo-on-Z-1440x720.png "Halo overview")
 
-Halo is a trustless, recursive zero-knowledge proof (ZKP) discovered by Sean Bowe at Electric Coin Co. It eliminates the trusted setup and allows greater scalability of the Zcash blockchain. Halo was the first zero-knowledge proof system that is both efficient & recursive widely regarded as a scientific breakthrough.
+## TL;DR
 
-![halo](https://electriccoin.co/wp-content/uploads/2021/01/Halo-on-Z-1440x720.png "halo")
+- Halo removes the **trusted setup** that earlier Zcash proving systems (Sprout, Sapling) required.
+- It enables **recursive proofs**: one proof can verify the correctness of many other proofs.
+- **Halo 2** is the production implementation, written in Rust, used by the Orchard shielded pool since NU5.
+- Removing the trusted setup means protocol upgrades no longer need a new multi-party ceremony.
+- The same research has influenced Ethereum, Filecoin, and many zkRollup projects.
 
+---
 
-**Components**
+## Core Explanation
 
-Succinct Polynomial Commitment Scheme: Allows a committer to commit to a polynomial with a short string that can be used by a verifier to confirm claimed evaluations of the committed polynomial.
+Zcash uses zero-knowledge proofs so that shielded transactions prove they are valid without revealing sender, receiver, or amount on the public blockchain. Earlier Zcash proof systems (Sprout used BCTV14; Sapling used Groth16) were secure and efficient, but they depended on a **trusted setup ceremony** to generate the public proving and verifying parameters.
 
-Polynomial Interactive Oracle Proof: Verifier asks prover (algorithm) to open all commitments at various points of their choosing using polynomial commitment scheme & checks identity holds true between them. 
+In a trusted setup, participants jointly generate secret randomness. If any secret material — often called "toxic waste" — is not destroyed, a dishonest party could potentially create fake proofs and inflate the shielded supply. Zcash greatly reduced this risk through elaborate multi-party computation ceremonies, but users still needed confidence that at least one participant destroyed their share.
 
+**Halo removes that recurring ceremony requirement entirely.** Instead of relying on a fixed common reference string tied to a specific circuit, Halo uses polynomial commitments and a recursive technique called nested amortization. Proofs can reason about earlier proofs, so a verifier can check the latest accumulator state and gain confidence in the whole chain of prior work — with no toxic waste and no trust in any setup participants.
+
+The practical benefit for Zcash:
+
+- Protocol upgrades can change the proof system without running a new trusted setup for each change.
+- Users have stronger trust assumptions: there is no ceremony whose integrity they must rely on.
+- Recursive composition opens a path to compressing large amounts of shielded computation into smaller verification objects.
+
+---
+
+## Deep Dive
 
 ### No Trusted Setup
 
-zkSNARKs rely on a common reference string (CRS) as a public parameter for proving & verifying. This CRS must be generated in advance by a trusted party. Until recently, elaborate secure multi-party computations (MPC) as those performed by Aztec network & Zcash were necessary to mitigate the risk involved during this [trusted setup ceremony](https://zkproof.org/2021/06/30/setup-ceremonies/amp/). 
+Traditional zk-SNARK systems require public parameters generated in advance. Those parameters are tied to specific circuits, and any secret randomness left over from their generation creates systemic risk. Zcash and other projects used [trusted setup ceremonies](https://zkproof.org/2021/06/30/setup-ceremonies/amp/) to reduce risk, but a residual trust assumption remained.
 
-Previously Zcash's Sprout & Sapling shielded pools utilised the BCTV14 & Groth 16 zk-proving systems. While these were secure there were limitations. They were not scalable as they were tied to a single application, the "toxic waste" (remnants from cryptographic material generated during the genesis ceremony) could persist, and there was an element of trust (albeit minute) for users to deem the ceremony acceptable.
+Halo avoids this by using two key primitives:
 
-By repeatedly collapsing multiple instances of hard problems together over cycles of elliptic curves so that computational proofs can be used to reason about themselves efficiently (Nested amortization) the need for a trusted setup is eliminated. This also means that the structured reference string (output from ceremony) is upgradeable enabling applications such as smart contracts.
+**Succinct polynomial commitment scheme.** A prover commits to a polynomial with a short string. A verifier can later check claimed evaluations of that polynomial without seeing the full computation. This commitment scheme is based on an inner product argument, not on a trusted setup.
 
-Halo provides users with two important assurances regarding the security of the large-scale zero-knowledge proof system. Firstly, it enables users to prove that no one who was involved in the genesis ceremony has created a secret backdoor to execute fraudulent transactions. Secondly, it allows users to demonstrate that the system has remained secure over time, even as it has undergone updates and changes.
+**Polynomial interactive oracle proof.** The verifier asks the prover to open commitments at chosen evaluation points, then checks that the expected identities hold between the openings.
 
-[Sean Bowes Explainer on Dystopia Labs](https://www.youtube.com/watch?v=KdkVTEHUxgo) 
- 
+By **repeatedly collapsing multiple hard-problem instances together over cycles of elliptic curves** (nested amortization), the system lets proofs reason about earlier proofs without ever needing secret setup material.
 
+Halo gives Zcash users two concrete assurances:
+1. No participant in any prior Zcash ceremony can use hidden toxic waste to forge proofs in the Halo-based system.
+2. Future protocol upgrades do not require a new trusted setup ceremony.
+
+[Sean Bowe's explainer on Dystopia Labs](https://www.youtube.com/watch?v=KdkVTEHUxgo)
+
+---
 
 ### Recursive Proofs
 
-Recursive proof composition allows a single proof to attest to the correctness of practically unlimited other proofs, allowing a large amount of computation (and information) to be compressed. This is an essential component for scalablilty, not least because it allows us to horizontally scale the network while still allowing pockets of participants to trust the integrity of the remainder of the network.
+Recursive proof composition allows one proof to attest to the correctness of many other proofs. A large amount of computation can be compressed into a single verification step that remains fast to check.
 
-Prior to Halo, achieving recursive proof composition required large computational expense and a trusted setup. One of the main discoveries was a technique called **nested amortization**. This technique allows for recursive composition using the polynomial commitment scheme based on inner product argument, massively improving on performance and avoiding the trusted setup.
+The [Halo paper](https://eprint.iacr.org/2019/1021.pdf) describes an aggregation technique in the polynomial commitment scheme: many independently created proofs can be verified almost as quickly as a single proof. Before Halo, recursive composition typically required a trusted setup or significant proving overhead. Nested amortization made it practical without either.
 
-In the [Halo paper](https://eprint.iacr.org/2019/1021.pdf), we fully described this polynomial commitment scheme and discovered a new aggregation technique existed in it. The technique allows a large number of independently created proofs to be verified nearly as quickly as verifying a single proof. This alone would offer a better alternative to the earlier zk-SNARKs used in Zcash.
+For Zcash, recursion creates the foundation for:
 
+- **Horizontal scaling** while preserving confidence in the rest of the network.
+- **Compression** of large batches of shielded computation.
+- **Future shielded assets and smart contracts** that reason about their own state efficiently.
 
-### Halo 2
+---
 
-Halo 2, is a high-performance zk-SNARK implementation written in Rust which eliminates the need for a trusted setup while setting the stage for scalability in Zcash. 
+### Halo 2 and the Orchard Pool
+
+Halo 2 is a high-performance zk-SNARK implementation in Rust that generalizes the original Halo approach. It introduced the **accumulation scheme**: proofs are added to an accumulator object, and each new proof reasons about the previous accumulator state. Checking the current accumulator gives confidence in all earlier linked proofs by induction.
 
 <a href="">
-    <img src="https://electriccoin.co/wp-content/uploads/2020/09/Halo-puzzle-03-1024x517.jpg" alt="" width="500" height="300"/>
+    <img src="https://electriccoin.co/wp-content/uploads/2020/09/Halo-puzzle-03-1024x517.jpg" alt="Halo 2 puzzle illustration" width="500" height="300"/>
 </a>
 
-It includes a generalization of our approach called an **accumulation scheme**. This new formalization exposes how our nested amortization technique actually works; by adding proofs to an object called an **accumulator,** where the proofs reason about the previous state of the accumulator, we can check that all previous proofs were correct (by induction) simply by checking the current state of the accumulator.
+Halo 2 also adopts improvements from the broader ZKP research community. In parallel with Halo's development, other teams discovered more efficient polynomial IOPs such as Marlin and PLONK. The most efficient, PLONK, provides flexibility for application-specific circuit design and roughly 5× better prover time compared with Sonic (used in Halo 1).
+
+**The Orchard shielded pool**, activated with NU5 in May 2022, is Zcash's first production deployment of Halo 2. Orchard uses Unified Addresses (starting with `u1`) and handles the full proving and verification flow through Halo 2. Migration from older pools (Sprout, Sapling) to Orchard is encouraged over time to concentrate shielded value in the fully trustless pool.
 
 <a href="">
-    <img src="https://i.imgur.com/l4HrYgE.png" alt="" width="500" height="300"/>
+    <img src="https://i.imgur.com/l4HrYgE.png" alt="Halo 2 accumulation scheme diagram" width="500" height="300"/>
 </a>
 
+---
 
+### Halo in the Wider Ecosystem
 
-In parallel, many other teams were discovering new Polynomial IOPs that were more efficient than Sonic (used in Halo 1), such as Marlin. 
+ECC has entered into research agreements with Protocol Labs, the Filecoin Foundation, and the Ethereum Foundation to explore Halo R&D across ecosystems. Halo 2 is released under the **MIT and Apache 2.0 open-source licenses**, so any project can build with the proving system.
 
-The most efficient of these new protocols is PLONK, which grants enormous flexibility in designing efficient implementations based on application-specific needs and providing 5x better prover time from Sonic.
+**Filecoin** — Halo 2's aggregation technique compresses costly proofs of spacetime and proofs of replication, scaling the network more efficiently. [ECC × Filecoin blog post](https://electriccoin.co/blog/ethereum-zcash-filecoin-collab/)
 
-[Overview of PLONK](https://www.youtube.com/watch?v=P1JeN30RdwQ)
+**Ethereum** — The Privacy and Scaling Explorations group (applied ZKP research under the Ethereum Foundation) researches how Halo 2 proofs can improve privacy and scalability in Ethereum, including potential use in a Verifiable Delay Function for randomness and Proof-of-Stake leader election.
 
+**Other projects using Halo 2:**
 
-### How does this benefit Zcash?
+- [Anoma](https://anoma.net/blog/an-introduction-to-zk-snark-plonkup) — privacy-preserving multichain atomic swap protocol
+- [Orbis](https://docs.orbisprotocol.com/orbis/technology/halo-2) — L2 zkRollup on Cardano
+- [DarkFi](https://darkrenaissance.github.io/darkfi/architecture/architecture.html) — private L1 zkEVM blockchain
+- [Scroll](https://scroll.mirror.xyz/nDAbJbSIJdQIWqp9kn8J0MVS4s6pYBwHmK7keidQs-k) — L2 zkRollup on Ethereum
 
-The Orchard Shielded pool activated with NU5 & is the implementation of this new proof system on the Zcash Network. Guarded by the same turnstile design as used between Sprout and Sapling with the intent to gradually retire the older shielded pools. This encourages migration to a fully trustless proof system, reinforcing confidence in the soundness of the monetary base, and reducing the implementation complexity and attack surface of Zcash overall. Following the activation of NU5 mid 2022, integration of recursive proofs became possible (although this is not complete). Several privacy enhancements were also made tangentially. The introduction of 'Actions' to replace inputs/outputs helped reducing the amount of transaction metadata. 
+---
 
-Trusted setups are generally difficult to coordinate & presented a systemic risk. It would be necessary to repeat them for each major protocol upgrade. Removing them presents a substantial improvement for safely implementing new protocol upgrades. 
+## Related Pages
 
-Recursive proof composition holds the potential for compressing unlimited amounts of computation, creating auditable distributed systems, making Zcash highly capable particularly with the shift to Proof of Stake. This is also useful for extensions such as Zcash Shielded Assets and improving Layer 1 capacity at the higher end of full node usage in the coming years for Zcash.
+- [zk-SNARKs](/zcash-tech/zk-snarks) — The zero-knowledge proof system background
+- [Shielded Pools](/using-zcash/shielded-pools) — Sprout, Sapling, and Orchard
+- [Viewing Keys](/zcash-tech/viewing-keys) — Selective disclosure without losing privacy
+- [FROST](/zcash-tech/frost) — Threshold signatures for shared custody
+- [Post-Quantum Security](/zcash-tech/post-quantum-security) — How Zcash prepares for quantum computing
+- [Developer Resources](/start-here/developer-resources) — Halo 2 library and SDKs
 
+## Resources
 
-## Halo in the wider ecosystem 
-
-The Electric Coin Company has entered into an agreement with Protocol Labs, the Filecoin Foundation, and the Ethereum Foundation to explore Halo R&D, including how the technology might be used in their respective networks. The agreement aims to provide better scalability, interoperability and privacy across ecosystems and for Web 3.0.
-
-Additionally, Halo 2 is under the [MIT and Apache 2.0 open-source licenses](https://github.com/zcash/halo2#readme), meaning anyone in the ecosystem can build with the proving system.
-
-### Filecoin
-
-Since its deployment, the halo2 library has been adopted in projects like the zkEVM, there is potential integration of Halo 2 into the proof system for the Filecoin Virtual Machine. Filecoin requires numerous costly proofs of spacetime / proofs of replication. Halo2 will be pivotal in compressing the space usage, better scaling the network.
-
-[Filecoin Foundation video with Zooko](https://www.youtube.com/watch?v=t4XOdagc9xw)
-
-Additionally, it would be highly beneficial to both the Filecoin and Zcash ecosystems if Filecoin storage payments could be made in ZEC, affording the same level of privacy for storage purchases that exists in Zcash shielded transfers. This support would add the ability to encrypt files in Filecoin storage and add support to mobile clients so that they could **attach** media or files to a Zcash encrypted memo. 
-
-[ECC x Filecoin Blog Post](https://electriccoin.co/blog/ethereum-zcash-filecoin-collab/)
-
-### Ethereum
-
-Implementation of a Halo 2 proof for the efficient Verifiable Delay Function (VDF) being developed. A VDF is a cryptographic primitive that has many potential use cases. 
-
-It can be used as a source of general purpose randomness including use in smart contract applications as well as leader election in Proof of Stake on Ethereum & other protocols.
-
-ECC, the Filecoin Foundation, Protocol Labs, and the Ethereum Foundation will also be working with [SupraNational](https://www.supranational.net/), a vendor specializing in hardware-accelerated cryptography, for potential GPU and ASIC design and development of the VDF.
-
-The [Privacy and Scaling Exploration group](https://appliedzkp.org/) is also researching different ways Halo 2 proofs can improve privacy and scalability for the Ethereum ecosystem. This group rolls up to the Ethereum foundation, and has a broad focus on zero-knowledge proofs and cryptographic primitives. 
-
-## Other projects using Halo
-
-+ [Anoma, a privacy preserving multichain atomic swap protocol](https://anoma.net/blog/an-introduction-to-zk-snark-plonkup)
-
-+ [Oribis, an L2 zkRollup on Cardano](https://docs.orbisprotocol.com/orbis/technology/halo-2)
-
-+ [Darkfi, a private L1 zkEVM blockchain](https://darkrenaissance.github.io/darkfi/architecture/architecture.html)
-
-+ [Scroll, an L2 zkRollup on Ethereum](https://scroll.mirror.xyz/nDAbJbSIJdQIWqp9kn8J0MVS4s6pYBwHmK7keidQs-k)
-
-
-**Further Learning**:
-
-[An introduction to zkp and halo 2 - Hanh Huynh Huu](https://www.youtube.com/watch?v=jDHWJLjQ9oA)
-
-[Halo 2 with Daira & Str4d - ZKPodcast](https://www.youtube.com/watch?v=-lZH8T5i-K4)
-
-[Technical Explainer Blog](https://electriccoin.co/blog/technical-explainer-halo-on-zcash/)
-
-[Halo 2 Community Showcase - Ying Tong @Zcon3](https://www.youtube.com/watch?v=JJi2TT2Ahp0)
-
-**Documentation**
-
-[Halo 2 resources](https://github.com/adria0/awesome-halo2)
-
-[Halo 2 docs](https://zcash.github.io/halo2/)
-
-[Halo 2 github](https://github.com/zcash/halo2)
+- [Halo paper (eprint)](https://eprint.iacr.org/2019/1021.pdf)
+- [Halo 2 GitHub](https://github.com/zcash/halo2)
+- [Halo 2 docs](https://zcash.github.io/halo2/)
+- [Halo 2 awesome list](https://github.com/adria0/awesome-halo2)
+- [Technical explainer blog — ECC](https://electriccoin.co/blog/technical-explainer-halo-on-zcash/)
+- [Sean Bowe's explainer — Dystopia Labs](https://www.youtube.com/watch?v=KdkVTEHUxgo)
+- [Intro to ZKP and Halo 2 — Hanh Huynh Huu](https://www.youtube.com/watch?v=jDHWJLjQ9oA)
+- [Halo 2 with Daira & Str4d — ZKPodcast](https://www.youtube.com/watch?v=-lZH8T5i-K4)
+- [Halo 2 Community Showcase — Ying Tong, Zcon3](https://www.youtube.com/watch?v=JJi2TT2Ahp0)

--- a/site/Zcash_Tech/Viewing_Keys.md
+++ b/site/Zcash_Tech/Viewing_Keys.md
@@ -4,60 +4,145 @@
 
 # Viewing Keys
 
-Shielded addresses enable users to transact while revealing as little information as possible on the Zcash blockchain. What happens when you need to disclose sensitive information around a shielded Zcash transaction to a specific party? Every shielded address includes a viewing key. Viewing keys were introduced in [ZIP 310](https://zips.z.cash/zip-0310) and added to the protocol in the Sapling network upgrade. Viewing keys are a crucial part of Zcash as they allow users to selectively disclose information about transactions.
+Viewing keys let a Zcash user selectively disclose shielded transaction information to a chosen party — without handing over the ability to spend funds. They are one of the main tools that make Zcash privacy practical for exchanges, custodians, auditors, and businesses that need limited read access for a specific purpose.
 
-### Why use a viewing key?
+## TL;DR
 
-Why would a user ever want to do this? From Electric Coin Co.'s blog on the matter...
+- A viewing key gives **read-only** access to shielded activity for an address or account.
+- A viewing key **cannot move funds** — it has no spend authority.
+- Viewing keys support **selective disclosure**: share transaction history with a chosen party without making it public to everyone.
+- **Incoming viewing keys** are useful for detecting received payments while keeping spend keys secure.
+- **Full viewing keys** reveal broader activity; share them only with trusted parties for a clear purpose.
+- **Unified viewing keys** (ZIP 316) bundle viewing information for a Unified Address across all supported receiver types.
 
-*- An exchange wants to detect when a customer deposits ZEC to a shielded address, while keeping the **spend authority** keys on secure hardware. The exchange could generate an incoming viewing key and load it onto an Internet-connected **detection** node, while the spending key remains on the more secure system.*
+---
 
-*- A custodian needs to provide visibility of their Zcash holdings to auditors. The custodian may generate a full viewing key for each of their shielded addresses and share that key with their auditor. The auditor will be able to verify the balance of those addresses and review past transaction activity to and from those addresses.* 
+## Core Explanation
 
-*- An exchange may need to conduct due diligence checks on a customer who makes deposits from a shielded address. The exchange could request the customers viewing key for their shielded address and use it to review the customers shielded transaction activity as part of these enhanced due diligence procedures.*
+Shielded Zcash addresses hide transaction details on-chain. That privacy is useful by default, but sometimes a user needs to prove something about shielded activity to another party — to confirm a deposit, provide audit visibility, or support a compliance workflow.
 
-### How to find your viewing key
+Viewing keys solve this by separating read access from spend authority. A party with the right viewing key can scan the blockchain and see the shielded information that key is authorized to reveal. They cannot authorize transactions or move funds.
 
-#### zcashd
+Viewing keys are part of Zcash's selective disclosure model. Sapling-era shielded addresses introduced the capability (specified in [ZIP 310](https://zips.z.cash/zip-0310)), and Unified Addresses expanded it through [ZIP 316](https://zips.z.cash/zip-0316) Unified Viewing Keys.
 
-* List all known addresses using *./zcash-cli listaddresses*
+---
 
-* Then issue the following command for either UA's or Sapling shielded addresses
+## Why Use a Viewing Key?
 
-  *./zcash-cli z_exportviewingkey "<UA or Z address>"*
+Electric Coin Co. describes three common use cases:
 
-#### Ywallet
+**Exchange deposit detection.** An exchange can keep spend authority on secure hardware while loading an incoming viewing key onto an Internet-connected detection node. The node detects customer deposits to a shielded address without being able to spend the funds.
 
-* On the top right corner select "Backup", Authenticate your phone, then simply copy your viewing key that is displayed.
+**Custodian audits.** A custodian can give an auditor a full viewing key for each relevant shielded address. The auditor can verify balances and review past transaction activity without gaining control of the funds.
 
-### How to use your viewing key
+**Customer due diligence.** An exchange or regulated service may ask a customer to share a viewing key so it can review shielded transaction activity as part of an enhanced due diligence workflow.
 
-#### zcashd
+In each case, the viewing key provides visibility without providing control. That separation is what makes it useful for operational and compliance purposes without compromising the fund holder's security.
 
-* Use the following with any vkey or ukey: 
+---
 
-*./zcash-cli z_importviewingkey "vkey/ukey" whenkeyisnew 30000*
+## Types of Viewing Keys
 
-#### ywallet
+| Type | What it reveals | When to use |
+|------|----------------|-------------|
+| Incoming viewing key | Received transactions only | Exchange deposit monitoring |
+| Full viewing key | All transactions (incoming and outgoing) | Custodian audits, full account review |
+| Unified viewing key | Cross-pool activity for a Unified Address | Modern wallets; covers Orchard, Sapling, and Transparent receivers |
 
-* In the top right corner, select "Account", click on "+" in the bottom right corner to add and import your viewing key to add your 'read-only' account.
+Always confirm which key type you have and what the receiving tool supports before sharing or importing.
+
+---
+
+## How to Find Your Viewing Key
+
+### Zashi
+
+1. Open Zashi and go to **Settings**.
+2. Select **Recovery Phrase** (or **Export Viewing Key** if available in your version).
+3. Authenticate with your device PIN or biometrics.
+4. Copy or share the viewing key displayed.
+
+### YWallet
+
+1. Select **Backup** in the top-right corner of the account.
+2. Authenticate on the device.
+3. Copy the viewing key shown.
+
+### zcashd / Zebra (CLI)
+
+List all known addresses:
+
+```bash
+./zcash-cli listaddresses
+```
+
+Export the viewing key for a Unified Address or Sapling shielded address:
+
+```bash
+./zcash-cli z_exportviewingkey "<UA or Z address>"
+```
+
+---
+
+## How to Use a Viewing Key
+
+### Zashi
+
+Zashi supports read-only accounts. Import a viewing key to monitor an address without holding the spend key on that device.
+
+### YWallet
+
+1. Select **Account** in the top-right corner.
+2. Tap **+** in the bottom-right corner.
+3. Choose **Import Viewing Key** and paste the key.
+4. The wallet adds a read-only account for that address.
 
 <a href="">
-    <img src="https://i.ibb.co/C0b002N/image-2024-01-13-175554676.png" alt="" width="200" height="280"/>
+    <img src="https://i.ibb.co/C0b002N/image-2024-01-13-175554676.png" alt="YWallet viewing key import screen" width="200" height="280"/>
 </a>
 
+### zcashd (CLI)
 
-#### zcashblockexplorer.com
+Import any supported viewing key type:
 
-* Simply point your browser to [here](https://zcashblockexplorer.com/vk) and wait for the results! note: this result is now on the zcashblockexplorer node and thus you're trusting this info with the owners of zcashblockexplorer.com
+```bash
+./zcash-cli z_importviewingkey "vkey/ukey" whenkeyisnew 30000
+```
 
-### Resources
+### Block explorer
 
-While a great technology, it's recommended that you use viewing keys on an as needed basis.
+Open [mainnet.zcashexplorer.app/vk](https://mainnet.zcashexplorer.app/vk) and enter the viewing key to inspect compatible shielded activity.
 
-Check out this tutorial on viewing keys. A list of resources on the subject is below if you want to dive deeper:
+**Important:** this sends viewing-key information to the block explorer service. Only use this option if you are comfortable trusting the operator with the information the viewing key can reveal.
 
-- [ECC, Explaining Viewing Keys](https://electriccoin.co/blog/explaining-viewing-keys/)
-- [ECC, Selective Disclosure and Viewing Keys](https://electriccoin.co/blog/viewing-keys-selective-disclosure/)
-- [ECC, Zcash Viewing Key Video Presentation](https://www.youtube.com/watch?v=NXjK_Ms7D5U&t=199s)
-- [ZIP 310](https://zips.z.cash/zip-0310)
+---
+
+## Common Mistakes
+
+**Sharing a spending key instead of a viewing key.** A spending key authorizes transactions and can move funds. Never share it when read-only access is the goal.
+
+**Treating viewing keys as public.** Viewing keys reveal sensitive financial information. Share them only when a party needs that visibility and you understand what the key exposes.
+
+**Assuming a viewing key shows everything.** What it reveals depends on the key type (incoming vs. full vs. unified), the address type, wallet support, and transaction direction.
+
+**Entering a viewing key into an untrusted third-party website.** A block explorer can be useful, but it also learns whatever the key can see. Use it only with trusted operators.
+
+**Forgetting operational separation.** Exchanges and custodians should keep spend authority on secure systems. Viewing keys are tools for detection and auditing workflows, not a replacement for key management.
+
+---
+
+## Related Pages
+
+- [Shielded Pools](/using-zcash/shielded-pools) — Orchard, Sapling, Sprout, and transparent value pools
+- [Wallets](/using-zcash/wallets) — Wallets that expose shielded-address and viewing-key workflows
+- [Transactions](/using-zcash/transactions) — How Zcash transactions move between address types
+- [zk-SNARKs](/zcash-tech/zk-snarks) — The proof system behind shielded transactions
+- [Halo](/zcash-tech/halo) — The Orchard proving system upgrade
+
+## Resources
+
+- [ZIP 310: Security Properties of Sapling Viewing Keys](https://zips.z.cash/zip-0310)
+- [ZIP 316: Unified Addresses and Unified Viewing Keys](https://zips.z.cash/zip-0316)
+- [ECC: Explaining Viewing Keys](https://electriccoin.co/blog/explaining-viewing-keys/)
+- [ECC: Selective Disclosure and Viewing Keys](https://electriccoin.co/blog/viewing-keys-selective-disclosure/)
+- [ECC: Zcash Viewing Key Video Presentation](https://www.youtube.com/watch?v=NXjK_Ms7D5U&t=199s)

--- a/site/zechubglobal/zcashbrasil/zcashtech/Halo.md
+++ b/site/zechubglobal/zcashbrasil/zcashtech/Halo.md
@@ -1,138 +1,81 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/zcashtech/Halo.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
+
 # Halo
 
+> 🇺🇸 [English version](/zcash-tech/halo)
 
-## O que é Halo?
+Halo é um sistema de prova de conhecimento zero confiável e recursivo descoberto por Sean Bowe na Electric Coin Co. Ele elimina a necessidade de uma configuração confiável (trusted setup) e torna a composição recursiva de provas prática. O Halo foi o primeiro sistema de prova de conhecimento zero a combinar essas duas propriedades de forma eficiente, sendo amplamente reconhecido como um avanço científico. O pool blindado Orchard do Zcash, ativado com a Atualização de Rede 5 (NU5), usa o sistema de prova Halo 2.
 
-Halo é um zero-knowledge proof (ZKP) descoberta por Sean Bowe na Electric Coin Co. Ele elimina o Trusted Setup e permite maior escalabilidade da blockchain Zcash. Halo foi o primeiro sistema zero-knowledge proof que é eficiente e recursivo amplamente considerado como um avanço científico.
+![Visão geral do Halo](https://electriccoin.co/wp-content/uploads/2021/01/Halo-on-Z-1440x720.png "Visão geral do Halo")
 
-- [halo](https://electriccoin.co/wp-content/uploads/2021/01/Halo-on-Z-1440x720.png "halo")
+## TL;DR
 
----
-
-**Componentes**
-
-Succinct Polynomial Commitment Scheme: permite que um colaborador se comprometa com um polinômio com uma string curta que pode ser usada por um verificador para confirmar as avaliações reivindicadas do polinômio confirmado.
-
-Polynomial Interactive Oracle Proof: O verificador pede ao provador (algoritmo) para abrir todos os compromissos em vários pontos de sua escolha usando o esquema de compromisso polinomial e verifica se a identidade é verdadeira entre eles.
-
----
-
-### No Trusted Setup
-
-zkSNARKs dependem de uma string de referência comum (CRS) como um parâmetro público para provar e verificar. Este CRS deve ser gerado antecipadamente por uma parte confiável. Até recentemente, era necessário elaborar cálculos multipartidários seguros (MPC) como aqueles executados pela rede Aztec e Zcash para mitigar o risco envolvido durante a [cerimônia do Trusted Setup](https://zkproof.org/2021/06/30/setup-cerimônias/amp/).
-
-Anteriormente, as pools blindadas Sprout & Sapling da Zcash utilizavam os sistemas BCTV14 & Groth 16 zk-proving. Embora estes fossem seguros, havia limitações. Eles não eram escaláveis, pois estavam vinculados a um único aplicativo, o "resíduo tóxico" (restos de material criptográfico gerado durante a cerimônia do Block Genesis) poderia persistir e havia um elemento de confiança (embora mínimo) para os usuários considerarem a cerimônia aceitável.
-
-Ao agrupar repetidamente várias instâncias de problemas difíceis em ciclos de curvas elípticas, de modo que as provas computacionais possam ser usadas para raciocinar sobre si mesmas com eficiência (amortização aninhada), a necessidade de um Trusted Setup é eliminada. Isso também significa que a string de referência estruturada (saída da cerimônia) pode ser atualizada, permitindo aplicativos como contratos inteligentes.
-
-O Halo fornece aos usuários duas garantias importantes em relação à segurança do sistema zero-knowledge proof em larga escala. Em primeiro lugar, permite que os usuários provem que ninguém que esteve envolvido na cerimônia criou um backdoor secreto para executar transações fraudulentas. Em segundo lugar, permite que os usuários demonstrem que o sistema permaneceu seguro ao longo do tempo, mesmo com atualizações e alterações.
-
-- [Explicação de Sean Bowes na Dystopia Labs](https://www.youtube.com/watch?v=KdkVTEHUxgo)
- 
----
-
-### Recursive Proofs
-
-A composição de Recursive Proofs permite que uma única prova ateste a correção de outras provas praticamente ilimitadas, permitindo que uma grande quantidade de computação (e informação) seja comprimida. Este é um componente essencial para a escalabilidade, até porque nos permite dimensionar horizontalmente a rede enquanto ainda permite que bolsões de participantes confiem na integridade do restante da rede.
-
-Antes do Halo, obter composição de Recursive Proofs exigia grandes despesas computacionais e um Trusted Setup. Uma das principais descobertas foi uma técnica chamada “nested amortization”. Essa técnica permite a composição recursiva usando o esquema de compromisso polinomial baseado no argumento do produto interno, melhorando massivamente o desempenho e evitando o Trusted setup.
-
-No [documento Halo](https://eprint.iacr.org/2019/1021.pdf), descrevemos completamente esse esquema de compromisso polinomial e descobrimos que existia uma nova técnica de agregação nele. A técnica permite que um grande número de provas criadas independentemente sejam verificadas quase tão rapidamente quanto a verificação de uma única prova. Isso por si só ofereceria uma alternativa melhor aos zk-SNARKs anteriores usados ​​na Zcash.
+- O Halo elimina a **configuração confiável** que os sistemas de prova anteriores do Zcash (Sprout, Sapling) exigiam.
+- Ele permite **provas recursivas**: uma prova pode verificar a correção de muitas outras provas.
+- O **Halo 2** é a implementação em produção, escrita em Rust, usada pelo pool blindado Orchard desde a NU5.
+- Remover a configuração confiável significa que as atualizações de protocolo não precisam mais de uma nova cerimônia multi-partes.
+- A mesma pesquisa influenciou o Ethereum, a Filecoin e vários projetos de zkRollup.
 
 ---
 
-### Halo 2
+## Explicação Principal
 
-Halo 2 é uma implementação zk-SNARK de alto desempenho escrita em Rust que elimina a necessidade de um Trusted Setup enquanto prepara o cenário de escalabilidade para a  Zcash.
+O Zcash usa provas de conhecimento zero para que transações blindadas provem sua validade sem revelar remetente, destinatário ou valor na blockchain pública. Os sistemas de prova anteriores do Zcash (Sprout usava BCTV14; Sapling usava Groth16) eram seguros e eficientes, mas dependiam de uma **cerimônia de configuração confiável**.
 
-![halo2image](https://electriccoin.co/wp-content/uploads/2020/09/Halo-puzzle-03-1024x517.jpg "halo2")
+Em uma configuração confiável, os participantes geram conjuntamente uma aleatoriedade secreta. Se algum material secreto — frequentemente chamado de "lixo tóxico" — não for destruído, uma parte desonesta poderia criar provas falsas. O Zcash reduziu esse risco por meio de cerimônias multi-partes elaboradas, mas os usuários ainda precisavam confiar que pelo menos um participante destruiu sua parte.
 
-Ele inclui uma generalização de nossa abordagem chamada de “esquema de acumulação”. Essa nova formalização expõe como nossa técnica de amortização aninhada realmente funciona; adicionando provas a um objeto chamado “acumulador”, onde as provas raciocinam sobre o estado anterior do acumulador, podendo verificar se todas as provas anteriores estavam corretas (por indução) simplesmente verificando o estado atual do acumulador.
-
-![Accumulatorimage](https://i.imgur.com/l4HrYgE.png "acumulador")
-
-Paralelamente, muitas outras equipes foram descobrindo novos IOPs polinomiais que eram mais eficientes que o Sonic (usado no Halo 1), como o Marlin.
-
-O mais eficiente desses novos protocolos é o PLONK, que concede enorme flexibilidade no design de implementações eficientes com base nas necessidades específicas do aplicativo e fornece tempo de prova 5x melhor do Sonic.
-
-- [Visão geral do PLONK](https://www.youtube.com/watch?v=P1JeN30RdwQ)
+**O Halo remove completamente esse requisito.** Em vez de depender de uma string de referência comum fixa, o Halo usa compromissos polinomiais e amortização aninhada. As provas raciocinam sobre provas anteriores, eliminando o lixo tóxico e a confiança em participantes da configuração.
 
 ---
 
-### Como isso beneficia a Zcash?
+## Aprofundamento
 
-A Pool Orchard Blindada ativada na NU5 é a implementação deste novo sistema na rede Zcash. Protegido pelo mesmo design de catraca usado entre Sprout e Sapling com a intenção de retirar gradualmente as Pools Blindadas mais antigas. 
+### Sem Configuração Confiável
 
-Isso incentiva a migração para um sistema de prova totalmente confiável, reforçando a confiança na solidez da base monetária e reduzindo a complexidade da implementação e a superfície de ataque da Zcash em geral. Após a ativação da NU5 em meados de 2022, a integração de Recursive Proofs tornou-se possível (embora isso não esteja completo). Vários aprimoramentos de privacidade também foram feitos tangencialmente. A introdução de 'Ações' para substituir inputs/outputs ajudou a reduzir a quantidade de metadados da transação.
+O Halo evita a configuração confiável com dois primitivos:
 
-Os Trusted Setup ​​geralmente são difíceis de coordenar e apresentam um risco sistêmico. Seria necessário repeti-los para cada grande atualização de protocolo. Removê-los apresenta uma melhoria substancial para a implementação segura de novas atualizações de protocolo.
+**Esquema de compromisso polinomial sucinto.** Um provador se compromete com um polinômio com uma string curta. Um verificador pode verificar avaliações reivindicadas sem ver toda a computação.
 
-A composição Recursive Proofs tem o potencial de comprimir quantidades ilimitadas de computação, criando sistemas distribuídos auditáveis, tornando a Zcash altamente capaz, especialmente com a mudança para Proof of Stake. Isso também é útil para extensões como Zcash Shielded Assets e para melhorar a capacidade da Layer 1 na extremidade superior do uso de um full node nos próximos anos para a Zcash.
+**Prova interativa de oráculo polinomial.** O verificador pede ao provador que abra compromissos em pontos escolhidos e verifica se as identidades esperadas se mantêm.
 
----
+Ao colapsar múltiplas instâncias de problemas difíceis sobre ciclos de curvas elípticas (**amortização aninhada**), o sistema permite que as provas raciocinem sobre provas anteriores sem material secreto.
 
-## Halo no ecossistema mais amplo
+Garantias concretas para usuários do Zcash:
+1. Nenhum participante de cerimônias anteriores pode usar lixo tóxico para forjar provas no sistema Halo.
+2. Futuras atualizações de protocolo não requerem nova cerimônia de configuração confiável.
 
-A Electric Coin Company firmou um acordo com a Protocol Labs, Filecoin Foundation e a Ethereum Foundation para explorar o Halo R&D, incluindo como a tecnologia pode ser usada em suas respectivas redes. O acordo visa fornecer melhor escalabilidade, interoperabilidade e privacidade entre os ecossistemas e para a Web 3.0.
+[Explicação de Sean Bowe no Dystopia Labs](https://www.youtube.com/watch?v=KdkVTEHUxgo)
 
-Além disso, o Halo 2 está sob as [licenças de código aberto MIT e Apache 2.0](https://github.com/zcash/halo2#readme), o que significa que qualquer pessoa no ecossistema pode construir com o sistema de teste.
+### Provas Recursivas
 
----
+A composição recursiva permite que uma prova ateste a correção de muitas outras provas. O [artigo do Halo](https://eprint.iacr.org/2019/1021.pdf) descreve uma técnica de agregação em que muitas provas independentes podem ser verificadas quase tão rapidamente quanto uma única prova.
 
-### Filecoin
+Para o Zcash, a recursão cria a base para escalabilidade horizontal, compressão de computação blindada e futuros contratos inteligentes.
 
-Desde a sua implantação, a biblioteca halo2 foi adotada em projetos como o zkEVM, há potencial de integração do Halo 2 no sistema de prova para a máquina virtual Filecoin. Filecoin requer inúmeras provas caras de espaço-tempo/provas de replicação. O Halo2 será fundamental na compactação do uso do espaço, dimensionando melhor a rede.
+### Halo 2 e o Pool Orchard
 
-- [Filecoin Foundation -  Zooko](https://www.youtube.com/watch?v=t4XOdagc9xw)
+O Halo 2 é uma implementação de alto desempenho em Rust com um **esquema de acumulação**: provas são adicionadas a um acumulador, e cada nova prova raciocina sobre o estado anterior. Verificar o acumulador atual garante confiança em toda a cadeia de provas anteriores.
 
-Além disso, seria altamente benéfico para os ecossistemas Filecoin & Zcash se os pagamentos de armazenamento Filecoin pudessem ser feitos em ZEC, proporcionando o mesmo nível de privacidade para compras de armazenamento que existe nas transferências blindadas Zcash. Esse suporte adicionaria a capacidade de criptografar arquivos no armazenamento Filecoin e adicionar suporte a clients móveis para que eles pudessem “anexar” mídia ou arquivos a um memorando Zcash.
+O **pool blindado Orchard**, ativado com a NU5 em maio de 2022, é o primeiro deployment em produção do Halo 2 no Zcash. Usa Endereços Unificados começando com `u1`.
 
-- [Blog ECC x Filecoin](https://electriccoin.co/blog/ethereum-zcash-filecoin-collab/)
-
----
-
-### Ethereum
-
-Implementação de uma Halo 2 Proof para a eficiente função de atraso verificável (VDF) que está sendo desenvolvida. Um VDF é um primitivo criptográfico que tem muitos casos de uso em potencial.
-
-Ele pode ser usado como uma fonte de aleatoriedade de propósito geral, incluindo o uso em aplicativos de contrato inteligente, bem como eleição de líder em Proof of Stake na Ethereum e outros protocolos.
-
-A ECC, Filecoin Foundation, Protocol Labs e a Ethereum Foundation também trabalharão com a [SupraNational](https://www.supranational.net/), um fornecedor especializado em criptografia acelerada por hardware, para possíveis projetos de GPU e ASIC e desenvolvimento do VDF.
-
-O [grupo de exploração de privacidade e escala](https://appliedzkp.org/) também está pesquisando diferentes maneiras pelas quais as Halo 2 Proofs podem melhorar a privacidade e a escalabilidade do ecossistema Ethereum. Este grupo se estende até a Ethereum Foundation e tem um amplo foco em Zero-knowledge Proof e primitivas criptográficas.
+O Halo 2 é lançado sob as **licenças open-source MIT e Apache 2.0**.
 
 ---
 
-## Outros projetos usando Halo
+## Páginas Relacionadas
 
-+ [Anoma, um protocolo que preserva a privacidade](https://anoma.net/blog/an-introduction-to-zk-snark-plonkup)
+- [zk-SNARKs](/zcash-tech/zk-snarks)
+- [Pools Blindados](/using-zcash/shielded-pools)
+- [Chaves de Visualização](/zcash-tech/viewing-keys)
+- [FROST](/zcash-tech/frost)
+- [Segurança Pós-Quântica](/zcash-tech/post-quantum-security)
 
-+ [Oribis, uma L2 zkRollup na Cardano](https://docs.orbisprotocol.com/orbis/technology/halo-2)
+## Recursos
 
-+ [Darkfi, uma blockchain privada L1 zkEVM](https://darkrenaissance.github.io/darkfi/architecture/architecture.html)
-
-+ [Scroll, um L2 zkRollup na Ethereum](https://scroll.mirror.xyz/nDAbJbSIJdQIWqp9kn8J0MVS4s6pYBwHmK7keidQs-k)
-
----
-
-**Aprendizagem Adicional**:
-
-- [Uma introdução ao zkp e halo 2 - Hanh Huynh Huu](https://www.youtube.com/watch?v=jDHWJLjQ9oA)
-
-- [Halo 2 com Daira & Str4d - ZKPodcast](https://www.youtube.com/watch?v=-lZH8T5i-K4)
-
-- [Blog - Explicação Técnica](https://electriccoin.co/blog/technical-explainer-halo-on-zcash/)
-
-- [Halo 2 Community Showcase - Ying Tong @Zcon3](https://www.youtube.com/watch?v=JJi2TT2Ahp0)
-
----
-
-**Documentação**
-
-- [Recursos do Halo 2](https://github.com/adria0/awesome-halo2)
-
-- [Documentos do Halo 2](https://zcash.github.io/halo2/)
-
-- [Halo 2 github](https://github.com/zcash/halo2)
-
-
+- [Artigo do Halo (eprint)](https://eprint.iacr.org/2019/1021.pdf)
+- [GitHub do Halo 2](https://github.com/zcash/halo2)
+- [Documentação do Halo 2](https://zcash.github.io/halo2/)
+- [Blog explicativo — ECC](https://electriccoin.co/blog/technical-explainer-halo-on-zcash/)
+- [Explicação de Sean Bowe — Dystopia Labs](https://www.youtube.com/watch?v=KdkVTEHUxgo)

--- a/site/zechubglobal/zcashbrasil/zcashtech/viewingkeys.md
+++ b/site/zechubglobal/zcashbrasil/zcashtech/viewingkeys.md
@@ -1,1 +1,144 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/zcashtech/viewingkeys.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
 
+# Chaves de Visualização
+
+> 🇺🇸 [English version](/zcash-tech/viewing-keys)
+
+As chaves de visualização permitem que um usuário do Zcash divulgue seletivamente informações de transações blindadas a uma parte escolhida — sem transferir a capacidade de gastar fundos. São uma das principais ferramentas que tornam a privacidade do Zcash prática para exchanges, custodiantes, auditores e empresas que precisam de acesso de leitura limitado para uma finalidade específica.
+
+## TL;DR
+
+- Uma chave de visualização fornece acesso **somente leitura** à atividade blindada de um endereço ou conta.
+- Uma chave de visualização **não pode mover fundos** — não tem autoridade de gasto.
+- Chaves de visualização suportam **divulgação seletiva**: compartilhe histórico de transações com uma parte escolhida sem torná-lo público para todos.
+- **Chaves de visualização de entrada** são úteis para detectar pagamentos recebidos mantendo as chaves de gasto seguras.
+- **Chaves de visualização completas** revelam atividade mais ampla; compartilhe apenas com partes confiáveis para uma finalidade clara.
+- **Chaves de visualização unificadas** (ZIP 316) agrupam informações de visualização para um Endereço Unificado em todos os tipos de receptores suportados.
+
+---
+
+## Explicação Principal
+
+Endereços blindados do Zcash ocultam detalhes de transações na blockchain. Essa privacidade é útil por padrão, mas às vezes um usuário precisa provar algo sobre atividade blindada a outra parte — para confirmar um depósito, fornecer visibilidade de auditoria ou apoiar um fluxo de conformidade.
+
+As chaves de visualização resolvem isso separando o acesso de leitura da autoridade de gasto. Uma parte com a chave de visualização correta pode verificar a blockchain e ver as informações blindadas que a chave está autorizada a revelar. Elas não podem autorizar transações ou mover fundos.
+
+Chaves de visualização fazem parte do modelo de divulgação seletiva do Zcash. Endereços blindados da era Sapling introduziram a capacidade (especificada na [ZIP 310](https://zips.z.cash/zip-0310)), e os Endereços Unificados a expandiram por meio das Chaves de Visualização Unificadas da [ZIP 316](https://zips.z.cash/zip-0316).
+
+---
+
+## Por Que Usar uma Chave de Visualização?
+
+A Electric Coin Co. descreve três casos de uso comuns:
+
+**Detecção de depósitos em exchanges.** Uma exchange pode manter a autoridade de gasto em hardware seguro enquanto carrega uma chave de visualização de entrada em um nó de detecção conectado à Internet. O nó detecta depósitos de clientes em endereços blindados sem poder gastar os fundos.
+
+**Auditorias de custodiantes.** Um custodiante pode dar a um auditor uma chave de visualização completa para cada endereço blindado relevante. O auditor pode verificar saldos e revisar atividade de transações passadas sem obter controle dos fundos.
+
+**Diligência devida do cliente.** Uma exchange ou serviço regulamentado pode pedir a um cliente que compartilhe uma chave de visualização para revisar a atividade de transações blindadas como parte de um fluxo de diligência devida aprimorada.
+
+---
+
+## Tipos de Chaves de Visualização
+
+| Tipo | O que revela | Quando usar |
+|------|-------------|-------------|
+| Chave de visualização de entrada | Apenas transações recebidas | Monitoramento de depósitos em exchanges |
+| Chave de visualização completa | Todas as transações (entrada e saída) | Auditorias de custodiantes, revisão completa da conta |
+| Chave de visualização unificada | Atividade cross-pool para um Endereço Unificado | Carteiras modernas; cobre Orchard, Sapling e receptores Transparentes |
+
+---
+
+## Como Encontrar Sua Chave de Visualização
+
+### Zashi
+
+1. Abra o Zashi e vá em **Configurações**.
+2. Selecione **Frase de Recuperação** (ou **Exportar Chave de Visualização** se disponível na sua versão).
+3. Autentique com PIN ou biometria do dispositivo.
+4. Copie ou compartilhe a chave de visualização exibida.
+
+### YWallet
+
+1. Selecione **Backup** no canto superior direito da conta.
+2. Autentique no dispositivo.
+3. Copie a chave de visualização exibida.
+
+### zcashd / Zebra (CLI)
+
+Liste todos os endereços conhecidos:
+
+```bash
+./zcash-cli listaddresses
+```
+
+Exporte a chave de visualização para um Endereço Unificado ou endereço blindado Sapling:
+
+```bash
+./zcash-cli z_exportviewingkey "<endereço UA ou Z>"
+```
+
+---
+
+## Como Usar uma Chave de Visualização
+
+### Zashi
+
+O Zashi suporta contas somente leitura. Importe uma chave de visualização para monitorar um endereço sem ter a chave de gasto naquele dispositivo.
+
+### YWallet
+
+1. Selecione **Conta** no canto superior direito.
+2. Toque em **+** no canto inferior direito.
+3. Escolha **Importar Chave de Visualização** e cole a chave.
+4. A carteira adiciona uma conta somente leitura para aquele endereço.
+
+<a href="">
+    <img src="https://i.ibb.co/C0b002N/image-2024-01-13-175554676.png" alt="Tela de importação de chave de visualização no YWallet" width="200" height="280"/>
+</a>
+
+### zcashd (CLI)
+
+Importe qualquer tipo de chave de visualização suportado:
+
+```bash
+./zcash-cli z_importviewingkey "vkey/ukey" whenkeyisnew 30000
+```
+
+### Explorador de blocos
+
+Abra [mainnet.zcashexplorer.app/vk](https://mainnet.zcashexplorer.app/vk) e insira a chave de visualização para inspecionar atividade blindada compatível.
+
+**Importante:** isso envia informações da chave de visualização para o serviço de explorador de blocos. Use apenas se estiver confortável em confiar ao operador as informações que a chave pode revelar.
+
+---
+
+## Erros Comuns
+
+**Compartilhar uma chave de gasto em vez de uma chave de visualização.** Uma chave de gasto autoriza transações e pode mover fundos. Nunca a compartilhe quando o acesso somente leitura for o objetivo.
+
+**Tratar chaves de visualização como públicas.** Chaves de visualização revelam informações financeiras sensíveis. Compartilhe-as apenas quando uma parte precisar dessa visibilidade e você entender o que a chave expõe.
+
+**Assumir que uma chave de visualização mostra tudo.** O que ela revela depende do tipo de chave (entrada vs. completa vs. unificada), do tipo de endereço, do suporte da carteira e da direção da transação.
+
+**Inserir uma chave de visualização em um site de terceiros não confiável.** Um explorador de blocos pode ser útil, mas também aprende tudo o que a chave pode ver. Use apenas com operadores confiáveis.
+
+---
+
+## Páginas Relacionadas
+
+- [Pools Blindados](/using-zcash/shielded-pools)
+- [Carteiras](/using-zcash/wallets)
+- [Transações](/using-zcash/transactions)
+- [zk-SNARKs](/zcash-tech/zk-snarks)
+- [Halo](/zcash-tech/halo)
+
+## Recursos
+
+- [ZIP 310: Propriedades de Segurança das Chaves de Visualização Sapling](https://zips.z.cash/zip-0310)
+- [ZIP 316: Endereços Unificados e Chaves de Visualização Unificadas](https://zips.z.cash/zip-0316)
+- [ECC: Explicando Chaves de Visualização](https://electriccoin.co/blog/explaining-viewing-keys/)
+- [ECC: Divulgação Seletiva e Chaves de Visualização](https://electriccoin.co/blog/viewing-keys-selective-disclosure/)
+- [ECC: Apresentação em Vídeo sobre Chaves de Visualização](https://www.youtube.com/watch?v=NXjK_Ms7D5U&t=199s)


### PR DESCRIPTION
## Summary

Rewrites both Zcash Tech pages to the agreed template structure, following the same approach as PR #1628 (ZGo Payment Processor).

### Changes

**`site/Zcash_Tech/Halo.md`**
- TL;DR, Core Explanation, Deep Dive sections (No Trusted Setup, Recursive Proofs, Halo 2 & Orchard, Wider Ecosystem)
- Fixes typo: "Sean Bowes" → "Sean Bowe"
- Related Pages links FROST and Post-Quantum Security

**`site/Zcash_Tech/Viewing_Keys.md`**
- TL;DR, Core Explanation, types table (incoming / full / unified), Common Mistakes section
- Adds **Zashi** wallet instructions (missing from original page)
- Adds Unified Viewing Key type (ZIP 316) alongside Sapling types
- Upgrades CLI examples to fenced code blocks
- Updates block explorer URL to current `mainnet.zcashexplorer.app/vk`

**PT-BR versions updated** to match:
- `site/zechubglobal/zcashbrasil/zcashtech/Halo.md`
- `site/zechubglobal/zcashbrasil/zcashtech/viewingkeys.md`

Both PT-BR files include a `🇺🇸 English version` cross-link.

## Template structure

Each page now follows:
1. One-paragraph intro
2. `## TL;DR` — bullet summary
3. `## Core Explanation` — beginner-friendly prose
4. `## Deep Dive` — technical sections
5. `## Related Pages`
6. `## Resources`

Closes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)