### PR TITLE
Add section: what a block explorer can and cannot see on Zcash

### DIFF
--- a/site/guides/Blockchain_Explorers.md
+++ b/site/guides/Blockchain_Explorers.md
@@ -46,6 +46,28 @@ Similar to addresses above, any transaction on a public blockchain has the amoun
 ![amounts](https://user-images.githubusercontent.com/81990132/206312357-e9504151-830f-4fa1-81cb-f23619fd7226.png)
 
 
+### What an explorer can and cannot see on Zcash
+
+#### TL;DR
+- Transparent (`t`) addresses are fully visible on an explorer, just like Bitcoin
+- Fully shielded (z to z) transactions hide the amount, the addresses, and the memo
+- The fee is still visible, even on a fully shielded transaction
+- Shielding (moving `t` to shielded) and deshielding (shielded back to `t`) are partly visible, because one side is transparent
+- Privacy holds only while funds stay inside the shielded pools
+
+Zcash has more than one kind of address, and an explorer treats them very differently.
+
+Transparent addresses, starting with `t`, work like Bitcoin. An explorer shows the sender, the receiver, the amount, and the trail back to where the funds came from.
+
+Shielded addresses are the private side. Funds in the Sapling or Orchard [shielded pools](https://github.com/ZecHub/zechub/blob/main/site/Using_Zcash/Shielded_Pools.md) are protected by zero knowledge proofs. Look up a fully shielded transaction and the explorer cannot show the amount, the addresses, or the memo. It can confirm only that a valid transaction happened and was recorded in a block. This is the hidden private example shown near the top of this page.
+
+One detail does stay visible even for fully shielded transactions: the fee. Zcash consensus rules require the transparent fee to be stated explicitly, so an explorer can always show it, even when the amounts are masked. For that reason it is good practice to use the standard wallet fee, so your transaction does not stand out by paying an unusual amount.
+
+The explorer can also see when funds cross between the transparent and shielded sides. Moving `t` funds into a pool is shielding, moving them back out is deshielding. Those crossings are partly visible because one side is transparent. Only fully private z to z activity, which never touches a `t` address, keeps everything but the fee hidden.
+
+The takeaway: privacy depends on staying inside the shielded pools. Once funds touch a `t` address, that part of their history is as public as Bitcoin. To prove your own shielded activity to someone you choose, such as an accountant, share a viewing key instead of making it public. See the [Viewing Keys](https://github.com/ZecHub/zechub/blob/main/site/Zcash_Tech/Viewing_Keys.md) page.
+
+
 ### Visual Guide
 
 Here are four good examples of different blockchain explorers:


### PR DESCRIPTION
Following the suggestion to add to the existing Blockchain Explorers page rather than a separate page. This new section explains what a block explorer can and cannot see specifically for shielded versus transparent Zcash transactions, including that the fee stays visible on fully shielded transactions. I checked the repo to avoid duplicating the Shielded Pools and Viewing Keys pages, and cross-linked to both instead. Followed the style guide (TL;DR, brief, plain English). Happy to adjust anything.
ZEC tip address: u1c39y4us66h56zt93ra3wprmgfzw4jqp5wwsxemtgsm9w9tlajr0rf83ep0zdlh34qm00vfgs3u8amxl6vj2c6mx0ccq8n3cvusqclxcs