### PR TITLE
Add Zcash gaming privacy use case page

### DIFF
--- a/site/Zcash_Use_Cases/About.md
+++ b/site/Zcash_Use_Cases/About.md
@@ -1,6 +1,6 @@
 # Use Zcash in the Real World
 
-Zcash is not just about privacy in theory — it's about **practical, everyday financial freedom**.
+Zcash is not just about privacy in theory - it's about **practical, everyday financial freedom**.
 
 This section shows you **exactly how to use Zcash in real-life scenarios**, with step-by-step guides and best practices.
 
@@ -33,18 +33,20 @@ Learn how to accept funds without exposing your identity or financial history.
 Avoid exposing your wallet, identity, or transaction graph when sending funds.
 
 
-###  [Freelancer Privacy Setup](/zcash-use-cases/freelancer-privacy-setup)  
+###  [Freelancer Privacy Setup](/zcash-use-cases/freelance-privacy-setup)  
 Get paid in Zcash while keeping your clients and income private.
 
 
-###  [Accept Payments as a Merchant](/zcash-use-cases/accept-payment-as-a-merchant)  
+###  [Accept Payments as a Merchant](/zcash-use-cases/accept-payments-as-a-merchant)  
 Accept payments using a shielded address and avoid exposing customer transaction data
 
 
-###  [Run a Private Community Treasury](/zcash-use-cases/run-a-private-community-treasury)
+###  [Run a Private Community Treasury](/zcash-use-cases/private-community-treasury)
 Use shielded addresses to hold shared funds and limit visibility of balances and transactions
 
 ###  [Journalist Privacy Setup](/zcash-use-cases/journalist-privacy-setup)   
 Use shielded addresses for all transactions and protect sources by avoiding traceable payments. Use memos carefully for secure communication
 
-<br/>
+
+### [Privacy in Play: Zcash in the Global Gaming Ecosystem](/zcash-use-cases/privacy-in-play-zcash-gaming)
+Apply Zcash privacy patterns to in-game purchases, creator tips, tournament payouts, guild treasuries, marketplaces, and studio settlement.<br/>

