### PR TITLE
Add Zcash Ecosystem Digest | June 21st

### DIFF
--- a/newsletter/Digest 06-21-26.md
+++ b/newsletter/Digest 06-21-26.md
@@ -1,0 +1,112 @@
+# Zcash Ecosystem Digest | June 21st
+ZF Engineering Update & Zebra v5.1.1, Zaino 0.3.1 Zallet Release, Dynamic Fees Proposal, Ledger Integration Progress, ZCG Election Voting Underway, Zcash Names Lands in Wallets & Binance US Adds ZEC/USD!
+Curated by [vancube](https://x.com/AmunnadiG)
+
+Subscribe to the Zcash Event Calendar!
+
+## ZODL, Zcash Foundation & Shielded Labs
+[ZF Engineering Update June 1-14: genesis-to-tip sync now completes in ~14 hours with no stalls, getpeerinfo RPC extended, latest release Zebra v5.1.1 - @ZcashFoundation](https://x.com/ZcashFoundation/status/2066926707945128328?s=20)
+
+[Arborist Call update: all Zcash Arborist Calls move to a single time slot, 15:00 UTC, on the same bi-weekly schedule - @ZcashFoundation](https://x.com/ZcashFoundation/status/2067952972529639473?s=20)
+
+[Another Z3 update: getting closer to the goal, with wallet migration testing coming in the next release - @thecodebuffet](https://x.com/thecodebuffet/status/2068111119630135741?s=20)
+
+[Monthly update from the Ledger integration team: general progress, the emergency soft-fork response, and a note on the upcoming Ironwood upgrade - @Zcash](https://x.com/Zcash/status/2066938225512665562?s=20)
+
+[Zcash Dynamic Fees proposal: more flexible fees, better UX during high demand, lower everyday costs, with optional priority transactions while preserving privacy - Shielded Labs](https://forum.zcashcommunity.com/t/zcash-dynamic-fees-now/55876)
+
+[Four Questions About the Orchard Vulnerability - article by Jason McGee and Zooko Wilcox of Shielded Labs - @zooko](https://x.com/zooko/status/2066329282973249847?s=20)
+
+[AI-assisted security auditing in the Zcash ecosystem - a deep dive from Least Authority as Zcash Ecosystem Security Lead - @zooko](https://x.com/zooko/status/2066539897075482672?s=20)
+
+[U.S. Digital Asset Policy in H1 2026: Implications for the Zcash Ecosystem - @paulbrigner](https://x.com/paulbrigner/status/2067238169414631843?s=20)
+
+---
+## Zcash Community Grants
+[ZCG election voting is underway: ZCAP members have until June 29 to vote on candidates for two committee seats - Zcash Foundation](https://forum.zcashcommunity.com/t/zcap-poll-now-open-zcg-election-june-2026/56156)
+
+[ZCAP has until June 29 to vote on ZCG candidates; a closer look at candidate Paul Brigner - @ZecHub](https://x.com/ZecHub/status/2067564452136788448?s=20)
+
+[Zcash Arabia resubmits its grant proposal for June to September 2026, addressing the committee's earlier feedback - Zcash Arabia](https://forum.zcashcommunity.com/t/grant-application-zcash-arabia-june-to-september-2026/56221)
+
+[The Tor Project x Funding the Commons matching round closes June 19, with Zcash Community Grants as an anchor sponsor - @ZcashCommGrants](https://x.com/ZcashCommGrants/status/2067916400102953027?s=20)
+
+[Applications for zkSNARKs grants are now live for anyone who has helped build, secure, write, run, or grow Zcash - @zksnarks_](https://x.com/zksnarks_/status/2067997865331535920?s=20)
+
+---
+## Community Projects
+[Zaino 0.3.1 "The Zallet Release" is out, improving the infrastructure powering apps like Zingo Wallet - @ZingoLabs](https://x.com/ZingoLabs/status/2066672545349169397?s=20)
+
+[ZODL 3.6.0: new currency conversion options, now supporting ZEC balance in BRL and the Nigerian Naira - @zodl_app](https://x.com/zodl_app/status/2067254692162199773?s=20)
+
+[Ledger x Zcash June 2026 update: UFVK sharing and Orchard UA generation complete, full Orchard history syncs in under 65 minutes, Ironwood prep underway - @ZcashTR](https://x.com/ZcashTR/status/2067283895565836336?s=20)
+
+[Zodl Mobile updates: improved Coinholder Survey UI, iOS fixes, server selection, multi-currency support, with 44K iOS and 16K Android installs - @ZcashTR](https://x.com/ZcashTR/status/2066798899847647557?s=20)
+
+[zkool 6.20.0 wallet released, with a new contacts address book, debounced transaction search, and optimizations since Ywallet - hhanh00](https://github.com/hhanh00/zkool2/releases/tag/zkool-v6.20.0)
+
+[Noir Wallet 1.0.22: RPC and explorer switching, transparent address payment records, and improved automatic recovery - @noir_wallet](https://x.com/noir_wallet/status/2066795726471086207?s=20)
+
+[Getting Started with Noir Wallet: a beginner-friendly guide to installing, securing, and using the wallet - @noir_wallet](https://x.com/noir_wallet/status/2068331305033720232?s=20)
+
+[Vizor wallet ships a visual refresh with richer color, improved hierarchy, and a more polished experience - @vizorwallet](https://x.com/vizorwallet/status/2067105911659986993?s=20)
+
+[Zcash Names in Edge Wallet: send shielded payments to names like satoshi.zcash instead of long addresses - @EdgeWallet](https://x.com/EdgeWallet/status/2066559091212685647?s=20)
+
+[Zingo Wallet integrates Zcash Names so you can use a memorable name instead of a long Zcash address - @ZingoLabs](https://x.com/ZingoLabs/status/2067676541278986355?s=20)
+
+[LeoDex is seeking beta testers for its new wallet extension: multi-crypto, no KYC, full shielded ZEC support, and cross-chain swaps - @leodexio](https://x.com/leodexio/status/2067641794553122845?s=20)
+
+[Ifocusdesign releases a new public Zcash node (lwd.ifocusdesign.com:443); community members welcome to try it - Free2Z](https://free2z.cash/Ifocusdesign/zpage/de-la-comunidad-al-desarrollo-la-historia-detras-del-nuevo-nodo-de-ifocusdesign-en-zcash)
+
+[Sovright Mining Pool testnet is live; formerly Bootstrap, with a first focus on mining decentralization - Zcash Community Forum](https://forum.zcashcommunity.com/t/sovright-mining-pool-testnet-is-live/56218)
+
+[Brave is building toward being the best shielded Zcash wallet and is recruiting experienced ZEC users across iOS, Android, and GrapheneOS - @iAnonymous3000](https://x.com/iAnonymous3000/status/2066686203957739795?s=20)
+
+[Binance US launches a ZEC/USD trading pair, expanding market access for Zcash traders - @zcashkorea](https://x.com/zcashkorea/status/2067714522572628032?s=20)
+
+[BitTap launches a ZEC/USDT spot trading pair, opening June 17 - BitTap](https://support.bittap.com/hc/en-us/articles/16507452817039-BitTap-Announcement-ZEC-USDT-Spot-Trading-Pair-to-Launch-on-June-17-2026)
+
+[Grayscale: Zcash is the first privacy protocol to participate in a full Anthropic Mythos-level audit; Grayscale Zcash Trust offers pure ZEC exposure in some US brokerage accounts - @Grayscale](https://x.com/Grayscale/status/2066569257543163939?s=20)
+
+[Cypherpunk accumulated an additional 6,846 ZEC for $3.4M, now holding ~1.91% of the network - @cypherpunk](https://x.com/cypherpunk/status/2067230797694636245?s=20)
+
+[ZecMap is building Zcash payments in real life and asking for community support, with over 1,090 ZEC donated so far - @ZecMap](https://x.com/ZecMap/status/2067201000893550727?s=20)
+
+[Protocol Study #4 - Transactions Unpacked: JoinSplit to Actions, with Shielded Labs and Zcash Brazil - @shieldedmark](https://x.com/pedamerico/status/2067018560434503730?s=20)
+
+[Zcash is one of 130+ blockchains you can build on with Tatum, offering JSON-RPC access for privacy wallets and shielded tx tracking - @tatum_io](https://x.com/tatum_io/status/1979068013182665032?s=20)
+
+[ruZcash on why protocol-level privacy matters: with over 500 million addresses already labeled to real people, privacy must be ensured by the protocol - @ruZCASH](https://x.com/ruZCASH/status/2067972489343340836?s=20)
+
+[Zcast announces its next live session, "How to use Zcash from scratch", a hands-on walkthrough of wallets and first private transactions, with a POAP for attendees - @ZcastEsp](https://x.com/ZcastEsp/status/2067683814684651865?s=20)
+
+[Zcast Live #11: Transparent vs Shielded Addresses - @ZcastEsp](https://x.com/ZcastEsp/status/2066929115102658976?s=20)
+
+[ZKAV Club Recording Station comes to The Blockspati by WebZero and Zcash in Berlin, June 18-19 - @ZkAv_Club](https://x.com/ZkAv_Club/status/2067120363192902132?s=20)
+
+[The Blockspati opening party with Zcash and Bitrefill, June 17, with a live performance from Souss X Dim Spirit - @joinwebzero](https://x.com/joinwebzero/status/2066514380150243590?s=20)
+
+[ZecHub Hackathon countdown: 30 days left to sync a Zebra node, read the FROST book, try zingolib, and build a demo app - @ZecHub](https://x.com/ZecHub/status/2066485323576529125?s=20)
+
+[Zcon Vozes, the annual conference organized by Zcash Brazil, with community videos now available - @ZecHub](https://x.com/ZecHub/status/2067309706897686956?s=20)
+
+[Zcash Brazil brought a discussion on technology and privacy into UNISUAM, connecting AI, blockchain, and web3 to real-world challenges for students - @zcashbrazil](https://x.com/zcashbrazil/status/2068015961287127079?s=20)
+
+[Zcash Nigeria ZEC Trivia Challenge runs June 19-28, with winners announced June 30 - @ZcashNigeria](https://x.com/ZcashNigeria/status/2066605609970270513?s=20)
+
+[Zcash East Africa community meetup on financial privacy and the growing African Zcash ecosystem, June 19 in Kenya - @ZcashEastAfrica](https://x.com/ZcashEastAfrica/status/2067583831738106139?s=20)
+
+[Zcash East Africa Thread Contest deadline extended to June 22 - @ZcashEastAfrica](https://x.com/ZcashEastAfrica/status/2067667312769982603?s=20)
+
+[ZEC Trivia night on the Zcash Discord, June 18, with questions based on the #updates room - @zcashbrazil](https://x.com/zcashbrazil/status/2066957112916533435?s=20)
+
+[Zcash Shielded News Vol.23 - @ZecHub](https://x.com/ZecHub/status/2067952644514025864?s=20)
+
+---
+## Meme of the week
+[Zcash meme of the week - @BTCTurtle](https://x.com/BTCTurtle/status/2067947685588443178?s=20)
+
+---
+## Jobs in the Ecosystem
+[ZecHub tasks are posted on Dework](https://app.dework.xyz/zechub-2424)


### PR DESCRIPTION
Closes #1756

Adds the Zcash Ecosystem Digest for June 21st.

Curated from this week's ecosystem activity across the regional ambassador accounts (Brazil, Turkey, Korea, Nigeria, East Africa, ruZcash, Zcast), the main org accounts, and the Zcash community forum. All descriptions are in plain English for easy translation. Includes 40+ community project links across the ZODL/ZF/Shielded Labs, Zcash Community Grants, and Community Projects sections, plus Meme of the week and Jobs.

Focused on the most active sources this week; happy to add any others on request.