### PR TITLE
Add ZecHub beginner roadmap

### DIFF
--- a/site/guides/Beginner_Roadmap.md
+++ b/site/guides/Beginner_Roadmap.md
@@ -1,0 +1,147 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Beginner_Roadmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecHub Beginner Roadmap
+
+This page is a visual starting map for new ZecHub readers. It sorts the wiki by experience level so a beginner can move from basic Zcash concepts to practical wallet use, privacy habits, and finally developer or infrastructure topics.
+
+---
+
+## Visual Map
+
+```text
+START
+  |
+  v
+LEVEL 1: NEW TO ZCASH
+  What is ZEC and Zcash? -> What is ZecHub? -> New User Guide
+  Glossary and FAQs      -> My First Zcash Workbook
+  |
+  v
+LEVEL 2: READY TO USE ZEC
+  Wallets -> Shielded Pools -> Transactions -> Memos
+  Custodial Exchanges -> Non-Custodial Exchanges -> Spending ZEC
+  Privacy Tools -> Tor/I2P -> VPN/dVPN -> Secure Messengers
+  |
+  v
+LEVEL 3: BUILDER OR POWER USER
+  zk-SNARKs -> Halo -> FROST -> Viewing Keys
+  Zebra Full Node -> Raspberry Pi Full Node -> Hardened Zebrad
+  Developer Resources -> ZIPs -> Zcash Devtool
+  |
+  v
+ECOSYSTEM CONTEXT
+  Organizations -> Community -> Global Ambassadors -> Development Fund
+```
+
+---
+
+## Level 1: New To Zcash
+
+Goal: understand Zcash, learn how this wiki is organized, and make a first wallet decision.
+
+| Step | Page | Why it matters |
+|---|---|---|
+| 1 | [What is ZEC and Zcash?](/start-here/what-is-zec-and-zcash) | Explains ZEC as digital cash and introduces Zcash privacy. |
+| 2 | [What is ZecHub?](/start-here/what-is-zechub) | Shows what ZecHub is and how the community maintains the wiki. |
+| 3 | [New User Guide](/start-here/new-user-guide) | Helps a new user buy ZEC, choose a wallet, and start safely. |
+| 4 | [Glossary and FAQs](/glossary-and-faqs/faq) | Defines common terms such as shielded, transparent, memo, and viewing key. |
+| 5 | [My First Zcash Workbook](/guides/my-first-zcash-workbook) | Gives beginners a hands-on learning path. |
+
+After this level, a reader should know the difference between transparent and shielded Zcash usage and where to find beginner help.
+
+---
+
+## Level 2: Ready To Use ZEC
+
+Goal: use ZEC in practical situations while keeping privacy and security in mind.
+
+### Wallets And Transactions
+
+| Page | Why it matters |
+|---|---|
+| [Wallets](/using-zcash/wallets) | Compares wallet options and helps users choose a safe starting point. |
+| [Shielded Pools](/using-zcash/shielded-pools) | Explains Sapling and Orchard pools and why shielded pools matter. |
+| [Transactions](/using-zcash/transactions) | Covers fees, confirmations, and transaction basics. |
+| [Memos](/using-zcash/memos) | Shows how encrypted memo fields work. |
+| [Using ZEC Privately](/guides/using-zec-privately) | Turns privacy concepts into an everyday workflow. |
+
+### Exchanges And Spending
+
+| Page | Why it matters |
+|---|---|
+| [Custodial Exchanges](/using-zcash/custodial-exchanges) | Lists centralized exchanges and their ZEC support details. |
+| [Non-Custodial Exchanges](/using-zcash/non-custodial-exchanges) | Introduces swap options that do not require custodying funds with an exchange. |
+| [Buying ZEC](/using-zcash/buying-zec) | Gives direct paths for getting ZEC. |
+| [Top 10 Places to Spend ZEC](/using-zcash/spend-zcash/top-10-places-to-spend-zec) | Shows real places where ZEC can be used. |
+| [Payment Request URIs](/using-zcash/payment-request-uris) | Explains structured Zcash payment requests. |
+
+### Privacy Habits
+
+| Page | Why it matters |
+|---|---|
+| [Tor and I2P](/privacy-tools/tor-and-i2p) | Helps users protect network metadata. |
+| [VPN and dVPN](/privacy-tools/vpn-and-dvpn) | Explains when a VPN can complement Zcash usage. |
+| [Secure Messengers](/privacy-tools/secure-messengers) | Covers communication tools that pair well with private payments. |
+| [GrapheneOS](/privacy-tools/grapheneos) | Introduces a privacy-focused mobile operating system. |
+
+After this level, a reader should be able to hold, send, receive, and spend ZEC with better privacy practices.
+
+---
+
+## Level 3: Builder Or Power User
+
+Goal: understand Zcash technology more deeply and start operating infrastructure or building tools.
+
+### Zcash Technology
+
+| Page | Why it matters |
+|---|---|
+| [zk-SNARKs](/zcash-tech/zk-snarks) | Explains the zero-knowledge proofs behind shielded transactions. |
+| [Halo](/zcash-tech/halo) | Introduces the proving system used by Zcash. |
+| [FROST](/zcash-tech/frost) | Covers threshold signatures and shared custody concepts. |
+| [Viewing Keys](/zcash-tech/viewing-keys) | Shows how selective disclosure works. |
+| [Zero-Knowledge vs Decoys](/guides/zero-knowledge-vs-decoys) | Compares Zcash privacy with decoy-based privacy systems. |
+
+### Nodes And Infrastructure
+
+| Page | Why it matters |
+|---|---|
+| [Raspberry Pi 4 Full Node](/guides/raspberry-pi-4-full-node) | Gives a practical node setup path for low-cost hardware. |
+| [Raspberry Pi 5 Zebra, Lightwalletd, Zingo](/guides/raspberry-pi5-zebra-lightwalletd-zingo) | Shows a newer local infrastructure setup. |
+| [Hardened Zebrad](/guides/hardened-zebrad) | Helps operators harden a Zebra node. |
+| [Migration Guide: zcashd to zebrad and zallet](/guides/migration-guide-zcashd-to-zebrad-zallet) | Helps users move from older tooling to current infrastructure. |
+| [Visualizing the Zcash Network](/guides/visualizing-the-zcash-network) | Provides a network-level view of Zcash. |
+
+### Development
+
+| Page | Why it matters |
+|---|---|
+| [Developer Resources](/start-here/developer-resources) | Collects SDKs, docs, and builder entry points. |
+| [Zcash Improvement Proposals](/guides/zcash-improvement-proposals) | Explains how protocol changes are proposed and tracked. |
+| [Zcash Devtool](/guides/zcash-devtool) | Introduces command-line development tooling. |
+| [Zingolib and Zaino Tutorial](/guides/zingolib-and-zaino-tutorial) | Helps developers work with Zcash wallet infrastructure. |
+| [BTCPay Server Zcash Plugin](/guides/btcpayserver-zcash-plugin) | Shows payment processor integration for merchants. |
+
+After this level, a reader should know where to start building, running infrastructure, or researching the protocol.
+
+---
+
+## Ecosystem Context
+
+These pages help readers understand the people, organizations, and funding structures around Zcash.
+
+| Page | Why it matters |
+|---|---|
+| [Zcash Organizations](/zcash-community/zcash-organizations) | Explains organizations that support the ecosystem. |
+| [Zcash Community](/zcash-community) | Points to community spaces and participation paths. |
+| [ZecHub Global](/zechubglobal) | Introduces regional ZecHub communities. |
+| [Development Fund](/start-here/development-fund) | Explains ecosystem funding. |
+| [Network Upgrades](/start-here/network-upgrades) | Gives historical context for protocol upgrades. |
+
+---
+
+## How Contributors Can Use This Map
+
+Use this roadmap to spot gaps in beginner coverage. If a linked topic is missing, outdated, or too advanced for its level, open a GitHub issue and suggest an update. As new pages are added to ZecHub, this map should be updated so beginners always have a clear path through the wiki.

