### PR TITLE
Add ZecMap wiki page (EN + PT-BR)

### DIFF
--- a/site/Using_Zcash/zecmap.md
+++ b/site/Using_Zcash/zecmap.md
@@ -1,0 +1,153 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecMap
+
+> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/usandozec/zecmap)
+
+ZecMap is a global, community-driven directory for discovering businesses and services that accept Zcash (ZEC). Built around an interactive map interface, it helps ZEC holders answer a practical question: **"Where can I spend my ZEC?"**
+
+Website: [zecmap.com](https://zecmap.com/)
+
+---
+
+## TL;DR
+
+- ZecMap is a **free, public directory** of merchants that accept ZEC — local businesses and online shops.
+- Browse the **interactive map** to find ZEC-friendly merchants near you or anywhere in the world.
+- **Anyone can submit** a business; listings go through a community review before appearing publicly.
+- A **Contributor Rewards Program** incentivizes adding and verifying merchant data.
+- ZecMap recently partnered with [CipherPay](https://x.com/ZecMap/status/2059622324958093616) to expand merchant integrations.
+
+---
+
+## What ZecMap Does
+
+ZecMap organizes Zcash-accepting businesses on a global map. Each listing shows the business name, category, location or website, and how ZEC is accepted. This makes it easy for ZEC holders to:
+
+- Find a nearby cafe, restaurant, hotel, shop, or service that accepts ZEC before making a trip.
+- Discover online stores, VPN providers, freelancers, or digital services that support Zcash payments.
+- Browse regional Zcash adoption by city, country, or travel route.
+- Help keep the directory current as new businesses begin accepting ZEC.
+
+---
+
+## Use Cases
+
+### Finding Local Merchants
+
+Open [zecmap.com](https://zecmap.com/) and search the map for merchants near you. Before visiting, confirm with the business that ZEC is currently accepted and ask which wallet or payment flow they prefer.
+
+### Discovering Online Shops and Services
+
+ZecMap lists online businesses too. Browse by category to find e-commerce stores, hosting services, VPN providers, and other digital merchants that accept ZEC payments.
+
+### Planning Travel Around ZEC
+
+Traveling to a new city or country? ZecMap lets you browse merchant coverage before you arrive, so you can plan stops at ZEC-friendly restaurants, shops, and services.
+
+### Supporting New Zcash Users
+
+New users often learn how to buy and store ZEC before they discover where to spend it. ZecMap provides that next step — a practical, browsable list of real-world ZEC utility.
+
+---
+
+## Adding a Business
+
+If a business accepts ZEC and is not yet on ZecMap, any community member can submit it. A good submission includes:
+
+| Field | What to provide |
+|-------|----------------|
+| Business name | Official name as it appears publicly |
+| Website or contact | URL or social profile |
+| Location | Address for physical businesses; region for online |
+| Category | Cafe, restaurant, store, service, online shop, etc. |
+| Evidence | Public payments page, merchant announcement, or direct confirmation |
+| Payment notes | In-person, online, or both; transparent or shielded ZEC |
+
+Submissions should avoid private customer data. If using transaction proof, remove personal details, order numbers, and home addresses before sharing.
+
+---
+
+## Verification and Approval
+
+Listings go through a review process before appearing publicly:
+
+1. Contributor submits a business with enough public information to verify.
+2. The listing is checked for duplicates and basic accuracy.
+3. ZEC acceptance is confirmed through a public source or merchant contact.
+4. Approved listings appear on the map.
+5. Community members can flag stale or incorrect listings so the directory stays current.
+
+Because merchant payment options can change, treat listings as community-maintained information, not a guarantee. Confirm with the merchant before a trip or large purchase.
+
+---
+
+## Contributor Rewards Program
+
+ZecMap rewards contributors who help grow and maintain the directory. Rewards are designed to encourage:
+
+- **New listings** — adding businesses that accept ZEC and aren't yet on the map.
+- **Verification** — confirming that existing listings are still active and accurate.
+- **Maintenance** — updating stale information or flagging closed businesses.
+- **Coverage expansion** — adding merchants in underrepresented cities, regions, or online categories.
+
+For current reward rules and how to claim, visit [zecmap.com](https://zecmap.com/) or check the ZecMap announcements in the Zcash community channels.
+
+---
+
+## Key Features
+
+- **Interactive global map** — browse or search merchants by location.
+- **Business listings** — local and online merchants with payment details.
+- **User accounts** — submit listings, track contributions, and build a contributor profile.
+- **Community review** — listings are checked before going live.
+- **Reporting tools** — flag outdated or incorrect entries to keep the map accurate.
+
+---
+
+## Ecosystem Integrations
+
+ZecMap accepts merchants that accept Zcash payments via **Flexa**, a payment network used by a growing number of retail locations. This expands the number of real-world merchants listed on the map beyond those that accept Zcash natively.
+
+ZecMap has also announced a partnership with [CipherPay](https://cipherpay.app) to deepen payment infrastructure integrations for merchants in the directory.
+
+---
+
+## Future Development
+
+Planned improvements include:
+
+- Mobile apps for Android and iOS.
+- Multilingual support for local Zcash communities.
+- Payment integration tools and setup guides for merchants.
+- Contributor rankings and reputation features.
+- Expanded categories for online services and community-verified businesses.
+- Better tools for reporting inactive listings and confirming live ZEC acceptance.
+
+---
+
+## Tips for Using ZecMap
+
+- **Confirm before you go.** Always verify with the merchant that ZEC is currently accepted.
+- **Check the payment type.** Some businesses accept transparent ZEC, others prefer shielded. Ask before paying.
+- **Help the community.** If you find a listing that is outdated or incorrect, report it so others aren't misled.
+- **Add what you know.** If a local business accepts ZEC and isn't listed, submit it — your local knowledge is valuable.
+
+---
+
+## Related Pages
+
+- [Spend ZEC](/using-zcash/spend-zcash) — Other ways to use ZEC in the real world
+- [Payment Processors](/using-zcash/payment-processors) — Tools for merchants to accept ZEC
+- [Using ZEC Privately](/guides/using-zec-privately) — Best practices for shielded payments
+- [Wallets](/using-zcash/wallets) — Wallets compatible with ZEC merchant payments
+- [Non-Custodial Exchanges](/using-zcash/non-custodial-exchanges) — Get ZEC to spend
+
+## Resources
+
+- [ZecMap](https://zecmap.com/)
+- [ZecMap on X/Twitter](https://x.com/ZecMap)
+- [ZecMap × CipherPay partnership announcement](https://x.com/ZecMap/status/2059622324958093616)
+- [ZecMap Flexa merchant inclusion announcement](https://x.com/ZecMap/status/2060453501063594002)

--- a/site/zechubglobal/zcashbrasil/usandozec/zecmap.md
+++ b/site/zechubglobal/zcashbrasil/usandozec/zecmap.md
@@ -1,0 +1,139 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/usandozec/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
+
+# ZecMap
+
+> 🇺🇸 [English version](/using-zcash/zecmap)
+
+O ZecMap é um diretório global e comunitário para descobrir empresas e serviços que aceitam Zcash (ZEC). Construído em torno de uma interface de mapa interativo, ajuda os detentores de ZEC a responder uma pergunta prática: **"Onde posso gastar meu ZEC?"**
+
+Site: [zecmap.com](https://zecmap.com/)
+
+---
+
+## TL;DR
+
+- O ZecMap é um **diretório público e gratuito** de comerciantes que aceitam ZEC — lojas físicas e online.
+- Navegue pelo **mapa interativo** para encontrar comerciantes que aceitam ZEC perto de você ou em qualquer lugar do mundo.
+- **Qualquer pessoa pode enviar** um negócio; as listagens passam por revisão comunitária antes de aparecerem publicamente.
+- Um **Programa de Recompensas para Contribuidores** incentiva a adição e verificação de dados de comerciantes.
+- O ZecMap recentemente fez parceria com o [CipherPay](https://x.com/ZecMap/status/2059622324958093616) para expandir as integrações de comerciantes.
+
+---
+
+## O que o ZecMap Faz
+
+O ZecMap organiza empresas que aceitam Zcash em um mapa global. Cada listagem mostra o nome do negócio, categoria, localização ou site, e como o ZEC é aceito. Isso facilita para os detentores de ZEC:
+
+- Encontrar um café, restaurante, hotel, loja ou serviço próximo que aceite ZEC antes de uma visita.
+- Descobrir lojas online, provedores de VPN, freelancers ou serviços digitais que suportam pagamentos em Zcash.
+- Explorar a adoção regional do Zcash por cidade, país ou rota de viagem.
+- Ajudar a manter o diretório atualizado à medida que novos negócios começam a aceitar ZEC.
+
+---
+
+## Casos de Uso
+
+### Encontrando Comerciantes Locais
+
+Abra o [zecmap.com](https://zecmap.com/) e busque comerciantes próximos. Antes de visitar, confirme com o negócio que o ZEC ainda é aceito e pergunte qual carteira ou fluxo de pagamento preferem.
+
+### Descobrindo Lojas e Serviços Online
+
+O ZecMap também lista negócios online. Navegue por categoria para encontrar lojas de e-commerce, serviços de hospedagem, provedores de VPN e outros comerciantes digitais que aceitam pagamentos em ZEC.
+
+### Planejando Viagens em ZEC
+
+Viajando para uma nova cidade ou país? O ZecMap permite que você explore a cobertura de comerciantes antes de chegar, planejando paradas em restaurantes, lojas e serviços que aceitam ZEC.
+
+### Apoiando Novos Usuários de Zcash
+
+Novos usuários geralmente aprendem a comprar e guardar ZEC antes de descobrir onde gastá-lo. O ZecMap fornece esse próximo passo — uma lista prática e navegável de utilidade real do ZEC.
+
+---
+
+## Adicionando um Negócio
+
+Se um negócio aceita ZEC e ainda não está no ZecMap, qualquer membro da comunidade pode enviá-lo. Um bom envio inclui:
+
+| Campo | O que fornecer |
+|-------|----------------|
+| Nome do negócio | Nome oficial como aparece publicamente |
+| Site ou contato | URL ou perfil social |
+| Localização | Endereço para negócios físicos; região para online |
+| Categoria | Café, restaurante, loja, serviço, loja online, etc. |
+| Evidência | Página pública de pagamentos, anúncio do comerciante ou confirmação direta |
+| Notas de pagamento | Presencial, online ou ambos; ZEC transparente ou blindado |
+
+Os envios devem evitar dados privados de clientes. Se usar prova de transação, remova dados pessoais, números de pedido e endereços residenciais antes de compartilhar.
+
+---
+
+## Verificação e Aprovação
+
+As listagens passam por um processo de revisão antes de aparecerem publicamente:
+
+1. O contribuidor envia um negócio com informações públicas suficientes para verificar.
+2. A listagem é verificada quanto a duplicatas e precisão básica.
+3. A aceitação de ZEC é confirmada por meio de uma fonte pública ou contato com o comerciante.
+4. Listagens aprovadas aparecem no mapa.
+5. Membros da comunidade podem sinalizar listagens desatualizadas ou incorretas.
+
+Trate as listagens como informações mantidas pela comunidade, não como garantia. Confirme com o comerciante antes de uma viagem ou compra importante.
+
+---
+
+## Programa de Recompensas para Contribuidores
+
+O ZecMap recompensa contribuidores que ajudam a crescer e manter o diretório. As recompensas incentivam:
+
+- **Novas listagens** — adicionar negócios que aceitam ZEC e ainda não estão no mapa.
+- **Verificação** — confirmar que listagens existentes ainda estão ativas e precisas.
+- **Manutenção** — atualizar informações desatualizadas ou sinalizar negócios fechados.
+- **Expansão de cobertura** — adicionar comerciantes em cidades, regiões ou categorias online sub-representadas.
+
+Para as regras atuais de recompensa, visite [zecmap.com](https://zecmap.com/) ou verifique os anúncios do ZecMap nos canais da comunidade Zcash.
+
+---
+
+## Recursos Principais
+
+- **Mapa global interativo** — navegue ou busque comerciantes por localização.
+- **Listagens de negócios** — comerciantes locais e online com detalhes de pagamento.
+- **Contas de usuário** — envie listagens, acompanhe contribuições e crie um perfil.
+- **Revisão comunitária** — listagens são verificadas antes de irem ao ar.
+- **Ferramentas de denúncia** — sinalize entradas desatualizadas para manter o mapa preciso.
+
+---
+
+## Integrações do Ecossistema
+
+O ZecMap aceita comerciantes que recebem pagamentos Zcash via **Flexa**, uma rede de pagamentos usada por um número crescente de locais de varejo. Isso expande o número de comerciantes do mundo real listados no mapa além daqueles que aceitam Zcash nativamente.
+
+O ZecMap também anunciou uma parceria com o [CipherPay](https://cipherpay.app) para aprofundar as integrações de infraestrutura de pagamento para comerciantes no diretório.
+
+---
+
+## Dicas para Usar o ZecMap
+
+- **Confirme antes de ir.** Sempre verifique com o comerciante que o ZEC ainda é aceito.
+- **Verifique o tipo de pagamento.** Alguns negócios aceitam ZEC transparente, outros preferem blindado. Pergunte antes de pagar.
+- **Ajude a comunidade.** Se encontrar uma listagem desatualizada ou incorreta, sinalize-a.
+- **Adicione o que você sabe.** Se um negócio local aceita ZEC e não está listado, envie-o.
+
+---
+
+## Páginas Relacionadas
+
+- [Gastar ZEC](/using-zcash/spend-zcash)
+- [Processadores de Pagamento](/using-zcash/payment-processors)
+- [Usando ZEC com Privacidade](/guides/using-zec-privately)
+- [Carteiras](/using-zcash/wallets)
+
+## Recursos
+
+- [ZecMap](https://zecmap.com/)
+- [ZecMap no X/Twitter](https://x.com/ZecMap)
+- [Parceria ZecMap × CipherPay](https://x.com/ZecMap/status/2059622324958093616)
+- [Inclusão de comerciantes Flexa no ZecMap](https://x.com/ZecMap/status/2060453501063594002)


### PR DESCRIPTION
## Summary

Adds `site/Using_Zcash/zecmap.md` covering all topics required by #1653:

- What ZecMap is and how the map interface works
- Use cases: local merchants, online shops, travel planning, onboarding new users
- Submission table showing exactly what to include when adding a business
- Verification and approval process (5-step flow)
- Contributor Rewards Program
- Key features overview
- Ecosystem integrations: Flexa merchant inclusion + CipherPay partnership (current news)
- Future development plans
- Tips for using the map safely

Also adds PT-BR version: `site/zechubglobal/zcashbrasil/usandozec/zecmap.md`

Both files cross-link to each other (`🇧🇷 Versão em Português` / `🇺🇸 English version`).

Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)