### PR TITLE
Connect Zcash real-world playbook journey

### DIFF
--- a/site/Zcash_Use_Cases/About.md
+++ b/site/Zcash_Use_Cases/About.md
@@ -1,50 +1,70 @@
+---
+slug: /zcash-use-case
+title: Use Zcash in the Real World
+---
+
 # Use Zcash in the Real World
 
-Zcash is not just about privacy in theory — it's about **practical, everyday financial freedom**.
+Zcash privacy is most useful when it becomes a practical workflow. This section turns the wiki's privacy concepts into a single linear journey: start with receiving donations, learn how to send without linking identity, then apply those habits to professional, merchant, treasury, and journalist scenarios.
 
-This section shows you **exactly how to use Zcash in real-life scenarios**, with step-by-step guides and best practices.
+Each playbook includes a concrete use case, setup guidance, common mistakes, and a next step so readers can move from beginner to advanced without guessing where to go next.
 
-## What You'll Learn
+---
 
-- How to protect your financial privacy
-- How to avoid common mistakes that expose your data
-- How to apply Zcash in real-world situations
+## The Linear Journey
 
-## How to Use These Guides
+| Step | Level | Playbook | Outcome |
+|---|---|---|---|
+| 1 | Beginner | [Receive Donations Privately](/zcash-use-cases/receive-donations-privately) | Publish a shielded receiving workflow without exposing donor or balance history. |
+| 2 | Beginner | [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity) | Send ZEC while reducing address, identity, and timing linkability. |
+| 3 | Intermediate | [Freelancer Privacy Setup](/zcash-use-cases/freelance-privacy-setup) | Receive client payments privately and track invoices without public income leakage. |
+| 4 | Intermediate | [Accept Payments as a Merchant](/zcash-use-cases/accept-payments-as-a-merchant) | Accept customer payments while protecting customer and revenue data. |
+| 5 | Advanced | [Run a Private Community Treasury](/zcash-use-cases/private-community-treasury) | Coordinate shared funds with shielded payments and internal accountability. |
+| 6 | Advanced | [Journalist Privacy Setup](/zcash-use-cases/journalist-privacy-setup) | Protect sensitive payment flows for journalists, sources, and high-risk work. |
 
-Each playbook is:
-- Short (5-7 minutes)
-- Step-by-step
-- Focused on real-world 
+Follow the playbooks in order. Each one builds on the previous step and ends with a next-step link.
 
+---
 
-If you're new, start here: [What is Zcash](/start-here/what-is-zec-and-zcash)
+## What You Need Before Starting
 
+- A Zcash wallet that supports shielded addresses.
+- A basic understanding of [shielded pools](/using-zcash/shielded-pools).
+- A plan for separating public, personal, work, and high-risk identities.
+- A habit of writing down operational steps before receiving or sending funds.
 
-##  Recommended Path
+If you are completely new, read [What is ZEC and Zcash?](/start-here/what-is-zec-and-zcash) and the [New User Guide](/start-here/new-user-guide) first.
 
-Follow this step-by-step journey to master real-world Zcash usage:
+---
 
-###  [Receive Donations Privately](/zcash-use-cases/receive-donations-privately)
-Learn how to accept funds without exposing your identity or financial history.
+## How To Use The Playbooks
 
+1. Start with the first playbook even if your final use case is more advanced.
+2. Complete the checklist at the end of each page before moving forward.
+3. Keep shielded funds shielded whenever possible.
+4. Treat transparent exchange deposits and withdrawals as identity-linked.
+5. Use memos for lightweight payment context, not for sensitive secrets.
+6. Revisit the journey when your wallet, role, or threat model changes.
 
-###  [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity) 
-Avoid exposing your wallet, identity, or transaction graph when sending funds.
+---
 
+## Completion Checklist
 
-###  [Freelancer Privacy Setup](/zcash-use-cases/freelancer-privacy-setup)  
-Get paid in Zcash while keeping your clients and income private.
+By the end of the journey, you should be able to:
 
+- receive ZEC to a shielded address
+- send ZEC without linking unrelated identities
+- separate client, merchant, community, and high-risk payment contexts
+- choose when to use memos and when to keep notes off-chain
+- avoid obvious timing and amount-correlation mistakes
+- explain when transparent transactions are unavoidable and how to reduce follow-on leakage
 
-###  [Accept Payments as a Merchant](/zcash-use-cases/accept-payment-as-a-merchant)  
-Accept payments using a shielded address and avoid exposing customer transaction data
+---
 
+## Related Pages
 
-###  [Run a Private Community Treasury](/zcash-use-cases/run-a-private-community-treasury)
-Use shielded addresses to hold shared funds and limit visibility of balances and transactions
-
-###  [Journalist Privacy Setup](/zcash-use-cases/journalist-privacy-setup)   
-Use shielded addresses for all transactions and protect sources by avoiding traceable payments. Use memos carefully for secure communication
-
-<br/>
+- [Wallets](/using-zcash/wallets)
+- [Shielded Pools](/using-zcash/shielded-pools)
+- [Transactions](/using-zcash/transactions)
+- [Memos](/using-zcash/memos)
+- [Using ZEC Privately](/guides/using-zec-privately)