--- a/site/guides/Beginner_Roadmap.md
+++ b/site/guides/Beginner_Roadmap.md
@@ -32,7 +32,7 @@ LEVEL 3: BUILDER OR POWER USER
   |
   v
 ECOSYSTEM CONTEXT
-  Organizations -> Community -> Global Ambassadors -> Development Fund
+  Zcash Foundation -> Community -> Global Ambassadors -> Development Fund
 ```
 
 ---
@@ -134,7 +134,7 @@ These pages help readers understand the people, organizations, and funding struc
 
 | Page | Why it matters |
 |---|---|
-| [Zcash Organizations](/zcash-community/zcash-organizations) | Explains organizations that support the ecosystem. |
+| [Zcash Foundation](/zcash-organizations/zcash-foundation) | Introduces one of the core organizations supporting the ecosystem. |
 | [Zcash Community](/zcash-community) | Points to community spaces and participation paths. |
 | [ZecHub Global](/zechubglobal) | Introduces regional ZecHub communities. |
 | [Development Fund](/start-here/development-fund) | Explains ecosystem funding. |


### PR DESCRIPTION
/claim #1712

Summary:
- Add a ZecHub Beginner Roadmap page sorted by experience level.
- Include a visual ASCII map from beginner topics to wallet/privacy use and developer topics.
- Link each level to existing ZecHub pages so new readers have a guided path through the wiki.

Verification:
- Compared branch against `main`; diff is scoped to `site/guides/Beginner_Roadmap.md` only.
- Checked internal links in the new roadmap against existing `site/` markdown paths.

Closes #1712