### PR TITLE
Standardize FROST and Zcash Wallet Syncing wiki pages

### DIFF
--- a/site/Zcash_Tech/FROST.md
+++ b/site/Zcash_Tech/FROST.md
@@ -2,133 +2,143 @@
   <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
 </a>
 
-# FROST 
+# FROST
 
+FROST, short for Flexible Round-Optimized Schnorr Threshold Signatures, is a threshold signature protocol for producing one Schnorr signature from a group of cooperating signers. It lets a wallet, treasury, exchange, or protocol split signing authority across multiple participants while keeping the final signature compact and privacy-preserving.
 
-## What is a Schnorr signature?
+## TL;DR
 
-A Schnorr digital signature is a set of algorithms: (KeyGen, Sign, Verify).
+- FROST turns a single signing key into shared signing authority, so no one participant has to hold the whole secret key.
+- A threshold such as 2-of-3 or 5-of-8 can sign, while fewer than the threshold cannot.
+- The final signature looks like a normal Schnorr signature, which helps avoid exposing the signer set on-chain.
+- FROST reduces the network rounds needed for threshold signing and supports safe parallel signing operations.
+- In Zcash, FROST can support private multisig, safer custody, shielded-asset authority, escrow, and organization-level spend controls.
 
-Schnorr signatures have several advantages. One key advantage is that when multiple keys are used to sign the same message, the resulting signatures can be combined into a single signature. This can be used to significantly reduce the size of multisig payments and other multisig related transactions.
+## Core Explanation
 
+### Schnorr signatures
 
-## What is FROST?
+A Schnorr digital signature is built from three core algorithms: key generation, signing, and verification.
 
-**Flexible Round-Optimized Schnorr Threshold Signatures** -
-*Created by Chelsea Komlo (University of Waterloo, Zcash Foundation) & Ian Goldberg (University of Waterloo).*
+Schnorr signatures are useful for threshold systems because multiple signing shares can be combined into one valid signature. Instead of placing several separate signatures on-chain, the group can produce a single compact signature that verifies against the group's public key.
 
-FROST is a threshold signature and distributed key generation protocol that offers minimal rounds of communication and is secure to be run in parallel. FROST protocol is a threshold version of the Schnorr signature scheme.
+This matters for Zcash because compact signatures reduce data size and can avoid revealing that a transaction was authorized by a group rather than a single signer.
 