--- a/site/Zcash_Use_Cases/Privacy_in_Play_Zcash_Gaming.md
+++ b/site/Zcash_Use_Cases/Privacy_in_Play_Zcash_Gaming.md
@@ -1,0 +1,203 @@
+---
+slug: /zcash-use-cases/privacy-in-play-zcash-gaming
+title: Privacy in Play: Zcash in the Global Gaming Ecosystem
+---
+
+# Privacy in Play: Zcash (ZEC) in the Global Gaming Ecosystem
+
+<span className="inline-flex items-center gap-[6px]">
+  <span className="inline-block w-[12px] h-[12px] bg-purple-500 rounded-full"></span>
+  Intermediate - 10 min
+</span>
+
+## TL;DR
+
+Games create frequent small payments: skins, passes, tips, guild dues, tournament prizes, marketplace sales, and creator rewards. On transparent chains, those payments can expose a player's balance, habits, teammates, winnings, and social graph.
+
+Zcash can help gaming communities use digital money without publishing every payment relationship. The practical pattern is simple: use shielded ZEC for settlement, keep gameplay identity separate from payment identity, and reveal payment details only to the parties that need them.
+
+## Who is this for?
+
+- Players who do not want purchases, tips, or winnings tied to a public wallet history
+- Streamers and creators who receive community support
+- Esports teams, tournament organizers, and guild treasurers
+- Indie game studios exploring private digital payments
+- Developers designing wallet, checkout, or payout flows around ZEC
+
+## Why gaming payments leak more than players expect
+
+Gaming payments are often small, social, and repeated. That makes metadata especially revealing.
+
+| Gaming activity | What transparent payments can reveal | Privacy-preserving Zcash pattern |
+| --- | --- | --- |
+| Buying in-game items | Spending frequency, balances, favorite games, and account value | Pay from a shielded wallet and avoid reusing a public address as the account identifier |
+| Tipping a streamer | Which fans support which creators, when, and how much | Receive tips to a shielded address and reconcile orders off-chain |
+| Tournament prizes | Player winnings, team finances, and prize distribution | Pay winners with shielded sends and keep private payout records |
+| Guild or clan treasury | Treasury balance, contributor identities, and spending cadence | Hold shared funds in a shielded workflow with documented approvals |
+| Player-to-player trade | Trading relationships, inventory value, and timing | Separate marketplace identity from wallet identity and settle with shielded ZEC |
+
+## What Zcash adds
+
+Zcash supports both transparent and shielded activity. For gaming privacy, the important workflows are shielded.
+
+- **Shielded payments** reduce public exposure of sender, receiver, amount, and encrypted memo data when both sides use shielded-compatible wallets.
+- **Unified addresses** make it easier for users to receive ZEC while supporting modern wallet behavior such as shielded-by-default flows where available.
+- **Encrypted memos** can carry short private payment references, such as an order code or tournament round, when the receiving wallet supports memos.
+- **Selective disclosure** lets a user keep public-chain observers out while still keeping records for refunds, accounting, tournament disputes, or compliance needs.
+
+This does not make the whole game private by itself. Game accounts, IP addresses, device fingerprints, chat logs, marketplace listings, KYC providers, and analytics can still identify users. Zcash protects the payment layer; the surrounding product still needs privacy-aware design.
+
+## Practical gaming use cases
+
+### 1. Private in-game purchases
+
+A player wants to buy a cosmetic item, battle pass, server slot, or downloadable expansion without linking that purchase to a public wallet history.
+
+A better flow:
+
+1. The game checkout displays a ZEC payment request or shielded receiving address.
+2. The player pays from a shielded wallet.
+3. The game confirms the invoice off-chain and grants the item.
+4. The order system stores an internal receipt ID instead of using a public wallet address as the player's identity.
+
+Design note: do not force wallet reuse as a login method. If the same public address becomes the player account, every payment can become an identity signal.
+
+### 2. Creator tips and streamer support
+
+Streamers, modders, artists, server operators, and guide writers often receive small donations. Transparent tips can expose fan behavior and creator income.
+
+A Zcash-friendly setup:
+
+- Publish a shielded-capable receiving address or payment request.
+- Keep public tip leaderboards opt-in instead of automatic.
+- Use private receipt notes for fulfillment, shout-outs, or reward tiers.
+- Separate creator accounting records from public social handles.
+
+For related creator workflows, see [Creators and Tips](/using-zcash/creators-and-tips) and [Receive Donations Privately](/zcash-use-cases/receive-donations-privately).
+
+### 3. Tournament and esports payouts
+
+Tournament payments can expose who won, how much they earned, and which team or region they are linked to. Even when winners are public, exact payment metadata may not need to be.
+
+A privacy-aware payout flow:
+
+1. Collect payout addresses through a private channel.
+2. Verify the winner identity off-chain.
+3. Send prize payments from a shielded wallet.
+4. Keep a private payout ledger for disputes, tax records, or sponsor reporting.
+5. Publish only the tournament result information that participants agreed to make public.
+
+This is useful for grassroots tournaments, privacy-focused events, and communities where participants may not want every payment mapped to a long-term public address.
+
+### 4. Guild, clan, or DAO treasuries
+
+Some gaming communities pool money for servers, prize pools, shared content, travel, or event costs. A public treasury can be useful for transparency, but it can also expose contributors and spending patterns.
+
+Zcash gives communities another option: keep payment details private while maintaining internal accountability.
+
+Recommended controls:
+
+- Define who can approve payments.
+- Record why each payout happened.
+- Keep private receipts and screenshots in a shared evidence folder.
+- Separate public budget summaries from private transaction details.
+- Rotate operational addresses when roles or devices change.
+
+For a more detailed treasury workflow, see [Run a Private Community Treasury](/zcash-use-cases/private-community-treasury).
+
+### 5. Player-to-player marketplaces
+
+Game marketplaces can reveal rare-item ownership, high-value traders, and trading relationships. A marketplace does not need to publish every buyer-seller payment trail to settle value.
+
+A safer marketplace design:
+
+- Use internal order IDs, not wallet addresses, as marketplace identities.
+- Let buyers pay with shielded ZEC.
+- Let sellers withdraw to shielded-compatible wallets.
+- Show only marketplace reputation data that users expect to be public.
+- Avoid embedding payment addresses into public item listings.
+
+### 6. Game studio settlement and regional payments
+
+Indie studios, server hosts, and community operators may need to pay contractors, moderators, translators, tournament staff, or regional partners. Transparent payments can leak payroll cadence and business relationships.
+
+A studio can use ZEC for private settlement while keeping normal invoices and accounting records off-chain. The key is to treat Zcash as the payment rail, not as the whole compliance system.
+
+## Player checklist
+
+Before using ZEC in a game or community:
+
+- Choose a wallet that supports shielded ZEC. Start with [Wallets](/using-zcash/wallets).
+- Understand the difference between shielded and transparent activity in [Shielded Pools](/using-zcash/shielded-pools).
+- Avoid reusing a public wallet address as your gamer tag, Discord handle, or marketplace username.
+- Keep a private note of what each payment was for.
+- Be careful with memos: include only the minimum reference needed for the receiver.
+- If you move funds through an exchange, remember that exchange account records are not private.
+
+## Developer checklist
+
+If you are adding ZEC payments to a game, marketplace, or creator platform:
+
+- Support shielded-compatible receiving flows wherever possible.
+- Use order IDs and account IDs internally instead of public wallet addresses.
+- Do not make payment addresses permanent public profile fields.
+- Give users clear copy about what is private and what is not.
+- Store only the payment metadata you actually need.
+- Add a refund path that does not require users to expose unrelated wallet history.
+- Document how support staff can verify a payment without asking users to dox their full wallet.
+- Review [Payment Request URIs](/using-zcash/payment-request-uris), [Payment Processors](/using-zcash/payment-processors), and [Developer Resources](/start-here/developer-resources).
+
+## Privacy pitfalls to avoid
+
+- **Transparent address reuse:** one reused address can connect many purchases or payouts.
+- **Exact amount correlation:** shielding or deshielding the exact same amount around a payment can leak timing clues.
+- **Public receipts:** screenshots, leaderboards, and social posts can undo payment privacy.
+- **Custodial shortcuts:** if a platform holds all user funds, the platform can see internal balances and transfers.
+- **Overloaded memos:** memos are useful, but they should not contain sensitive personal data.
+- **Single-identity wallets:** a wallet used for gaming, salary, trading, and social donations can link contexts even when individual sends are shielded.
+
+## Example architecture
+
+A privacy-aware gaming checkout can look like this:
+
+1. The game creates an internal order for an item, event entry, or creator tip.
+2. The checkout displays a ZEC payment request with an order reference.
+3. The player pays from a shielded wallet.
+4. The backend watches for payment confirmation.
+5. The game grants the item or marks the invoice paid.
+6. Support staff can verify the order without seeing the player's unrelated wallet history.
+7. The user keeps their own receipt, transaction note, or viewing information for future proof.
+
+This keeps the gameplay experience familiar while reducing unnecessary public payment metadata.
+
+## Where Zcash is not enough
+
+Zcash does not hide everything about a gaming experience. Teams still need to think about:
+
+- Account registration and login privacy
+- IP address and device telemetry
+- Anti-cheat data collection
+- Chat, voice, and social graph metadata
+- Platform KYC or payment processor rules
+- Marketplace moderation and fraud handling
+- Regional tax, prize, and reporting obligations
+
+For strong privacy, combine shielded payments with good product design, minimal data collection, clear consent, and private-by-default community norms.
+
+## Future direction: private game assets
+
+Today, this page focuses on using ZEC as a private payment and settlement asset. Longer term, designs such as [Zcash Shielded Assets](/zcash-tech/zcash-shielded-assets) point toward a world where other assets could inherit similar privacy properties. If game assets, credits, or collectibles ever use shielded asset designs, the same lesson applies: privacy is strongest when the product does not leak identity through surrounding metadata.
+
+## Next steps
+
+- New to Zcash? Start with [What is ZEC and Zcash](/start-here/what-is-zec-and-zcash).
+- Need a wallet? Read [Wallets](/using-zcash/wallets).
+- Want a private payment workflow? Read [Using ZEC Privately](/guides/using-zec-privately).
+- Accepting payments as a studio or shop? Read [Accept Payments as a Merchant](/zcash-use-cases/accept-payments-as-a-merchant).
+- Sending money without linking identity? Read [Send Money Without Linking Identity](/zcash-use-cases/send-money-without-linking-identity).
+
+## References
+
+- [Is Zcash traceable?](https://z.cash/learn/is-zcash-traceable/)
+- [What are Zcash unified addresses?](https://z.cash/learn/what-are-zcash-unified-addresses/)
+- [Sending Memos with zcash-cli](https://zcash.readthedocs.io/en/latest/rtd_pages/memos.html)


### PR DESCRIPTION
/claim #1557

Summary:
- Add a new Zcash use-case wiki page for private gaming payments and settlement.
- Cover player purchases, creator tips, tournament payouts, guild treasuries, player marketplaces, and studio settlement.
- Link the page from the Zcash use-cases index and include references to Zcash privacy, unified addresses, and memos.

Verification:
- Checked internal links in the new page and updated index against current `site/` markdown routes.
- Kept the PR scoped to `site/Zcash_Use_Cases/`.

Closes #1557