--- a/site/Zcash_Use_Cases/Accept_Payments_AS_A_Merchant.md
+++ b/site/Zcash_Use_Cases/Accept_Payments_AS_A_Merchant.md
@@ -120,8 +120,8 @@ You can:
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
 
-- [Wallets](/wallets)
-- [Privacy - Best Practices](/privacy/best-practices)
+- [Wallets](/using-zcash/wallets)
+- [Using ZEC Privately](/guides/using-zec-privately)
 
 <br/>
 
@@ -135,5 +135,5 @@ You can now run private payment flows for business.
 
 ## Next Step
 
-- [Run a Private Community Treasury](/use-cases/private-community-treasury)
+- [Run a Private Community Treasury](/zcash-use-cases/private-community-treasury)
 <br/>

--- a/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md
+++ b/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md
@@ -110,7 +110,7 @@ You can:
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
-- [Wallets](/wallets)
+- [Wallets](/using-zcash/wallets)
 
 <br/>
 
@@ -124,5 +124,5 @@ You now understand how to receive income privately.
 
 ## Next Step
 
-- [Accept Payments as a Merchant](/use-cases/accept-payments-as-a-merchant)
+- [Accept Payments as a Merchant](/zcash-use-cases/accept-payments-as-a-merchant)
 <br/>

--- a/site/Zcash_Use_Cases/Journalist_privacy_setup.md
+++ b/site/Zcash_Use_Cases/Journalist_privacy_setup.md
@@ -113,8 +113,8 @@ You can:
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
-- [Privacy - Best practices](/privacy/best-practices)
-- [Send money without linking identity](/use-cases/send-money-without-linking-identity)
+- [Using ZEC Privately](/guides/using-zec-privately)
+- [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity)
 
  <br/>
 
@@ -134,7 +134,7 @@ You now understand:
 ## What Next?
 
 - [Go to home page](/)
-- [Explore developer paths](/developers)
-- [Contribute to ZecHub](/contribute/help-build-zechub)
+- [Explore developer resources](/start-here/developer-resources)
+- [Learn what ZecHub is](/start-here/what-is-zechub)
 
 <br/> 

--- a/site/Zcash_Use_Cases/Private_Community_treasury.md
+++ b/site/Zcash_Use_Cases/Private_Community_treasury.md
@@ -121,8 +121,8 @@ Your community can:
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
-- [Privacy - Best practices](/privacy/best-practices)
-- [Send money without linking identity](/use-cases/send-money-without-linking-identity)
+- [Using ZEC Privately](/guides/using-zec-privately)
+- [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity)
  
 
 <br/>
@@ -137,4 +137,4 @@ You understand how to manage shared funds privately.
 
 ## Next Step
 
-- [Journalist Privacy Setup](/use-cases/journalist-privacy-setup)
+- [Journalist Privacy Setup](/zcash-use-cases/journalist-privacy-setup)

--- a/site/Zcash_Use_Cases/Receive_Donations_Privately.md
+++ b/site/Zcash_Use_Cases/Receive_Donations_Privately.md
@@ -106,8 +106,8 @@ You can:
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
-- [Privacy - Shielded vs Transparent](/privacy/shielded-vs-transparent)
-- [Wallets](/wallets)
+- [Shielded Pools](/using-zcash/shielded-pools)
+- [Wallets](/using-zcash/wallets)
 
 <br/>
 

--- a/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md
+++ b/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md
@@ -96,7 +96,7 @@ You can:
 <br/>
 
 ## <img src="https://raw.githubusercontent.com/amochuko/zechub/82d2046091b73a626d818571a978fcaffdc7ebf4/assets/icons/chain-for-links-svgrepo-com.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
-- [Privacy - Shielded vs Transparent](/privacy/shielded-vs-transparent)
+- [Using ZEC Privately](/guides/using-zec-privately)
 
 <br/>
 
@@ -110,4 +110,4 @@ You can now send funds privately without exposing identity.
 
 ## Next Step
 
-- [Freelancer Privacy Setup](/use-cases/freelancer-privacy-setup)
+- [Freelancer Privacy Setup](/zcash-use-cases/freelance-privacy-setup)


### PR DESCRIPTION
/claim #1555

Summary:
- Add the `/zcash-use-case` slug and a linear journey overview to `site/Zcash_Use_Cases/About.md`.
- Connect the six real-world Zcash playbooks into a beginner-to-advanced path.
- Fix broken next-step and related links across the existing playbook pages.

Verification:
- Compared branch against `main`; diff is scoped to the real-world playbook pages.
- Checked internal links across the updated playbook files against existing `site/` markdown paths.

Closes #1555