-Unlike signatures in a single-party setting, threshold signatures require cooperation among a threshold number of signers each holding a share of a common private key. 
+For a short primer, see [Short Video on Schnorr Digital Signatures](https://youtu.be/r9hJiDrtukI?t=19).
+
+### What FROST adds
+
+FROST was created by Chelsea Komlo of the University of Waterloo and Zcash Foundation, and Ian Goldberg of the University of Waterloo.
+
+FROST is a threshold version of the Schnorr signature scheme. In a normal single-party signature, one private key signs one message. In FROST, a group jointly controls a signing key. Each participant holds a secret share, and any threshold number of participants can cooperate to create a valid signature.
+
+That design improves resilience and reduces single-key risk. A stolen laptop, compromised server, or unavailable signer does not automatically give an attacker the whole key or prevent the group from signing.
 
 [What are Threshold Signatures? Chelsea Komlo - Zcon3](https://youtu.be/cAfTTfblzoU?t=110)
 
-Consequently, generating signatures in a threshold setting imposes overhead due to network rounds among signers, proving costly when secret shares are stored on network-limited devices or when coordination occurs over unreliable networks.
+### How FROST works
 
-Network overhead during signing operations is reduced by employing a novel technique to protect against forgery attacks applicable to other schemes.
- 
-FROST improves upon threshold signature protocols as an unlimited number of signature operations can be performed safely in parallel (concurrency).
- 
-It can be used as either a 2-round protocol where signers send and receive 2 messages in total, or optimized to a single-round signing protocol with a pre-processing stage. 
+The FROST protocol has two main phases:
 
-FROST achieves its efficiency improvements in part by allowing the protocol to abort in the presence of a misbehaving participant (who is then identified and excluded from future operations).
- 
-Proofs of security demonstrating that FROST is secure against chosen-message attacks assuming the discrete logarithm problem is hard and the adversary controls fewer participants than the threshold are provided [here](https://eprint.iacr.org/2020/852.pdf#page=16).
-
-
-## How does FROST work?
-
-The FROST protocol contains two important components:
-
-First, n participants run a *distributed key generation (DKG) protocol* to generate a common verification key; at the end, each participant obtains a private secret key share and a public verification key share. 
-
-Afterwards, any t-out-of-n participants can run a *threshold signing protocol* to collaboratively generate a valid Schnorr signature. 
+1. A key-generation phase creates a shared verification key and gives each participant a private secret share.
+2. A threshold-signing phase lets any approved threshold of participants create a valid Schnorr signature.
 
 <a href="">
-    <img src="https://static.cryptohopper.com/images/news/uploads/1634081807-frost-flexible-round-optimized-schnorr-threshold-signatures-1.jpg" alt="" width="400" height="300"/>
+    <img src="https://static.cryptohopper.com/images/news/uploads/1634081807-frost-flexible-round-optimized-schnorr-threshold-signatures-1.jpg" alt="FROST threshold signature overview" width="400" height="300"/>
 </a>
 
-**Distributed key generation (DKG)**
+### Distributed key generation
 
-The goal of this phase is to generate long-lived secret key shares and a joint verification key. This phase is run by n participants. 
+In distributed key generation, or DKG, the participants generate long-lived secret key shares and one joint verification key.
 
-FROST builds its own key generation phase upon [Pedersens DKG (GJKR03)](https://blog.gtank.cc/notes-on-threshold-signatures/)  in which it uses both Shamir secret sharing and Feldmans verifiable secret sharing schemes as subroutines. In addition, Each participant is required to demonstrate knowledge of their own secret by sending to other participants a zero-knowledge proof, which itself is a Schnorr signature. This additional step protects against rogue-key attacks in the setting where t ≥ n/2.
+FROST builds on [Pedersen's DKG (GJKR03)](https://blog.gtank.cc/notes-on-threshold-signatures/) and uses both Shamir secret sharing and Feldman's verifiable secret sharing as subroutines. Each participant also proves knowledge of their own secret with a zero-knowledge proof, itself a Schnorr signature. This protects against rogue-key attacks in settings where the threshold is at least half of the group.
 
-At the end of the DKG protocol, a joint verification key vk is generated. Also, each participant P ᵢ holds a value (i, sk ᵢ ) that is their long-lived secret share and a verification key share vk ᵢ = sk ᵢ *G. Participant P ᵢs verification key share vk ᵢis used by other participants to verify the correctness of P ᵢs signature shares in the signing phase, while the verification key vk is used by external parties to verify signatures issued by the group.
+At the end of DKG:
 
-**Threshold Signing**
+- The group has one joint verification key.
+- Each participant holds a long-lived secret key share.
+- Each participant has a public verification key share that the group can use to check signature shares during signing.
 
-This phase builds upon known techniques that employ additive secret sharing and share conversion to non-interactively generate the nonce for each signature. This phase also leverages binding techniques to avoid known forgery attacks without limiting concurrency.
+### Threshold signing
 
-Preprocessing: In the preprocessing stage, each participant prepares a fixed number of Elliptic Curve (EC) point pairs for further use, which is run for a single time for multiple threshold signing phases.
+After key generation, any threshold number of participants can cooperate to sign. The signing flow uses nonce commitments and binding techniques so that attackers cannot mix signature shares from different signing sessions or reorder the participant set to forge a signature.
+
+FROST can be used as a two-round signing protocol, or it can be optimized so that online signing needs only one round after a preprocessing stage.
 
 <a href="">
-    <img src="https://i.ibb.co/nQD1c3n/preprocess.png" alt="" width="400" height="300"/>
+    <img src="https://i.ibb.co/nQD1c3n/preprocess.png" alt="FROST preprocessing stage" width="400" height="300"/>
 </a>
 
-Signing Round 1: Each participant Pᵢ begins by generating a single private nonce pair (dᵢ, eᵢ) and corresponding pair of EC points (Dᵢ, Eᵢ) and broadcasts this pair of points to all other participants. Each participant stores these pairs of EC points received for use later. Signing rounds 2 and 3 are the actual operations in which t-out-of-n participants cooperate to create a valid Schnorr signature.
-
-Signing Round 2: To create a valid Schnorr signature, any t participants work together to execute this round. The core technique behind this round is t-out-of-t additive secret sharing.
-
-This step prevents forgery attack because attackers cannot combine signature shares across distinct signing operations or permute the set of signers or published points for each signer. 
+During preprocessing, participants prepare elliptic-curve point pairs for later signing. In the online signing rounds, participants publish nonce commitments, compute the shared challenge, and broadcast response values. The valid response shares are combined into one Schnorr signature.
 
 <a href="">
-    <img src="https://i.ibb.co/b5rJbXx/sign.png" alt="" width="400" height="300"/>
+    <img src="https://i.ibb.co/b5rJbXx/sign.png" alt="FROST threshold signing flow" width="400" height="300"/>
 </a>
-
-Having computed the challenge c, each participant is able to compute the response zᵢ to the challenge using the single-use nonces and the long-term secret shares, which are t-out-of-n (degree t-1) Shamir secret shares of the groups long-lived key. At the end of signing round 2, each participant broadcasts zᵢ to other participants.
 
 [Read the full paper](https://eprint.iacr.org/2020/852.pdf)
 
+## Visual / Analogy
 
-## Does it benefit Zcash?
+Think of FROST like a high-security vault that needs several approved keyholders, but not every keyholder, to open. The vault does not reveal which people participated when it opens. Outside observers only see that the vault was opened with a valid authorization.
 
-Absolutely yes. The introduction of FROST to Zcash will allow multiple parties, separated geographically to control spend authority of shielded ZEC. An advantage being that transactions broadcast using this signature scheme will be indistinguishable from other transactions on the network, maintaining strong resistance to payment tracking and limiting the amount of blockchain data available for analysis. 
+For Zcash, that is the important privacy property: the authorization can be distributed among several parties without making the transaction look like an obvious multisig transaction.
 
-In practice this allows for an entire host of new applications to be built on the network ranging from escrow providers or other non-custodial services. 
+## Deep Dive
 
-FROST will also become an essential component in the secure issuance and management of Zcash Shielded Assets (ZSA) enabling safer management of spend authority within development orgs & ZEC custodians such as exchanges by further distributing trust while providing this capability to Zcash users as well. 
+### Security and concurrency
 
+FROST reduces network overhead during signing while protecting against forgery attacks that can affect earlier Schnorr threshold constructions. It also supports multiple signing operations safely in parallel, which is important for wallets, exchanges, custodians, and services that need to coordinate many approvals at once.
 
-## FROST use in the wider ecosystem
+If a participant misbehaves during signing, FROST can abort and identify the participant so they can be excluded from future operations.
+
+The original paper includes proofs showing FROST is secure against chosen-message attacks when the discrete logarithm problem is hard and the attacker controls fewer participants than the signing threshold. See the proof section in the [FROST paper](https://eprint.iacr.org/2020/852.pdf#page=16).
+
+### FROST in standards and the wider ecosystem
+
+The two-round FROST protocol is now published as [RFC 9591](https://datatracker.ietf.org/doc/rfc9591/), an informational RFC from the IRTF Crypto Forum Research Group. The earlier [draft-irtf-cfrg-frost version 11](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/11/) was one step in that standardization path.
 
 **FROST in [Coinbase](https://github.com/coinbase/kryptology/tree/master/pkg/dkg/frost)**
 
-In order to improve efficiency of the Coinbase threshold-signing systems they developed a version of FROST. The Coinbase implementation makes slight changes from the original FROST draft.
+Coinbase developed a version of FROST to improve the efficiency of its threshold-signing systems. Its implementation changed some design choices from the original draft: it did not use a separate signature aggregator role, and it removed the one-time preprocessing stage in favor of an additional signing round.
 
-They opted not use the signature aggregator role. Instead, each participant is a signature aggregator. This design is more secure: all the participants of the protocol verify what others have computed to achieve a higher level of security and reduce risk. The (one-time) preprocessing stage was also removed in order to speed up the implementation, having a third signing round instead.
+See also: [Coinbase Article - Threshold Signatures](https://www.coinbase.com/blog/threshold-digital-signatures)
 
-___
+**[ROAST](https://eprint.iacr.org/2022/550.pdf) by Blockstream**
 
-**[ROAST](https://eprint.iacr.org/2022/550.pdf) by Blockstream** 
+ROAST is a wrapper around threshold signature schemes such as FROST. It is designed to help a quorum of honest signers obtain a valid signature even when some signers are disruptive or network connections have high latency. Blockstream proposed ROAST for use on the [Liquid sidechain](https://blog.blockstream.com/roast-robust-asynchronous-schnorr-threshold-signatures/).
 
-An application specific improvement on FROST proposed for use on [Blockstream Liquid Sidechain](https://blog.blockstream.com/roast-robust-asynchronous-schnorr-threshold-signatures/) for Bitcoin.
+## Practical Implications
 
-"ROAST is a simple wrapper around threshold signature schemes like FROST. It guarantees that a quorum of honest signers, e.g., the Liquid functionaries, can always obtain a valid signature even in the presence of disruptive signers when network connections have arbitrarily high latency." 
+FROST can benefit Zcash in several concrete ways:
 
-___
+- **Private multisig:** Multiple parties can control shielded ZEC without creating an obvious on-chain multisig footprint.
+- **Custody and exchanges:** Organizations can distribute spend authority across teams, hardware devices, or locations.
+- **Escrow and non-custodial services:** Applications can require multiple approvals without giving one operator unilateral control.
+- **Zcash Shielded Assets:** FROST can help manage asset-issuance or administrative authority while reducing single-key risk.
+- **Operational resilience:** A threshold group can keep working even if one signer is offline, as long as enough participants remain available.
 
-**FROST in IETF**
+## Common Mistakes
 
-The Internet Engineering Task Force, founded in 1986, is the premiere standards development organization for the Internet. The IETF makes voluntary standards that are often adopted by Internet users, network operators, and equipment vendors, and it thus helps shape the trajectory of the development of the Internet.
+**Assuming FROST hides all operational metadata.** The final signature can look like a normal Schnorr signature, but the coordination layer still needs careful privacy and security design. Network logs, signer availability, and policy workflows can leak information outside the blockchain.
 
-FROST version 11 (two-round variant) has been [submitted to IRTF](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/11/). 
+**Treating threshold signing as a backup plan only.** FROST is not just key backup. It is a live signing protocol with rules for signer selection, nonce handling, share verification, and misbehavior handling.
 
-This is an important step for the complete evaluation & of FROST as a new threshold signature scheme standard for use across the internet, in hardware devices and for other services in the years to come. 
-___
+**Reusing nonce material.** Threshold signing protocols depend on careful nonce generation and handling. Implementations must follow the protocol exactly.
 
+**Confusing FROST with traditional on-chain multisig.** Traditional multisig can reveal several signers or several signatures. FROST creates one aggregated Schnorr signature, so the privacy and data-size properties are different.
 
-Further Learning:
+## Related Pages
 
-[Coinbase Article - Threshold Signatures](https://www.coinbase.com/blog/threshold-digital-signatures)
+- [Halo](Halo.md), the trustless recursive proof system used in modern Zcash proving work.
+- [Viewing Keys](Viewing_Keys.md), selective disclosure tools for shielded transactions.
+- [Zcash Shielded Assets](Zcash_Shielded_Assets.md), where distributed issuance or administrative authority can benefit from threshold signing.
+- [Zcash Wallet Syncing](Zcash_Wallet_Syncing.md), another Zcash privacy infrastructure topic for wallet builders and users.
+- [Lightwallet Nodes](Lightwallet_Nodes.md), the server infrastructure used by many Zcash light wallets.
 
-[Shamir Secret Sharing - Explainer & Example](https://www.geeksforgeeks.org/shamirs-secret-sharing-algorithm-cryptography/)
+## Further Learning
 
-[Short Video on Schnorr Digital Signatures](https://youtu.be/r9hJiDrtukI?t=19)
-
-___
-___
-
-
-
-
+- [FROST paper](https://eprint.iacr.org/2020/852.pdf)
+- [RFC 9591: The FROST Protocol for Two-Round Schnorr Signatures](https://datatracker.ietf.org/doc/rfc9591/)
+- [Shamir Secret Sharing - Explainer & Example](https://www.geeksforgeeks.org/shamirs-secret-sharing-algorithm-cryptography/)
+- [Coinbase Article - Threshold Signatures](https://www.coinbase.com/blog/threshold-digital-signatures)
+- [What are Threshold Signatures? Chelsea Komlo - Zcon3](https://youtu.be/cAfTTfblzoU?t=110)

--- a/site/Zcash_Tech/Zcash_Wallet_Syncing.md
+++ b/site/Zcash_Tech/Zcash_Wallet_Syncing.md
@@ -4,59 +4,129 @@
 
 # Zcash Wallet Syncing
 
-### How Zcash syncing works
+Zcash wallet syncing is the process a wallet uses to find the shielded notes, balances, transaction history, memos, and spendable funds that belong to a user. Because shielded Zcash transactions protect transaction details, syncing a privacy-preserving wallet is more involved than asking a public blockchain indexer for an account balance.
 
-To understand how warp sync works, let me explain a bit more about Zcash. It is a privacy-oriented cryptocurrencies that use a technology called zero-knowledge proofs to shield the details of transactions from anyone who is not authorized to see them. This means that the transactions recorded on the blockchain are encrypted or hidden, and only the sender and receiver can decrypt them with their private keys.
+## TL;DR
 
-However, this also poses a challenge for light wallets, which are applications that do not store the entire blockchain data on the device, but rely on a server to provide them with the necessary information. With non-privacy coins, such as Bitcoin or Ethereum, the server can easily index the blockchain and keep a database of every account. When a light wallet asks for its specific account data, the server can quickly return it.
+- Zcash shielded transactions hide transaction details from public observers, so wallets must scan encrypted data to find the notes they can decrypt.
+- Light wallets usually download compact blocks from a lightwalletd server instead of downloading the entire blockchain.
+- Wallets use different sync strategies, such as warp sync, spend-before-sync, Blaze sync, and DAGSync, to make private wallets usable faster.
+- Faster syncing often trades extra memory, CPU, or implementation complexity for quicker access to spendable funds.
+- Sync design matters for privacy because wallets need useful data without exposing which addresses or notes belong to the user.
 
-But with  Zcash, the server cannot do that, because it cannot see the details of the transactions. So how can a light wallet synchronize its account balance and transaction history without downloading and decrypting the entire blockchain data itself?
+## Core Explanation
 
-Zcash solves this problem by using a mixed approach. It has a specialized server called lightwalletd that filters the data from a full node and keeps only the data needed for transaction identification. This data is called compact blocks, and it is much smaller than the original blocks. Light wallets only have to download these compact blocks from the lightwalletd server, and then decrypt them themselves with their private keys.
+### Why Zcash syncing is different
 
-However, even decrypting and processing these compact blocks can take a significant amount of time, especially if there are many transactions in each block. So every wallet has its own alternative method to speed up the syncronization process so you can use your funds as soon as possible.
+With non-private chains, a server can index public account activity and quickly answer a wallet's balance request. The server can see which outputs belong to which public addresses, so it can maintain a database of account balances and transaction history.
+
+Zcash shielded transactions work differently. Transaction details are encrypted, and only the holder of the relevant keys can detect and decrypt their own received notes. That protects users, but it also means a server cannot simply look up a complete private account history on the user's behalf.
+
+The wallet has to scan blockchain data, try decrypting relevant encrypted outputs with the user's keys, maintain witnesses, detect spent notes, and build a local view of the user's funds.
+
+### Compact blocks and lightwalletd
+
+Most Zcash light wallets use a mixed approach. A specialized server called lightwalletd filters data from a full node and serves compact blocks. Compact blocks are much smaller than full blocks and include the data wallets need for transaction detection.
+
+The light wallet downloads compact blocks, then performs local trial decryption with the user's keys. If the wallet can decrypt a note, it adds the note to the user's local wallet state. If it later sees that note's nullifier used on-chain, the wallet knows the note has been spent.
+
+This preserves privacy better than giving the server a list of addresses to index, but it can still take time because the wallet must process many blocks locally.
 
 ### Warp Sync
-Warp sync is a feature of YWallet that allows it to skip the intermediate steps of decrypting and processing each compact block, and instead jump directly to the final result.
 
-To do so it uses some clever mathematics and cryptography to calculate the final result without having to go through each step. 
+Warp sync is a YWallet feature that speeds up synchronization by skipping intermediate work and jumping directly to the final wallet state where possible.
 
-Warp sync can process thousands of blocks per second, much faster than the usual synchronization method. This means that YWallet users can enjoy fast and smooth performance, even with hundreds of thousands of transactions and received notes in their accounts.
+Instead of decrypting and processing every compact block one after another, warp sync uses cryptographic techniques to calculate the final result more efficiently. It can process thousands of blocks per second, which helps users with large histories or many received notes.
 
-Aside from this **step skipping** technique, YWallet is also capable of processing various blocks at the same time, distributing the load on your available hardware making the process even faster.
+YWallet also processes multiple blocks at the same time, distributing the workload across available hardware.
 
-Read More on [Warp Sync](https://ywallet.app/warp/)
+Read more on [Warp Sync](https://ywallet.app/warp/).
 
 ### Spend-before-sync
-Spend-before-sync is a new feature implemented in Zcash Mobile Wallet SDK V2, that allows users to instantly spend funds upon opening their wallet, without having to wait for a full wallet synchronization. This feature speeds up discovering the wallet spendable balance and improves the user experience.
 
-Spend-before-sync works by using a compact blocks synchronization algorithm that processes blocks from the lightwalletd server in non-linear order, this means that instead of waiting for a block to be processed before moving to the other, wallets can now use a bit more memory and processing power to scan different sections of the blockchain. Usually it will scan in different ranges, looking for newer transactions at the same time the older blocks are downloaded and processed. If a recent, unspent note is discovered, it will be made available inmediately.
+Spend-before-sync is a Zcash Mobile Wallet SDK V2 feature that lets a wallet discover and spend some funds before a full historical sync finishes.
+
+Instead of scanning the blockchain strictly from oldest to newest, the wallet can process block ranges in a non-linear order. It may look for newer transactions while older blocks are still being downloaded and scanned. If the wallet finds a recent unspent note, that note can become available sooner.
 
 <a href="">
-    <img src="https://github.com/ZecHub/zechub/assets/9355622/363d08df-b7b7-461b-a386-251d9ad702ca" alt="" width="140" height="150"/>
+    <img src="https://github.com/ZecHub/zechub/assets/9355622/363d08df-b7b7-461b-a386-251d9ad702ca" alt="Spend-before-sync wallet scanning illustration" width="140" height="150"/>
 </a>
 
 ### Blaze Sync
-Developed by Zecwallet team, Blaze sync is a syncronization algorithm for light wallets that starts scanning the blockchain "backwards", starting from the highest, most recent block, and going back from there.
 
-This allows the wallet to find spent notes before received ones, while making available the ones already unspent, without waiting for the complete syncronization process to finish.
+Blaze sync was developed by the Zecwallet team as a synchronization algorithm for light wallets.
 
-Besides  that, it uses Out of Order Sync, by decoupling "he components of the sync from each other - Downloading blocks, doing trial decryptions, updating witnesses", and processing them in paralell, taking some more memory and CPU resources, but increasing sync speed X5.
+It starts scanning from the most recent blocks and moves backward. That can help the wallet find spent notes before older received notes, and it can make already-unspent funds available without waiting for the full synchronization process to finish.
+
+Blaze sync also uses out-of-order sync by decoupling the main sync components: downloading blocks, trial decryption, and updating witnesses. Processing those pieces in parallel can use more memory and CPU, but it can significantly increase sync speed.
 
 ### DAGSync
 
-DAGSync is a proposed syncronization algorithm that aims at improving the user experience of Zcash shielded wallets, by making the syncronization faster.
+DAGSync is a proposed synchronization approach for improving the user experience of shielded Zcash wallets.
 
-It is based on [the idea of using a Directed Acyclic Graph](https://words.str4d.xyz/dagsync-graph-aware-zcash-wallets/) (DAG) to represent the dependencies between notes, witnesses, and nullifiers in a Zcash wallet. 
+It is based on [the idea of using a Directed Acyclic Graph](https://words.str4d.xyz/dagsync-graph-aware-zcash-wallets/) to represent dependencies between notes, witnesses, and nullifiers. A directed acyclic graph, or DAG, is a structure made of nodes and one-way edges with no cycles.
 
-A DAG is a data structure that consists of nodes and edges, where each edge has a direction that indicates a relationship between two nodes. A DAG has no cycles, meaning that there is no way to start from a node and follow the edges back to the same node.
+In wallet terms, the DAG helps identify which pieces of wallet state depend on other pieces. A wallet can then prioritize the work that unlocks useful information sooner.
 
 <a href="">
-    <img src="https://github.com/ZecHub/zechub/assets/9355622/eee7e08d-5c98-4c88-a48e-12f7a92a195f" alt="" width="110" height="230"/>
+    <img src="https://github.com/ZecHub/zechub/assets/9355622/eee7e08d-5c98-4c88-a48e-12f7a92a195f" alt="DAGSync dependency graph illustration" width="110" height="230"/>
 </a>
 
----
+## Visual / Analogy
 
-Interestingly enough, all these mechanism try to solve the inquiries proposed by Zcash Security in its post about [Scalable Private Messaging](https://zecsec.com/posts/scalable-private-money-needs-scalable-private-messaging/) and its relationship with private payment systems, some even taking the extra step of downloading all memo data from servers, except for those exclusive to an address, increasing privacy at the cost of a bit of extra resources.
+Think of a Zcash wallet like a private mailbox in a large mailroom. The public mailroom can hand you every envelope, but it cannot tell which envelopes are yours because the labels are encrypted. Your wallet has to try your keys locally, discover which envelopes open for you, and then track which discovered notes have already been spent.
 
-Also, the Zcash Foundation has been looking at other alternatives to improve the performance of light wallets. That's the case with [Oblivious Message Retrieval (OMR](https://zfnd.org/oblivious-message-retrieval/)), a construction the foundation has been studying "to determine whether it offers a potential solution to the recent performance problems that have affected Zcash wallet users"
+Sync improvements are different ways to search the mailroom faster without asking the server to reveal or learn your private mailbox contents.
+
+## Deep Dive
+
+### The core sync work
+
+Behind the wallet interface, syncing usually includes several jobs:
+
+- Download compact block data from a lightwalletd server.
+- Trial-decrypt outputs with the wallet's incoming viewing keys.
+- Store received notes and update wallet witnesses.
+- Track nullifiers to know which notes have been spent.
+- Maintain enough local state to construct future shielded spends.
+
+The harder part is doing this quickly without weakening privacy. If a wallet asks a server for exactly the notes that belong to one address, the server learns too much. If the wallet downloads and scans a broad set of data, privacy improves, but the device has more work to do.
+
+### Scalable private messaging
+
+These sync strategies relate to broader questions raised by Zcash Security in [Scalable Private Messaging](https://zecsec.com/posts/scalable-private-money-needs-scalable-private-messaging/): private payment systems need private ways to retrieve messages at scale. Some wallet designs even download more memo data than strictly necessary to reduce address-specific leakage, accepting extra bandwidth or processing cost for better privacy.
+
+Zcash Foundation has also researched [Oblivious Message Retrieval (OMR)](https://zfnd.org/oblivious-message-retrieval/), a construction studied as a possible answer to recent wallet performance problems. OMR aims to help wallets retrieve needed messages without revealing too much about which messages they care about.
+
+## Practical Implications
+
+- **For users:** A wallet may show spendable funds before it has completed every historical scan, depending on the sync algorithm it uses.
+- **For mobile wallets:** Faster sync can improve onboarding and daily usability, especially on devices with limited battery, memory, and network reliability.
+- **For wallet developers:** Sync speed, privacy, bandwidth, memory use, and implementation complexity have to be balanced together.
+- **For infrastructure operators:** Reliable lightwalletd service is important because many light wallets depend on compact block delivery.
+- **For privacy:** Faster sync should not require the wallet to reveal exactly which address, note, or memo it is trying to find.
+
+## Common Mistakes
+
+**Assuming the server knows your shielded balance.** A lightwalletd server provides compact block data, but the wallet usually has to decrypt and interpret that data locally.
+
+**Stopping sync too early.** A wallet may discover spendable funds before full sync is complete, but older history, memos, or note state may still be processing.
+
+**Comparing Zcash sync directly to transparent-chain sync.** Shielded privacy changes the problem. A slower sync path can be a sign that the wallet is preserving privacy rather than handing account information to an indexer.
+
+**Ignoring resource tradeoffs.** Algorithms that sync faster may use more memory, CPU, bandwidth, or more complex background processing.
+
+## Related Pages
+
+- [Lightwallet Nodes](Lightwallet_Nodes.md), the server infrastructure used by many Zcash light wallets.
+- [Viewing Keys](Viewing_Keys.md), the keys wallets use for selective disclosure and local transaction detection.
+- [Zcash Shielded Assets](Zcash_Shielded_Assets.md), an extension area that also depends on private wallet state.
+- [FROST](FROST.md), another Zcash cryptography topic focused on distributed signing authority.
+- [Halo](Halo.md), the proof-system work behind modern Zcash shielded infrastructure.
+
+## Further Reading
+
+- [Warp Sync](https://ywallet.app/warp/)
+- [DAGSync: Graph-aware Zcash wallets](https://words.str4d.xyz/dagsync-graph-aware-zcash-wallets/)
+- [Scalable Private Messaging](https://zecsec.com/posts/scalable-private-money-needs-scalable-private-messaging/)
+- [Oblivious Message Retrieval](https://zfnd.org/oblivious-message-retrieval/)


### PR DESCRIPTION
## Summary

- Standardizes `site/Zcash_Tech/FROST.md` around the requested wiki structure: title, TL;DR, core explanation, visual/analogy, deep dive, practical implications, common mistakes, related pages, and further learning.
- Standardizes `site/Zcash_Tech/Zcash_Wallet_Syncing.md` with the same required structure while preserving the existing sync strategies, links, and images.
- Updates the FROST standards note to point readers to RFC 9591 while preserving the earlier draft link as part of the standardization history.

## Bounty

Closes #1746

## Validation

- `git diff --check main standardize-zcash-tech-pages-1746 -- site/Zcash_Tech/FROST.md site/Zcash_Tech/Zcash_Wallet_Syncing.md`
- Verified the diff only changes the two requested wiki pages.
- Verified both pages include the required Title, TL;DR, Core Explanation, and Related Pages sections.