### PR TITLE
i18n(it): complete curated corpus to 180 pages (add remaining 90)

### DIFF
--- a/translations/it/site/Privacy_Tools/Shade_Protocol.md
+++ b/translations/it/site/Privacy_Tools/Shade_Protocol.md
@@ -1,0 +1,76 @@
+[![Edit Page](https://img.shields.io/badge/Edit-blue)](https://github.com/zechub/zechub/edit/main/site/Privacy_Tools/Shade_Protocol.md)
+
+# Shade Protocol
+
+![Shade Protocol Logo](https://framerusercontent.com/images/Af8EzlNiwGr4FTFX7oqdBuE.png)
+
+## Cos'è Shade Protocol?
+
+Shade Protocol è un ecosistema DeFi (Decentralized Finance) che tutela la privacy e che mira a offrire una suite di prodotti finanziari garantendo al contempo la privacy e la sicurezza degli utenti. Costruito su Secret Network, Shade Protocol si concentra sulla creazione di un ambiente finanziario incentrato sulla privacy, fornendo agli utenti strumenti come stablecoin, asset sintetici, piattaforme di lending e altro ancora. Il prodotto di punta di Shade Protocol è la Silk Stablecoin, che combina caratteristiche di privacy con la stabilità del prezzo.
+
+## Tecnologia utilizzata 
+
+**Secret Network**
+
+Shade Protocol è costruito su Secret Network, una blockchain layer 1 che fornisce smart contract che tutelano la privacy. Secret Network usa input, output e stato cifrati per garantire la privacy delle transazioni, proteggendo i dati degli utenti dall'essere esposti sul registro pubblico.
+
+![Secret Network Diagram](https://miro.medium.com/v2/resize:fit:828/format:webp/1*yyZ5hFOw6z8zXX_rgJn5iw.png)
+
+Secret Network consente agli sviluppatori di costruire applicazioni decentralizzate con dati cifrati, sia nativamente su Secret sia su altre blockchain attraverso la comunicazione cross chain, sbloccando potenti nuovi casi d'uso per il Web3.
+
+**Cosmos SDK e Tendermint Core**
+
+Cosmos è stato creato per interconnettere blockchain eterogenee definendo modi migliori e più moderni per costruire queste blockchain usando nuovi strumenti come Tendermint e il Cosmos SDK.  
+Il protocollo usa il Cosmos SDK, un framework modulare per costruire applicazioni blockchain scalabili e interoperabili. Questo consente a Shade Protocol di beneficiare della robustezza e dell'interoperabilità dell'ecosistema Cosmos.
+
+![Cosmos SDK and Tendermint Core Diagram](https://s3.ap-northeast-1.amazonaws.com/gimg.gateimg.com/learn/83dfbb311bfd6ce22d1c9468160d8e33b4c5ce8e.jpg)
+
+Per il consenso e la sicurezza della rete, Shade Protocol impiega Tendermint Core, che fornisce un consenso Byzantine Fault Tolerant (BFT), garantendo alta sicurezza e finalità rapida.
+
+**Decentralized Finance che tutela la privacy**
+
+La DeFi che tutela la privacy sfrutta tecniche crittografiche avanzate come transazioni cifrate, zero knowledge proof e smart contract privati per mantenere la privacy degli utenti e la riservatezza dei dati sulle reti blockchain. Usando tecnologie come i secret contract di Secret Network e il Cosmos SDK per l'interoperabilità, queste soluzioni abilitano transazioni riservate, gestione privata degli asset e divulgazione selettiva, garantendo che le attività finanziarie rimangano sicure e conformi alle normative sulla privacy. Questo approccio protegge gli utenti dal tracciamento e dalle frodi, offrendo libertà finanziaria decentralizzata pur aderendo agli standard di privacy.
+
+## Applicazioni
+
+**Token Shade e Silk**
+
+Shade Protocol utilizza le viewing key per i suoi due token principali: Shade ($SHD) e Silk ($SILK). Shade ($SHD) svolge molteplici ruoli, fungendo da token di tesoreria, governance e revenue sharing all'interno dell'ecosistema. Viene usato nello staking, nelle proposte di governance, nella fornitura di liquidità, nelle transazioni e nei bond. Silk ($SILK), d'altra parte, è la stablecoin del protocollo incentrata sulla privacy, ancorata a un paniere diversificato di valute e materie prime globali come oro, Bitcoin, USD, Euro e Yen.
+
+![Shade and Silk Tokens - Part 1](https://framerusercontent.com/images/9wTrxCdx8AoRcCwsGub13QXuY.png?scale-down-to=1024)
+
+![Shade and Silk Tokens - Part 2](https://framerusercontent.com/images/IUC9YWfErTebCBsMkdbCnjSWGEY.png)
+
+### Privacy
+
+Una delle ragioni principali per cui gli utenti potrebbero preferire Shade Protocol è la privacy che offre. Le transazioni su Shade sono schermate dalla vista pubblica, garantendo che i dati finanziari rimangano riservati. A differenza delle tradizionali blockchain pubbliche dove i dettagli delle transazioni sono visibili a tutti, i token di Shade Protocol utilizzano input, output e stati cifrati, il che significa che le informazioni sensibili rimangono nascoste da occhi indiscreti. Questo migliora la privacy e la sicurezza degli utenti, consentendo agli individui di impegnarsi in attività finanziarie senza esporre le proprie informazioni personali o la cronologia delle transazioni, proteggendo così da potenziali minacce e preservando la riservatezza finanziaria.
+
+### Valore stabile
+
+La Silk Stablecoin fornisce stabilità del prezzo, fondamentale per gli utenti che vogliono evitare la volatilità spesso associata alle criptovalute. Silk è ancorata a un paniere di asset, il che aiuta a mantenere il suo valore nel tempo. Ogni stablecoin deriva il suo valore da una fonte specifica, tipicamente essendo ancorata al dollaro statunitense. Tuttavia, questo approccio comporta rischi significativi, spesso non riconosciuti. Silk mitiga questi rischi mantenendo la stabilità in mezzo alla volatilità globale senza affidarsi a un singolo ancoraggio di valore come il dollaro statunitense. Invece, il valore di Silk si basa su un indice ponderato noto come Silk Currency Basket. Questo paniere include una selezione di valute globali (USD, CAD, EUR, JPY) e materie prime come Bitcoin e oro. Incorporando più valute e asset, Silk raggiunge una maggiore stabilità dell'ancoraggio rispetto alle singole valute. Ricerche e test approfonditi hanno dimostrato che oro e Bitcoin, in quanto riserve di valore affidabili, superano le valute tradizionali, giustificando la loro inclusione nel paniere.
+
+### Decentralizzazione
+
+In quanto piattaforma DeFi, Shade Protocol opera senza controllo centrale, fornendo agli utenti autonomia finanziaria. La governance decentralizzata di Shade Protocol consente alla sua community di detentori di token di partecipare direttamente al processo decisionale. I detentori di token possono proporre modifiche, votare sulle iniziative e contribuire allo sviluppo e alla direzione del protocollo. Questo garantisce che il controllo sia distribuito tra un gruppo diversificato di stakeholder anziché essere detenuto da un'autorità centrale. Sfruttando la tecnologia blockchain, il processo di governance è trasparente, sicuro e immutabile, favorendo un ecosistema più inclusivo e resiliente.
+
+### Interoperabilità
+
+Far parte dell'ecosistema Cosmos significa che Shade Protocol può interagire facilmente con altre blockchain, migliorando la liquidità e fornendo più opportunità agli utenti di sfruttare i propri asset su reti diverse. Utilizzando le tecnologie che tutelano la privacy di Secret Network, Shade Protocol garantisce che queste attività cross chain mantengano riservatezza e integrità. Questa interoperabilità non solo migliora la flessibilità e la funzionalità delle applicazioni decentralizzate, ma favorisce anche un ecosistema blockchain più interconnesso e robusto, riducendo la dipendenza da reti isolate e promuovendo un'adozione più ampia delle soluzioni di finanza decentralizzata.
+
+![Interoperability Diagram](https://framerusercontent.com/images/3zIwSJHEwP9tkn4aI0do0lhgFTE.png)
+
+## Conclusione
+
+Shade Protocol è un progetto pionieristico nello spazio DeFi, che offre soluzioni finanziarie incentrate sulla privacy costruite su una tecnologia robusta. Fornendo una stablecoin con caratteristiche di privacy e sviluppando una suite completa di strumenti finanziari, Shade Protocol mira a soddisfare gli utenti che apprezzano sicurezza, stabilità e decentralizzazione.
+
+I principi di coesione e cattura del valore di Shade Protocol forniscono una solida base per la stabilità e un'esperienza utente fluida, posizionandolo come futuro leader tra i protocolli DeFi. Con una governance adattiva e scalabile e una roadmap ben definita per l'introduzione di nuove primitive di Shade Protocol, il potenziale di crescita rapida è senza dubbio immenso.
+
+#### Link di riferimento
+ 
+[Sito web di Shade Protocol](https://shadeprotocol.com)
+
+[Medium (Shade Protocol) ](https://medium.com/@shadeprotocoldevs/what-is-shade-protocol-efc1ef7aeabf)
+
+[Altcoin Buzz.io](https://www.altcoinbuzz.io/reviews/what-is-shade-protocol/)
+
+[Messari.io](https://messari.io/project/shade/profile)

--- a/translations/it/site/Privacy_Tools/Tor_and_I2P.md
+++ b/translations/it/site/Privacy_Tools/Tor_and_I2P.md
@@ -1,0 +1,83 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Privacy_Tools/Tor_and_I2P.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# Perché la Privacy è Importante
+
+Nell'era digitale, salvaguardare la tua [privacy](https://www.privacyguides.org/en/) è diventato sempre più fondamentale. Mentre alcuni potrebbero considerare la privacy una causa persa, non lo è. La tua privacy è in gioco e dovrebbe essere una tua preoccupazione. La privacy ha un valore significativo poiché è legata al potere, e garantire che tale potere venga esercitato in modo responsabile è cruciale.
+
+## Tecnologie Tor & I2P
+
+## Tor
+
+[Tor](https://www.privacyguides.org/en/tor/?h=tor) è uno strumento proxy che utilizza la rete Tor per stabilire connessioni per le applicazioni. Torbot ottiene questo instradando il loro traffico attraverso Tor, migliorando così la [privacy e l'anonimato](https://www.torproject.org/) per queste applicazioni.
+
+## Rete I2P
+
+La rete I2P, nota anche come [Invisible Internet Project](https://geti2p.net/en/about/intro), è una rete overlay peer-to-peer completamente cifrata. Garantisce che il contenuto, l'origine e la destinazione dei messaggi siano nascosti agli osservatori. In altre parole, nessuno può vedere l'origine o la destinazione del traffico né il contenuto effettivo dei messaggi trasmessi. La cifratura usata in I2P garantisce un alto livello di privacy e anonimato per i suoi utenti.
+
+## Tor e I2P condividono caratteristiche comuni ma hanno anche differenze significative. 
+
+Sia Tor che I2P sono reti peer-to-peer decentralizzate e anonime, ma I2P offre livelli di sicurezza più elevati rispetto a Tor. Tuttavia, I2P è progettato principalmente per accedere a servizi come email, chat e torrenting all'interno della propria rete e non può essere usato per accedere alla normale internet. Tor, d'altra parte, permette agli utenti di accedere al deep web, proprio come I2P, ma funziona anche come un normale browser per accedere ai siti web del surface web.
+
+*Nota: Per maggiori informazioni sulle somiglianze e le differenze tra Tor & I2P visita [qui](https://geti2p.net/en/comparison/tor)*
+
+## Integrare Tor con Ywallet su Smartphone
+
+Orbot è una rete privata virtuale (VPN) gratuita progettata per gli smartphone che indirizza il traffico di tutte le applicazioni del tuo dispositivo attraverso la rete Tor.
+
+Segui queste istruzioni qui sotto per connettere Tor al wallet Zcash *(Ywallet)*:
+
+1.  Scarica e installa *Orbot* dall'app store.
+
+2.  Dopo l'installazione, apparirà un messaggio di benvenuto. Prosegui fino alla pagina principale di *Orbot* e clicca su *'Tor Enabled Apps'.*              
+
+3. Questo aprirà una pagina sullo schermo che mostra le applicazioni compatibili con Tor. Cerca l'app *Ywallet* e assicurati che sia selezionata.
+
+4. Apparirà una richiesta di connessione per configurare una VPN, che permetterà a *Orbot* di monitorare il traffico di rete. *Orbot* si inizializzerà una volta approvata questa autorizzazione. 
+
+5. Controlla la barra delle applicazioni o la pagina principale di Orbot per verificare che Tor sia in esecuzione; questo è confermato quando vedi 'Connected to the Tor network'.
+
+* Per il video tutorial guarda [qui](https://drive.google.com/file/d/12ODTLrjgSzYFeAOTrv-P9LvfBVOvrSXK/view?usp=sharing)
+
+*Nota: Se Tor è bloccato dalla tua rete mobile, puoi usare un Bridge Server come modo alternativo per connetterti.*
+
+
+## Come configurare un wallet Zcash con Torbot su PC/Desktop
+
+## Supporto Tor in Zcash?
+
+* Il browser Tor può essere scaricato dal sito ufficiale, puoi accedere al link [qui](https://www.torproject.org/download/).
+
+ Il modo più comodo per installare Tor è tramite il Tor Browser Bundle. Se preferisci le installazioni headless, puoi optare per installare separatamente il daemon Tor. 
+
+*Nota: Per impostazione predefinita, il Tor Browser bundle espone un listener SOCKS su tcp/9150 e il daemon Tor espone il listener SOCKS su tcp/9050.*
+
+* Fai riferimento alle [istruzioni](https://support.torproject.org/apt/) di installazione specifiche per il tuo sistema operativo fornite dal Tor Project.
+
+## Installare il wallet Zcashd
+
+Zcashd è il wallet ufficiale full-node basato su linux che viene aggiornato e mantenuto dagli sviluppatori core della Electric Coin Co. È pensato per gli utenti che potrebbero voler effettuare mining e validare le transazioni zcash, oltre che inviare e ricevere Zcash.
+
+* Il sito ufficiale per scaricare il wallet Zcashd si trova [qui](https://electriccoin.co/zcashd/) 
+
+* Installa il wallet: Link al video tutorial [qui](https://www.youtube.com/watch?v=hTKL0jPu7X0) fornito dagli sviluppatori del wallet Zcash.
+
+##  Eseguire Zcashd tramite Tor 
+
+* Per configurare Zcashd in modo che usi il proxy SOCKS di Tor, puoi aggiungere l'argomento da riga di comando -proxy al comando del daemon.
+
+ Per esempio:
+
+  $ zcashd -proxy=127.0.0.1:9050
+      
+In alternativa, aggiungi la seguente riga al file zcash.conf:
+
+  proxy=127.0.0.1:9050
+
+Affinché le modifiche alla configurazione abbiano effetto, si consiglia di riavviare zcashd.
+
+Nota che questo presuppone che venga usato il daemon Tor. Nel caso in cui si usi il Tor Browser Bundle, sostituisci 9050 con 9150.
+
+Inoltre, puoi aggiungere l'argomento da riga di comando -listenonion per fare in modo che il daemon generi un indirizzo .onion al quale il tuo nodo può essere raggiunto.

--- a/translations/it/site/Privacy_Tools/VPN_and_DVPN.md
+++ b/translations/it/site/Privacy_Tools/VPN_and_DVPN.md
@@ -1,0 +1,81 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Privacy_Tools/VPN_and_DVPN.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# VPN e dVPN
+
+Nell'era digitale, mantenere la privacy e la sicurezza online è di fondamentale importanza. Le reti private virtuali (VPN) e le VPN decentralizzate (dVPN) svolgono un ruolo cruciale nel proteggere le tue attività e i tuoi dati online. Questa pagina wiki esplora le principali differenze tra le VPN tradizionali e le emergenti dVPN, le considerazioni di sicurezza nella scelta di una VPN, e un elenco di servizi VPN che accettano la criptovaluta orientata alla privacy, Zcash.
+
+# Qual è la differenza?
+
+__Reti private virtuali (VPN)__: le VPN tradizionali creano un tunnel sicuro e cifrato tra il tuo dispositivo e un server remoto controllato dal provider VPN. Questo tunnel nasconde le tue attività online da occhi indiscreti, come hacker, ISP o agenzie governative. Le VPN sono ampiamente utilizzate per scopi come la navigazione anonima, l'accesso a contenuti soggetti a restrizioni geografiche e la protezione dalle minacce informatiche.
+
+![image223](https://raw.githubusercontent.com/ZecHub/zechub/main/site/Privacy_Tools/assets/image-223.png)
+
+
+__VPN decentralizzate (dVPN)__: al contrario, le dVPN sfruttano la blockchain e la tecnologia peer-to-peer per creare una rete decentralizzata di nodi. Il traffico degli utenti viene instradato attraverso questi nodi, rendendo difficile per qualsiasi singola entità monitorare o controllare l'intera rete. Le dVPN sono in genere più resistenti alla censura, poiché non esiste un'autorità centralizzata che sovrintende alla rete. Sono particolarmente adatte agli utenti che cercano una privacy e una sicurezza maggiori.
+
+![dvpn](https://raw.githubusercontent.com/ZecHub/zechub/main/site/Privacy_Tools/assets/dvpn.png)
+
+
+# Considerazioni di sicurezza nella scelta di una VPN
+
+Quando scegli un servizio VPN, è importante considerare i seguenti fattori di sicurezza:
+
+1. __Cifratura__: assicurati che la VPN usi protocolli di cifratura robusti come OpenVPN o WireGuard per proteggere i tuoi dati dall'intercettazione.
+
+2. __Politica no-log__: cerca provider che abbiano una rigorosa politica no-log, ovvero che non conservino registri delle tue attività online.
+
+3. __Posizioni dei server__: considera la distribuzione geografica delle posizioni dei server per accedere a contenuti da diverse regioni e ridurre al minimo la latenza.
+
+4. __Kill switch__: un kill switch disconnetterà la tua connessione internet se la connessione VPN cade, impedendo che i tuoi dati vengano esposti.
+
+5. __Privacy e giurisdizione__: informati sulle pratiche di privacy del provider VPN e sulla sua giurisdizione, poiché diversi paesi hanno leggi di conservazione dei dati differenti.
+
+6. __Protezione dalle fughe di dati__: assicurati che la VPN prevenga le fughe DNS e WebRTC per mantenere il tuo anonimato.
+
+7. __Prezzo e funzionalità__: valuta i costi e le funzionalità offerti dai diversi provider per trovarne uno che corrisponda alle tue esigenze e al tuo budget.
+
+# VPN che accettano Zcash
+
+Zcash (ZEC) è una criptovaluta progettata per una privacy avanzata, il che la rende una scelta privilegiata per chi cerca anonimato nelle proprie transazioni finanziarie. Sebbene non tutti i servizi VPN accettino direttamente Zcash, alcuni potrebbero accettare pagamenti in criptovaluta tramite servizi intermediari. Tuttavia, è essenziale verificare direttamente con il provider VPN per le opzioni di pagamento più aggiornate. Ecco alcuni servizi VPN noti per accettare pagamenti in criptovaluta:
+
+1. [__Mullvad VPN__](https://mullvad.net/en)
+   
+   Mullvad VPN è un servizio VPN molto apprezzato, noto per il suo forte impegno verso la privacy e la sicurezza degli utenti. È uno dei pochi provider VPN che accetta criptovalute, incluso 
+   Zcash, come metodo di pagamento. Le caratteristiche principali di Mullvad includono:
+
+   __Politica no-log__: Mullvad segue una rigorosa politica no-log, ovvero non memorizza alcun dato relativo alle tue attività online.
+
+   __Cifratura robusta__: il servizio impiega protocolli di cifratura robusti, incluso WireGuard, per proteggere i tuoi dati.
+
+   __VPN multi-hop__: Mullvad offre l'opzione di connessioni multi-hop, che instradano il tuo traffico attraverso più server per migliorare privacy e sicurezza.
+
+   __Bridge Mode__: dispone di una modalità bridge che può aiutare ad aggirare determinate misure di censura.
+
+   __Creazione di account anonima__: agli utenti viene assegnato un numero di account generato casualmente, eliminando la necessità di informazioni personali durante la registrazione.
+
+   __Pagamento in Zcash__: Mullvad accetta Zcash come opzione di pagamento, consentendo agli utenti di pagare l'abbonamento con maggiore privacy. Mullvad VPN.
+
+3. [__Nym VPN (dVPN)__](https://nymtech.net/)
+   
+   Nym VPN è una VPN decentralizzata (dVPN) che si concentra sul miglioramento della privacy e della sicurezza degli utenti attraverso una rete orientata alla privacy. Nym VPN funziona diversamente dalle VPN tradizionali 
+   utilizzando una mixnet, in cui il traffico degli utenti viene instradato attraverso una rete di nodi. Le caratteristiche chiave di Nym VPN includono:
+
+   __Decentralizzazione__: Nym VPN è decentralizzata e open-source, riducendo il rischio di controllo centrale e censura.
+
+   __Mixnet per la privacy__: il servizio instrada il traffico degli utenti attraverso una mixnet, rendendo difficile per qualsiasi singola entità monitorare o analizzare il traffico di rete.
+
+   __Gestione dei nodi__: gli utenti possono gestire nodi per contribuire alla rete e guadagnare ricompense, decentralizzando ulteriormente l'infrastruttura.
+
+   __Privacy robusta__: Nym VPN è progettata pensando alla privacy e non richiede agli utenti di fornire informazioni personali durante la creazione dell'account.
+
+## Altre VPN che supportano il pagamento in zcash:-
+
+ 3. [__ExpressVPN__](https://www.expressvpn.com/)
+ 4. [__NordVPN__](https://nordvpn.com/)
+ 5. [__CyberGhost__](https://www.cyberghostvpn.com/en_US/)
+ 6. [__Private Internet Access (PIA)__](https://www.privateinternetaccess.com/)
+
+Tieni presente che la disponibilità delle opzioni di pagamento in criptovaluta può cambiare, quindi è consigliabile controllare il sito web del provider VPN o contattare l'assistenza clienti per le informazioni più aggiornate sui metodi di pagamento accettati, incluso Zcash.

--- a/translations/it/site/Privacy_Tools/Web_Browsers.md
+++ b/translations/it/site/Privacy_Tools/Web_Browsers.md
@@ -1,0 +1,31 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Privacy_Tools/Web_Browsers.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# Browser web
+
+1. **Brave:** uno dei browser più importanti e sicuri sul mercato oggi. Blocca gli annunci e i tracker invasivi della privacy. Blocca l'archiviazione di dati di terze parti. 
+
+2. **Mulvad:** un browser web incentrato sulla privacy sviluppato in collaborazione tra Mullvad VPN e il Tor Project. È realizzato per ridurre al minimo il tracciamento e il fingerprinting
+
+3. **Tor:** questo browser blocca plugin come Flash, RealPlayer, QuickTime e altri: possono essere manipolati per rivelare il tuo indirizzo IP. Non consigliamo di installare add-on o plugin aggiuntivi nel browser Tor
+
+
+## Quali sono le considerazioni di sicurezza nella scelta di un browser web?
+
+Quando scegli un browser web ci sono alcune cose da tenere a mente: vulnerabilità di sicurezza ed exploit vengono solitamente scoperti con regolarità. Alcuni browser sono tracciabili in qualche modo, ma ci sono browser che consentono agli utenti di navigare in modo anonimo - il [browser Tor](https://www.torproject.org/download/) ad esempio. 
+
+**Fingerprinting**: se vuoi mantenere private cose come i software installati sulla tua macchina, la configurazione hardware e altro, considera di cercare un browser web che supporti la funzionalità di resistenza al fingerprinting. 
+
+**Test HTTPS**: un'altra considerazione di sicurezza da cercare quando si sceglie un browser web è il protocollo del test HTTPS, che aiuta a cifrare la connessione al sito web e nasconde cookie, URL e altri tipi di metadati sensibili. Con HTTPS, la connessione è cifrata e nessuna terza parte sulla rete può leggere i contenuti trasferiti tra il server e il tuo browser. 
+
+**Protezione dai cookie di tracciamento**: inoltre, una grande porzione delle pagine web nel world wide web ha tracker nascosti di terze parti; questi tracker leggono e scrivono cookie nel tuo browser. Questi cookie possono rappresentare una minaccia dannosa perché possono essere usati per tracciare la tua navigazione tra i siti web; per prevenire questo tracciamento, scegli un browser web che blocchi i cookie di navigazione sconosciuti.
+
+**Test di navigazione**: mentre navighi da una pagina web a un'altra, incontrerai molti link (alcuni sono link interni, mentre altri rimandano a un altro sito web). Quando clicchi su questi link, alcune API del browser consentono al primo sito di comunicare con il secondo sito. Per risolvere questo problema, scegli un browser web che impedisca ai siti web di condividere dati di tracciamento quando clicchi su un link. Quando scegli il browser che ritieni possa adattarsi alle tue esigenze, assicurati che fornisca solide funzionalità di privacy e funzionalità essenziali come ad blocker integrati e simili. Inoltre, molti di questi browser web supportano estensioni e add-on, e a volte queste estensioni possono comportare rischi di sicurezza: assicurati di installare sempre queste estensioni da un ecosistema sicuro o da fonti attendibili.
+ 
+## Integrazione del wallet Zcash nel browser Brave
+
+Il browser Brave sta aprendo la strada all'ecosistema web3. Come? Più di 2 milioni di domini unstoppable possono ora essere sfruttati per mostrare siti web decentralizzati. Con le solide funzionalità di sicurezza dei browser Brave, le persone possono esplorare Internet senza essere tracciate. Brave e Zcash stanno unendo le forze per portare nuovi strumenti di privacy nell'ecosistema Web3. Per maggiori vantaggi, Brave si integrerebbe rapidamente con il protocollo Zcash tramite il wallet cripto integrato di Brave per rivoluzionare le transazioni cripto - questa integrazione consentirebbe agli utenti di archiviare, inviare e ricevere ZEC in modo sicuro e molto facile, oltre ad altre criptovalute. La collaborazione tra il browser web Brave e Zcash cambierebbe davvero le regole del gioco, poiché gli utenti avranno un maggiore controllo sulla loro attività Web3. 
+
+Un altro fatto intrigante sull'integrazione tra il browser Brave e Zcash è la funzionalità di messaggistica privata e decentralizzata; il team di Brave, ECC e della Filecoin Foundation sta aprendo la strada a una funzionalità basata sulla privacy nel browser Brave - questa collaborazione mira a offrire messaggi privati e la trasmissione di contenuti multimediali tramite il protocollo Zcash. Qui, l'Interplanetary File System (IPFS) avrà un ruolo essenziale nell'offrire una capacità di archiviazione sicura per i contenuti cifrati.

--- a/translations/it/site/Research/Dash_Zcash_Orchard_Integration.md
+++ b/translations/it/site/Research/Dash_Zcash_Orchard_Integration.md
@@ -1,0 +1,180 @@
+---
+published: 2026-04-14
+---
+
+<a href="https://github.com/zechub/zechub/edit/main/site/Research/Dash_Zcash_Orchard_Integration.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Integrazione di Zcash Orchard in Dash
+
+
+
+## Introduzione
+
+Nel febbraio 2026, la rete Dash ha annunciato l'integrazione del pool schermato Orchard di Zcash nella catena Dash Evolution. Questo ha segnato una delle collaborazioni cross-chain sulla privacy più significative nello spazio delle criptovalute, poiché Dash ha adottato la crittografia a conoscenza zero all'avanguardia di Zcash per completare il proprio modello di privacy basato su CoinJoin. L'integrazione conferma la posizione di Zcash come leader nella tecnologia della privacy e apre un nuovo capitolo per la collaborazione cross-chain sulla privacy.
+
+Questo articolo spiega cos'è il protocollo Orchard, come Dash lo sta implementando, perché è importante per entrambi gli ecosistemi e cosa segnala per il panorama più ampio delle privacy coin.
+
+
+## Cos'è il protocollo Zcash Orchard?
+
+Orchard è il pool schermato più avanzato di Zcash, attivato con il Network Upgrade 5 (NU5) a metà del 2022. Rappresenta il culmine di anni di ricerca crittografica presso Electric Coin Company (ECC) e la comunità Zcash.
+
+### Tecnologia di base: Halo 2
+
+Orchard è costruito sul sistema di prova **Halo 2**, un'implementazione zk-SNARK ad alte prestazioni scritta in Rust. Halo 2 ha introdotto due grandi innovazioni:
+
+- **Nessun trusted setup**: i precedenti pool schermati di Zcash (Sprout e Sapling) si basavano su cerimonie di calcolo multi-parte per generare i parametri crittografici. Se la casualità segreta (i cosiddetti "rifiuti tossici", o "toxic waste") di queste cerimonie non veniva distrutta correttamente, in teoria poteva essere usata per creare token schermati contraffatti. Halo 2 elimina interamente questo requisito attraverso una tecnica chiamata **ammortamento annidato** (nested amortization), che fa collassare insieme molteplici istanze di problemi difficili lungo cicli di curve ellittiche, in modo che le prove computazionali possano ragionare su sé stesse.
+
+- **Composizione ricorsiva delle prove**: una singola prova può attestare la correttezza di un numero praticamente illimitato di altre prove, comprimendo una grande quantità di calcolo in una forma compatta e verificabile. Questo è essenziale per la scalabilità e per gli aggiornamenti futuri.
+
+### Come funziona la privacy di Orchard
+
+In una transazione blockchain tradizionale, mittente, destinatario e importo sono tutti visibili on-chain. In una transazione schermata Orchard, le prove a conoscenza zero garantiscono matematicamente che:
+
+- La transazione è valida (gli input sono uguali agli output, nessun token viene creato dal nulla)
+- Il mittente dispone di fondi sufficienti
+- Non si è verificato alcun double-spending
+
+Tutto questo è verificato **senza rivelare** chi ha inviato i fondi, chi li ha ricevuti o quanto è stato trasferito. Come ha affermato il CTO di Dash, Samuel Westrich, invece di offuscare le tracce delle transazioni attraverso il mixing, le prove a conoscenza zero garantiscono che "non ci sia alcuna traccia da cui partire".
+
+### Le Actions sostituiscono input e output
+
+Orchard ha introdotto il concetto di **Actions** per sostituire il tradizionale modello input/output. Ogni Action raggruppa insieme una spesa e un output, riducendo la quantità di metadati di transazione che vengono divulgati. Questo rende più difficile per gli osservatori condurre analisi del traffico o attacchi euristici sulle transazioni schermate.
+
+
+## Cos'è la catena Dash Evolution?
+
+Per comprendere l'integrazione, è importante comprendere l'architettura di Dash.
+
+### Architettura a doppia catena
+
+Dash opera con un sistema a doppia catena:
+
+- **Dash Core (Layer 1)**: la blockchain proof-of-work originale, protetta da miner e masternode. È qui che vive il token nativo DASH e dove opera il mixing per la privacy CoinJoin.
+
+- **Dash Evolution (Platform Layer)**: una catena secondaria costruita accanto a Core che supporta funzionalità di smart contract, applicazioni decentralizzate e gestione dell'identità. Evolution usa un meccanismo di consenso Tendermint modificato chiamato **Tenderdash** ed è validata dalle Evolution Masternode che proteggono entrambe le catene contemporaneamente.
+
+La catena Evolution è il luogo in cui avviene l'integrazione di Orchard. Questa scelta progettuale consente a Dash di introdurre privacy crittografica avanzata senza modificare la collaudata catena Core.
+
+
+## Come funziona l'integrazione
+
+### Architettura tecnica
+
+Dash ha effettuato il fork della crate open-source Orchard in Rust di Zcash e l'ha adattata alla catena Evolution. L'integrazione segue una struttura a **pool di credito protetto** (protected credit pool):
+
+1. **Lock**: gli utenti bloccano i loro asset DASH su Dash Core
+2. **Mint**: token "Credits" ancorati vengono coniati sulla catena Evolution
+3. **Transfer**: i Credits possono essere trasferiti in modo anonimo usando le prove a conoscenza zero di Orchard, con mittente, destinatario e importo completamente schermati
+4. **Burn**: i token vengono bruciati su Evolution per recuperare gli asset DASH sottostanti su Core
+
+Questo modello è analogo a un peg bidirezionale tra le catene Core ed Evolution, ma con piena privacy a conoscenza zero per le transazioni sul lato Evolution.
+
+### Rollout per fasi
+
+L'integrazione è pianificata in due fasi:
+
+**Fase 1 (marzo 2026, in attesa degli audit di cybersicurezza):**
+- Distribuire i pool schermati Orchard sulla catena Evolution
+- Supportare i trasferimenti schermati di base di Dash Credits tra le parti
+- Completamento di audit di sicurezza indipendenti prima dell'attivazione sulla mainnet
+
+**Fase 2 (aggiornamenti successivi):**
+- Estendere le funzionalità di privacy di Orchard agli **asset del mondo reale tokenizzati (RWA)** emessi su Evolution
+- Abilitare operazioni che preservano la privacy per la DeFi e le interazioni con gli smart contract sulla piattaforma
+- Portare la schermatura a conoscenza zero a qualsiasi tipo di token, non solo alla valuta nativa
+
+### Sincronizzazione mobile
+
+Una barriera all'usabilità storicamente impegnativa per i sistemi di privacy a conoscenza zero è stata la lentezza della sincronizzazione sui dispositivi mobili. Il team di Dash ha indicato che l'architettura di Evolution potrebbe consentire una **sincronizzazione mobile più rapida dei dati schermati**, il che rappresenterebbe un miglioramento significativo per gli utenti di tutti i giorni. Questo lavoro è attualmente in fase di validazione.
+
+
+## Perché è importante: CoinJoin vs. Orchard
+
+### La privacy esistente di Dash: CoinJoin
+
+Dash ha tradizionalmente offerto privacy attraverso **CoinJoin**, un meccanismo di mixing non custodiale. CoinJoin funziona combinando gli input e gli output delle transazioni di più utenti in un'unica transazione, rendendo difficile (ma non impossibile) per gli osservatori tracciare quali input corrispondano a quali output.
+
+CoinJoin ha dei limiti:
+
+- **Opt-in**: gli utenti devono abilitare manualmente il mixing nel wallet Dash Core
+- **Offuscamento, non cifratura**: le tracce delle transazioni esistono comunque on-chain; sono solo più difficili da seguire
+- **Soggetto ad analisi**: con risorse e dati sufficienti, le società di chain analysis hanno dimostrato la capacità di de-anonimizzare alcune transazioni CoinJoin
+- **Insieme di anonimato limitato**: la privacy fornita dipende da quanti altri utenti stanno effettuando il mixing contemporaneamente
+
+### L'avanzamento qualitativo di Orchard
+
+Orchard rappresenta un approccio fondamentalmente diverso alla privacy:
+
+- **Garanzie crittografiche**: la privacy è imposta dalla matematica, non dal comportamento della folla
+- **Nessuna traccia**: non ci sono tracce di transazioni da analizzare perché mittente, destinatario e importo non vengono mai scritti sulla catena in chiaro
+- **Insieme schermato più ampio**: tutte le transazioni Orchard condividono un pool schermato comune, aumentando l'insieme di anonimato
+- **Nessun trusted setup**: il sistema di prova Halo 2 elimina qualsiasi assunzione residua di fiducia
+
+L'integrazione non sostituisce CoinJoin su Dash Core. Orchard fornisce invece un **livello crittografico complementare** sulla catena Evolution, offrendo agli utenti di Dash una scelta tra il mixing leggero di CoinJoin e la privacy matematica delle prove a conoscenza zero.
+
+
+## Cosa significa per Zcash
+
+L'integrazione di Dash comporta implicazioni significative per l'ecosistema Zcash.
+
+### Validazione della tecnologia Zcash
+
+Quando un altro importante progetto di criptovaluta adotta lo stack crittografico di Zcash, ciò serve da validazione esterna della maturità, della sicurezza e della qualità progettuale della tecnologia. Samuel Westrich, CTO di Dash Core Group, ha osservato:
+
+> "Sono personalmente interessato alla tecnologia delle prove ZK e ai suoi usi nella blockchain fin dai primi paper del 2014. Negli anni abbiamo tenuto d'occhio Zcash. Con l'ultima release della crate Orchard, abbiamo ritenuto che fosse un buon momento per esaminare l'aggiunta della tecnologia alla nostra più recente catena Evolution."
+
+Ha aggiunto che "Orchard è open source e maturo; integrarlo è stato più facile del previsto".
+
+### Espansione dell'ecosistema
+
+La crate Orchard è rilasciata sotto le licenze open-source MIT e Apache 2.0. Ogni integrazione da parte di un altro progetto espande la base di utenti dei primitivi crittografici di Zcash, aumenta il numero di sviluppatori che conoscono il codice e porta potenzialmente a miglioramenti a monte che beneficiano Zcash stesso.
+
+### Riconoscimento cross-chain
+
+L'ingresso di Dash nell'elenco dei progetti che usano Halo 2 e Orchard pone Zcash accanto a progetti come Filecoin, Ethereum e diverse soluzioni zkRollup che hanno adottato o esplorato la tecnologia Halo 2. Questo ecosistema in crescita rafforza gli effetti di rete attorno alla ricerca sulla privacy di Zcash.
+
+### Zcash come standard per la privacy
+
+L'integrazione posiziona la tecnologia di Zcash come emergente **standard di settore per la privacy della blockchain**, proprio come TLS è diventato lo standard per la cifratura del web. Quando progetti concorrenti scelgono di adottare gli strumenti di Zcash invece di costruire i propri, ciò testimonia la qualità e l'affidabilità della scienza sottostante.
+
+
+## Impatto più ampio sulle criptovalute incentrate sulla privacy
+
+### La narrativa della privacy
+
+L'integrazione arriva in un periodo di accresciuto interesse per la tecnologia della privacy in tutto il settore delle criptovalute. Le privacy coin hanno registrato impennate di oltre l'80% all'inizio del 2026, spinte dalla crescente consapevolezza della sorveglianza finanziaria e del valore della privacy transazionale.
+
+### Contesto normativo
+
+L'integrazione arriva anche sullo sfondo di una pressione normativa sui token della privacy. Nel gennaio 2026, la Financial Services Authority (DFSA) di Dubai ha vietato agli exchange di criptovalute regolamentati di vendere token della privacy, tra cui ZEC e XMR, ai nuovi utenti. Sebbene il divieto non impedisca ai cittadini di detenere questi token, evidenzia la tensione tra la privacy degli utenti e la conformità normativa.
+
+Le integrazioni cross-chain sulla privacy come Dash-Orchard potrebbero influenzare il modo in cui i regolatori considerano la tecnologia della privacy. Il fatto che le funzionalità di privacy possano essere adottate come componenti modulari da qualsiasi blockchain suggerisce che vietare token specifici possa essere meno efficace rispetto al confrontarsi con la tecnologia sottostante.
+
+### Partnership future
+
+L'integrazione di Dash crea un precedente per altri progetti blockchain. Se Orchard può essere distribuito con successo su una catena con meccanismi di consenso e architettura diversi, ciò dimostra che la tecnologia della privacy di Zcash è realmente portabile. Questo potrebbe incoraggiare ulteriori adozioni in tutto l'ecosistema, tra cui:
+
+- Reti Layer-2 in cerca di funzionalità di privacy
+- Protocolli DeFi che vogliono schermare i dati delle transazioni degli utenti
+- Piattaforme di asset del mondo reale che richiedono trasferimenti confidenziali
+- Blockchain aziendali che necessitano di una privacy conforme alle normative
+
+
+## Conclusione
+
+L'integrazione del protocollo Orchard di Zcash nella catena Evolution di Dash rappresenta una pietra miliare nella collaborazione cross-chain sulla privacy. Per Dash significa un salto qualitativo dal modello di offuscamento di CoinJoin alle garanzie di privacy crittografica di Orchard. Per Zcash conferma che gli anni di ricerca su Halo 2 e sul pool schermato Orchard hanno prodotto una tecnologia abbastanza robusta e matura da essere adottata da altri grandi progetti.
+
+Soprattutto, questa integrazione segnala che la privacy nelle criptovalute non è una competizione a somma zero tra progetti. La tecnologia della privacy open-source trae beneficio da un'adozione più ampia, da una revisione più estesa e da uno sviluppo condiviso. Man mano che Orchard di Zcash si diffonde nell'ecosistema blockchain, l'intero spazio si avvicina a un futuro in cui la privacy finanziaria è un'impostazione predefinita, non un'eccezione.
+
+
+## Approfondimenti
+
+- [Documentazione di Halo 2](https://zcash.github.io/halo2/)
+- [Zcash Orchard Crate (GitHub)](https://github.com/zcash/orchard)
+- [Repository GitHub di Halo 2](https://github.com/zcash/halo2)
+- [Documentazione della piattaforma Dash Evolution](https://docs.dash.org/en/stable/)
+- [Cointelegraph: Dash Integrates Zcash Privacy Pool](https://cointelegraph.com/news/dash-integrates-z-cash-orchard-privacy)
+- [HackerNoon: Dash Brings Zcash Orchard Privacy to Evolution Chain](https://hackernoon.com/dash-brings-zcash-orchard-privacy-to-evolution-chain-for-shielded-transactions)

--- a/translations/it/site/Research/Namada_Privacy_and_Best_Practices.md
+++ b/translations/it/site/Research/Namada_Privacy_and_Best_Practices.md
@@ -1,0 +1,102 @@
+---
+published: 2025-08-02
+---
+
+<a href="https://github.com/Zechub/zechub/edit/main/site/Research/Namada_Best_Practices.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+![Namada Logo](https://raw.githubusercontent.com/ZecHub/zechub-wiki/main/public/nam.png)
+
+# Best practice per la privacy su Namada
+
+> Indicazioni pratiche e attuabili per ottenere la massima privacy su Namada - e per capire esattamente dove finiscono le sue protezioni.
+
+**La privacy è un diritto fondamentale.** Namada è stata creata appositamente per proteggerla attraverso una crittografia a conoscenza zero avanzata. Questa guida sintetizza le pratiche più efficaci adottate da utenti e sviluppatori attenti alla privacy.
+
+---
+
+## Come Namada protegge la tua privacy
+
+Namada è una blockchain sovrana e privacy-first che nasconde gli indirizzi dei wallet, gli importi delle transazioni e i saldi usando le **prove a conoscenza zero (zk-SNARKs)**.
+
+### Funzionalità di privacy principali
+
+- **Transazioni schermate** - Nascondono completamente mittente, destinatario e importi.
+- **Multi-Asset Shielded Pool (MASP)** - Trasferimenti, swap e bridging privati su qualsiasi asset.
+- **Privacy cross-chain** - Bridging schermato tramite IBC (il supporto per Ethereum e Solana è in arrivo).
+- **Ricompense Shielded Yield** - Guadagna token NAM semplicemente schermando le transazioni.
+- **Commissioni basse** - Privacy robusta senza sacrificare l'usabilità.
+
+---
+
+## Limitazioni importanti
+
+Anche la privacy on-chain più solida può essere compromessa dal comportamento dell'utente o da fattori off-chain.
+
+<div class="border-l-4 border-yellow-400 bg-yellow-400/10 p-6 my-8 rounded-r-xl text-sm">
+
+**Namada NON protegge da:**
+
+- Connessione senza VPN o Tor (il tuo indirizzo IP è esposto)
+- Riutilizzo ripetuto degli indirizzi schermati
+- Esecuzione di transazioni trasparenti (non schermate)
+- Collegamento del tuo indirizzo Namada ai social media o all'identità del mondo reale
+- Uso di exchange KYC centralizzati per depositi o prelievi
+
+</div>
+
+---
+
+## Best practice per la massima privacy
+
+### 1. Principi generali
+- Per impostazione predefinita usa le **transazioni schermate** per ogni operazione.
+- Non riutilizzare mai gli indirizzi schermati per scopi diversi.
+- Evita di mescolare attività schermate e trasparenti nella stessa sessione.
+
+### 2. Bridging degli asset
+- Usa un indirizzo trasparente dedicato **solo** per i bridge in entrata.
+- Scherma immediatamente gli asset dopo il bridging in entrata.
+- Riduci al minimo il bridging in uscita da Namada quando possibile.
+
+### 3. MASP (Multi-Asset Shielded Pool)
+- Tieni tutti gli asset all'interno del MASP per impostazione predefinita.
+- Tratta il tuo saldo MASP come il tuo principale wallet privato.
+
+### 4. View Key
+- Condividi le viewing key **solo** con parti di cui ti fidi pienamente.
+- Non pubblicare né postare mai pubblicamente le viewing key.
+
+### 5. Igiene delle transazioni
+- Randomizza i tempi e gli importi tra le transazioni.
+- Raggruppa più transazioni quando possibile.
+- Evita di inviare importi tondi o facilmente identificabili.
+
+### 6. Sicurezza operativa
+- Usa sempre una **VPN** (idealmente Tor) quando interagisci con wallet o dApp.
+- Non condividere mai screenshot che contengano indirizzi o saldi.
+- Usa wallet separati per attività diverse (trading, donazioni, uso personale).
+
+---
+
+## Checklist estesa per la privacy
+
+1. **Scherma sempre per primo** - sposta gli asset nel MASP prima di effettuare transazioni.
+2. **Ruota gli indirizzi schermati** regolarmente per casi d'uso diversi.
+3. **Preleva direttamente verso indirizzi schermati** dagli exchange quando possibile.
+4. **Varia i tempi delle transazioni** per spezzare schemi identificabili.
+5. **Usa hardware wallet** per le quantità maggiori.
+6. **Mantieni il software aggiornato** - esegui sempre l'ultimo client Namada.
+7. **Proteggi il tuo dispositivo** con cifratura robusta e gestori di password.
+8. **Sii estremamente prudente** riguardo alle fughe di metadati in chat o log pubblici.
+
+---
+
+## Contribuisci
+
+Hai ulteriori best practice o feedback?  
+[Unisciti alla discussione su Discord](https://discord.gg/srC76aE6)
+
+---
+*Ultimo aggiornamento: marzo 2026*

--- a/translations/it/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/it/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -1,0 +1,117 @@
+---
+published: 2023-12-07
+---
+
+![CBDC](https://raw.githubusercontent.com/ZecHub/zechub-wiki/main/public/cbdc.webp)
+# Svelando il lato oscuro: navigare l'odissea delle Central Bank Digital Currency (CBDC) tra le ombre finanziarie
+Di : [**Abhishek Tiwari**]
+
+Nel panorama in continuo mutamento della finanza globale si sta aprendo un nuovo capitolo, uno che solleva più di qualche perplessità. Le Central Bank Digital Currency (CBDC) emergono non solo come protagoniste, ma come potenziali agenti di sconvolgimento finanziario, gettando ombre sulla comprensione tradizionale del denaro e suscitando preoccupazioni in merito a privacy, sorveglianza e ingerenza governativa.
+
+Immagina un mondo in cui le transazioni finanziarie lasciano una traccia indelebile nel regno digitale, un mondo introdotto dalle CBDC: innovazioni che promettono una rivoluzione ma che segnalano anche una potenziale distopia finanziaria.
+
+## L'enigma delle CBDC: uno sguardo dietro il sipario digitale
+
+Al cuore di questa metamorfosi digitale si trova il concetto di CBDC, un concetto che, per quanto intrigante, fa scattare campanelli d'allarme. Immagina la valuta della tua nazione trasformata nel codice binario del regno digitale, dove la banca centrale assume il ruolo centrale in una sinfonia di controllo finanziario senza precedenti. Non più confinate alla fisicità di banconote e monete, le CBDC diventano forze dinamiche, plasmando un futuro guastato da timori di abuso di potere governativo.
+
+Ma questo viaggio non è privo di scettici. Mentre le CBDC si sforzano di abbattere le barriere, sorge la domanda: sono rifugi inclusivi o cavalli di Troia che compromettono la privacy finanziaria? La promessa di inclusività diventa un'arma a doppio taglio, poiché le ombre delle transazioni tracciabili incombono minacciose, lasciando gli individui esposti sotto i riflettori digitali.
+
+Mentre attraversiamo questo terreno digitale, alcune CBDC mostrano non solo intelligenza ma un potenziale vaso di Pandora. Possono eseguire contratti, automatizzare transazioni finanziarie e danzare al ritmo del denaro programmabile. Sorge la domanda: è un faro di progresso o un pericoloso salto in un territorio finanziario inesplorato?
+
+## Le sfide: navigare un campo minato di difetti finanziari
+
+Eppure, come in ogni grande viaggio, le sfide abbondano e le ombre proiettate dalle CBDC si fanno più marcate. La trasparenza delle transazioni minaccia l'essenza stessa della privacy. Man mano che le transazioni diventano tracciabili, emerge una nuova era di sorveglianza finanziaria, lasciando gli individui vulnerabili a uno scrutinio ingiustificato.
+
+Nel regno della cybersicurezza, un eroe non celebrato diventa un protagonista riluttante. La vulnerabilità delle CBDC alle minacce informatiche diventa una trama secondaria della nostra narrazione. Mentre ci imbarchiamo in questa odissea digitale, la posta in gioco è alta e la custodia dei dati personali diventa fondamentale.
+
+E che dire delle strutture bancarie tradizionali? La stabilità che conosciamo da decenni affronta potenziali sconvolgimenti, e le fondamenta delle banche tradizionali tremano sulla scia delle CBDC. Man mano che le Banche Centrali diventano concorrenti diretti dei prestatori di servizi di pagamento, le banche potrebbero perdere reddito. Allo stesso modo, una nuova forma di opportunità di investimento potrebbe ridurre la domanda di depositi da parte dei consumatori. A sua volta, questo potrebbe ridurre i prestiti bancari all'economia complessiva e quindi la crescita economica. È una danza delicata tra l'innovazione e il timore di un'instabilità finanziaria, dove l'esito resta incerto.
+
+Il Central Bank Digital Currency Tracker, appena lanciato dalla HRF, profila ogni paese che compie passi verso una CBDC e collega queste mosse, in una pagina web, a informazioni sul rispetto dei diritti umani e sulla corruzione di quel paese. Nel compilare il tracker, la HRF ha rilevato che "le dittature sono in prima linea nell'adozione delle CBDC". La HRF stima che 3,7 miliardi di persone – il 46% della popolazione mondiale – vivano sotto dittature che sperimentano le CBDC.
+
+Le CBDC sono vulnerabili ai blackout elettrici e all'insufficiente connettività internet 
+
+Implementare le CBDC diventa la missione del nostro eroe, un viaggio irto di sfide tecniche, normative e logistiche. L'invito a creare una valuta digitale non è solo un'innovazione, ma un potenziale invito all'ingerenza e alla manipolazione governativa all'interno del sistema finanziario.
+
+## In viaggio tra le nazioni: storie di CBDC svelate
+
+__Cina: Digital Currency Electronic Payment (DCEP)__
+
+
+![DCEP](https://forkast.news/wp-content/uploads/2020/08/dcep-featured.jpg)
+
+Nelle strade distopiche della Cina, il Digital Currency Electronic Payment (DCEP) si dispiega non come una meraviglia, ma come un presagio di controllo sociale con il proprio insieme di ombre finanziarie minacciose. Le transazioni di tutti i giorni pulsano di vita, grazie al denaro programmabile e al fascino delle funzionalità offline.
+
+**Caratteristiche:**
+Il DCEP va oltre l'essere un surrogato digitale, progettato per facilitare senza soluzione di continuità le transazioni quotidiane. Tuttavia, le ombre di una sorveglianza accresciuta sollevano preoccupazioni sulla privacy. Il delicato equilibrio tra il progresso tecnologico e i diritti individuali diventa motivo di scrutinio, presagendo un futuro in cui le libertà personali vengono sacrificate.
+
+**Precedenti:**
+La storia cinese di opacità finanziaria e di ingerenza governativa nel settore bancario è uno sfondo oscuro alla narrazione che si dispiega. Il potenziale del DCEP di estendere la portata del governo nelle transazioni finanziarie personali aggiunge un ulteriore motivo di preoccupazione, dato il passato del paese nel reprimere il dissenso e nel violare le libertà individuali.
+
+
+__Stati Uniti: Digital Dollar Project__
+
+![Digital Dollar](https://www.ledgerinsights.com/wp-content/uploads/2020/03/digital-dollar-CBDC.jpg)
+
+Nei vasti e desolanti paesaggi degli Stati Uniti, il Digital Dollar Project emerge non come un faro di progresso, ma come una testimonianza di efficienza e inclusività, sebbene con la sua dose di incertezze. Iniziativa del settore privato, mira a ridisegnare il panorama finanziario in una narrazione tinta di sfumature di controllo aziendale.
+
+**Caratteristiche:**
+Efficienza e inclusività occupano il centro della scena in questa narrazione, ma le ombre delle sfide normative e della sicurezza dei dati incombono minacciose, gettando dubbi sul potenziale impatto del progetto sulle libertà individuali. Discussioni legislative in corso segnano la narrazione, ma l'esito resta incerto in una storia offuscata dall'ambiguità.
+
+**Precedenti:**
+Gli USA hanno una storia complessa di regolamentazione finanziaria, con frequenti dibattiti su privacy e intervento governativo. Il successo del Digital Dollar Project dipende da confini chiari definiti da un quadro normativo ben definito, un'aspirazione che appare sempre più sfuggente in un mondo dominato dagli interessi aziendali.
+
+__Svezia: E-Krona__
+
+![E-Krona](https://www.paymentscardsandmobile.com/wp-content/uploads/2018/10/ekrona_logo.png)
+
+Mentre attraversiamo i paesaggi desolati della Svezia, l'E-Krona si dispiega come una narrazione di adattabilità, ma non senza le sue insidie finanziarie. È un'evoluzione digitale incentrata sul mantenimento dell'accesso alla valuta in una società senza contanti, che ritrae una società priva delle familiari comodità del contante fisico.
+
+**Caratteristiche:**
+I riflettori dell'E-Krona sono puntati sull'accessibilità, con l'aspirazione di essere un'alternativa resiliente al contante fisico in un mondo in cui l'anonimato è scarso. Tuttavia, sorgono delle sfide, specialmente nelle aree rurali, e persistono le preoccupazioni sulla privacy, gettando un'ombra sulla potenziale erosione delle libertà personali.
+
+**Precedenti:**
+Il passato svedese di innovazione finanziaria è oscurato dalle potenziali sfide dell'integrare una valuta digitale nelle strutture esistenti. L'atto di equilibrio tra progresso e protezione diventa sempre più precario in una narrazione intrisa di ombre.
+
+__Unione Europea: CBDC dell'Eurozona__
+
+![Eurozone](https://upload.wikimedia.org/wikipedia/commons/c/cb/Logo_European_Central_Bank.svg)
+
+Il nostro viaggio si conclude nel mosaico di nazioni che formano l'Unione Europea, dove la CBDC dell'Eurozona cerca non di completare il contante fisico, ma di tracciare un percorso di controllo e conformità in un cupo panorama finanziario.
+
+**Caratteristiche:**
+La narrazione della CBDC dell'Eurozona ruota attorno al completamento del contante fisico, al miglioramento dei pagamenti transfrontalieri e alla promozione dell'innovazione finanziaria - ideali che mascherano un intento più oscuro di controllo centralizzato. L'armonizzazione normativa diventa un punto focale, garantendo un'esperienza utente coerente e sicura, ma a costo dell'autonomia finanziaria individuale.
+
+**Precedenti:**
+I diversi panorami normativi tra gli Stati membri dell'UE pongono sfide per un'integrazione senza soluzione di continuità, dipingendo il quadro di una distopia finanziaria frammentata. Navigare queste sfide diventa cruciale per un'esperienza utente sicura e coerente, anche se l'ombra del controllo centralizzato incombe minacciosa.
+
+**Aspetti rassicuranti:**
+La sicurezza della CBDC dell'Eurozona risiede nel navigare con successo le sfide normative. Se raggiunge l'armonizzazione tra gli Stati membri dell'UE, può contribuire a un'esperienza utente sicura e coerente nel panorama finanziario digitale
+
+## Il lato umano della saga digitale: rischi e diritti nell'ombra
+
+Mentre la nostra esplorazione critica dell'odissea digitale si dispiega, emerge una narrazione parallela: il lato umano della saga digitale. La privacy, un tempo diritto sacro, diventa un personaggio della nostra storia, affrontando un'erosione di fronte alle transazioni tracciabili e al timore di una sorveglianza ingiustificata.
+
+La sorveglianza governativa, un tempo concetto lontano, diventa un potenziale antagonista. L'uso improprio della tecnologia CBDC potrebbe concedere un accesso senza precedenti alle transazioni finanziarie dei cittadini, una narrazione che ricorda gli incubi orwelliani che minacciano il diritto alla privacy finanziaria.
+
+L'inclusione finanziaria, un tempo faro di speranza, affronta le ombre di una potenziale discriminazione. L'uso improprio delle CBDC potrebbe portare a un accesso selettivo, violando i principi di parità di trattamento e di inclusività. È una trama secondaria che sfida l'essenza stessa della libertà finanziaria.
+
+![Flow](https://blog.digitalasset.com/hubfs/Imported_Blog_Media/futureofCBDC-2.png)
+
+## Risorse: una mappa per l'esploratore digitale
+
+Per chi si avventura nel territorio inesplorato delle CBDC, le risorse diventano la tua bussola.
+1. La Banca dei Regolamenti Internazionali ([BIS](https://www.bis.org/search/index.htm?globalset_q=cbdc))
+2. il Fondo Monetario Internazionale ([IMF](https://www.imf.org/en/About))
+3. Paper di ricerca ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+4. Riviste accademiche ([journal](https://www.bis.org/publ/work976.pdf))
+5. Articolo del C.E.I  ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
+
+Queste risorse offrono uno sguardo sul panorama in evoluzione, fornendo approfondimenti, ricerche e aggiornamenti sull'odissea digitale.
+
+## Conclusione: navigare le acque inesplorate con saggezza
+
+Mentre navighiamo le acque inesplorate, macchiate da difetti finanziari del passato e dall'ingerenza governativa, la nostra narrazione prende svolte inaspettate. Dalle strade vivaci della Cina ai sereni paesaggi della Svezia, dai campi di battaglia legislativi degli Stati Uniti agli sforzi coordinati dell'Unione Europea, l'odissea digitale è un arazzo intessuto di innovazione, sfide e narrazioni umane.
+
+Privacy, cybersicurezza e stabilità finanziaria diventano personaggi della nostra storia distopica, ciascuno con un ruolo cruciale nel plasmare la narrazione delle CBDC tra gli inquietanti spettri di difetti finanziari del passato e di una potenziale ingerenza governativa. Non è solo un viaggio di evoluzione digitale; è una ricerca di equilibrio, dove il progresso incontra la protezione, e le ombre dei difetti finanziari del passato e dell'intrusione governativa incombono minacciose.
+
+In questa odissea distopica, restiamo informati, poniamo domande penetranti e navighiamo con saggezza. Mentre esploriamo le acque inesplorate delle CBDC, macchiate da difetti finanziari del passato e da una potenziale ingerenza governativa, facciamo in modo che i nostri diritti, la nostra privacy e il nostro panorama finanziario restino sicuri e resilienti. Il futuro è digitale - imbarchiamoci in questo viaggio con mente aperta, cuore saggio e un occhio critico sulle ombre dei difetti finanziari del passato e dell'ingerenza governativa che potrebbero minacciare la nostra libertà finanziaria.

--- a/translations/it/site/Research/Social_Media_Data_Collection.md
+++ b/translations/it/site/Research/Social_Media_Data_Collection.md
@@ -1,0 +1,85 @@
+---
+published: 2023-10-23 
+---
+
+<a href="https://github.com/Zechub/zechub/edit/main/site/Research/Social_Media_Data_Collection.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# Raccolta dati sui social media
+
+Attualmente è difficile trovare una persona che non sia esposta alla portata dei social network. Sono diventati popolari per la loro facilità d'uso e per la loro velocità ed efficacia nel diffondere un messaggio.
+
+Sfortunatamente, questa stessa comodità ci ha anche resi, come utenti, poco attenti alla quantità di informazioni che le piattaforme di social media raccolgono su di noi e a ciò che possono farne, o a ciò che una terza parte malintenzionata potrebbe fare se vi accedesse.
+
+Di seguito, illustreremo i dati che alcune di queste piattaforme raccolgono su di noi, cosa ne fanno e perché questo potrebbe rappresentare un pericolo per la nostra privacy e, potenzialmente, per la nostra sicurezza personale o familiare.
+
+Discord
+-------
+
+Dobbiamo iniziare da Discord perché è l'app di comunicazione che usiamo "in casa."
+
+Discord è molto utile per gestire una grande comunità su un'ampia gamma di argomenti, ma è colpevole tanto quanto molte altre di trarre vantaggio dalle nostre informazioni personali.
+
+### Dati che Discord conserva
+
+Secondo la sua informativa sulla privacy, Discord raccoglie le seguenti informazioni su di noi:
+
+-   Messaggi di testo (incluse le bozze), messaggi vocali, immagini di copertina per le live, gli amici che aggiungi o gli utenti con cui interagisci, i giochi a cui giochi, i server o le comunità a cui sei iscritto, gli acquisti o le vendite che effettui tramite l'app, e le decisioni che prendi quando moderi i contenuti.
+
+Non conservano i tuoi video o il video delle tue live, anche se lasciano aperta la porta a cambiare questa decisione in futuro.
+
+Raccolgono inoltre automaticamente alcune informazioni, come l'indirizzo IP da cui ti connetti, il browser che usi e il tuo sistema operativo.
+
+### Come li usano
+
+La maggior parte delle cose che fanno con i nostri dati potrebbe essere considerata giustificabile, come migliorare l'esperienza utente, offrire un'esperienza più personalizzata e mantenere gli standard della comunità. Tuttavia, possono anche usare i tuoi dati per promuovere i loro servizi, e possono persino condividerne alcuni con terze parti per promuovere i loro servizi o analizzare la crescita aziendale.
+
+Affermano inoltre di poter usare le informazioni per fornirle a qualsiasi autorità che potrebbe richiederle tramite un'ordinanza del tribunale.
+
+Twitter
+-------
+
+Come Discord, Twitter conserva una buona quantità di informazioni sui suoi server. Salva anche i messaggi diretti, chi segui e con chi interagisci (post salvati, preferiti), e di fatto le sue politiche sono piuttosto simili, inclusa la condivisione dei tuoi dati con terze parti e autorità.
+
+Meta
+----
+
+Il gruppo di applicazioni di Meta, che include Facebook, Instagram e ora Threads, va ancora oltre, con un elenco talmente lungo, solo delle informazioni che fornisci, che sarebbe troppo lungo da dettagliare. Include tutti i tuoi post, comprese le note vocali, le foto scattate usando la funzione "fotocamera" del tuo dispositivo o la sua galleria, gli annunci che vedi, il tempo che trascorri a guardarli, e persino quelli che scegli di ignorare. Include i metadati dei tuoi messaggi, come posizione, data, ora e dispositivo. Include anche il tempo che trascorri su ciascuna delle diverse funzioni dell'app, e, se la legge non ti protegge, le tue convinzioni religiose, le tue convinzioni filosofiche, il tuo orientamento sessuale, e persino l'appartenenza sindacale.
+
+Ma vanno oltre: attraverso il loro famoso Pixel, Meta è in grado di sapere cosa fai **al di fuori di Facebook**: i siti web che visiti, quanto tempo ci trascorri, a quali giochi giochi, cosa acquisti, e persino dati come il tuo livello di istruzione. Inoltre, ovviamente, le informazioni tecniche sul tuo dispositivo, come l'indirizzo IP, il sistema operativo, il browser, tra gli altri, indipendentemente dal fatto che tu abbia effettuato l'accesso a Facebook o meno.
+
+Perché dovrebbe importarmi?
+------------------
+
+"Non ho nulla da nascondere" è l'argomento più comune per minimizzare l'importanza di tutti i dati che queste piattaforme raccolgono su di noi. Tuttavia, anche quando ciò che stai facendo non è illegale, ci sono buone ragioni per essere preoccupati di ciò che queste aziende sanno di te.
+
+Un attivista politico potrebbe essere gravemente danneggiato se una qualsiasi organizzazione potente a cui si oppone decidesse che ciò che fa è "sbagliato" e richiedesse informazioni su questa persona a una di queste aziende, [che le fornirebbero senza esitazione](https://gizmodo.com/twitter-saudi-arabia-x-jack-dorsey-areej-al-sadhan-abdu-1850805085).
+
+Ci sono anche chiari esempi in cui le tue informazioni personali potrebbero finire nelle mani di estranei, aziende o hacker che potrebbero usarle per scopi malevoli, come il furto d'identità, l'accesso ai tuoi account, l'invio di pubblicità indesiderata, l'estorsione, o [la manipolazione](https://en.wikipedia.org/wiki/Facebook%E2%80%93Cambridge_Analytica_data_scandal).
+
+Allo stesso modo, puoi perdere il controllo dei tuoi dati. Potresti non sapere come i tuoi dati siano memorizzati, elaborati o condivisi con terze parti, oppure potresti non essere in grado di eliminarli o modificarli se cambi idea. Questo potrebbe anche metterti a rischio se il fornitore di servizi di cui ti fidavi [non protegge i tuoi dati adeguatamente](https://www.iotworldtoday.com/security/duolingo-data-breach-exposes-3-million-user-emails) [in modo corretto](https://edition.cnn.com/2023/01/05/tech/twitter-data-email-addresses/index.html).
+
+Esistono alternative?
+-----------------------
+
+Anche se non così popolari, esistono alternative per almeno la maggior parte dei social network più diffusi. Diamo un'occhiata ad alcune:
+
+### Matrix, come Discord ma più privato
+
+Matrix è l'alternativa più vicina a Discord e Telegram, condividendo molte delle loro funzionalità ma aggiungendo miglioramenti per la privacy come la cifratura end-to-end, il non fare business con i dati e il mantenere il proprio codice open source. È completamente gratuito se decidi di far girare un proprio server, anche se potresti voler pagare per un server specializzato su internet o donare al progetto. È multipiattaforma e permette persino l'integrazione con Discord, Telegram e altre applicazioni popolari.
+
+### Mastodon
+
+Una delle alternative più popolari a Twitter, anche se non l'unica. Mastodon si distingue per essere decentralizzato, il che significa che qualsiasi individuo o organizzazione che lo desideri può lanciare la propria istanza o "server" per persone con interessi o caratteristiche comuni, ma possono interagire con altre istanze indipendenti.
+
+In Mastodon, ogni amministratore stabilisce le proprie regole, e poiché non si occupano del business dei dati, non raccolgono troppe informazioni sui loro utenti, sulla demografia o sulle preferenze, né le condividono con terze parti.
+
+Sfortunatamente, non implementano la cifratura end-to-end nei loro messaggi, il che è qualcosa da tenere a mente.
+
+### Signal
+
+Descritto nella nostra wiki sui client di messaggistica, Signal è un'alternativa più privata e sicura a Telegram e WhatsApp, condividendo funzionalità molto attraenti e interessanti
+
+

--- a/translations/it/site/Research/Track_Early_Onchain_And_Social_Signals_for_Zcash.md
+++ b/translations/it/site/Research/Track_Early_Onchain_And_Social_Signals_for_Zcash.md
@@ -1,0 +1,106 @@
+---
+published: 2025-08-19 
+---
+
+# Tracciare i Primi Segnali On-chain e Social per Zcash (ZEC)
+
+### Introduzione 
+
+Questo articolo di ricerca analizza come i primi segnali on-chain per Zcash, in particolare i movimenti delle whale e i segnali di sentiment social su piattaforme come X, abbiano importanti implicazioni sul momentum di ZEC. Zcash è una criptovaluta incentrata sulla privacy derivata dal codice di Bitcoin, con la grande innovazione di aggiungere un registro cifrato usando prove a conoscenza zero. 
+
+La Messari ZEC Dashboard e l'analisi delle discussioni su X sono tra gli strumenti usati per vedere se i grandi movimenti di Zcash sono collegati a un maggior numero di tweet e a un crescente interesse online. Un'altra area di interesse è come le attività della comunità Zcash, come wallet, eventi e sviluppo, influenzino il movimento di Zcash sul mercato.
+
+Vengono inoltre monitorate le tendenze passate di ZEC e confrontate con altre privacy coin; quanto siano riconosciute e accettate da diversi settori e aziende aiuta a fornire contesto su cui fondare le dinamiche. Non si tratta di fare ipotesi azzardate sul prezzo di ZEC o di fare previsioni facili, ma di analizzare i segnali in anticipo per mostrare crescente interesse, grandi cambiamenti o attività della comunità prima che il pubblico più ampio se ne accorga.
+
+La tecnologia blockchain funziona in modo innovativo e le operazioni nelle criptovalute portano a un'esperienza piuttosto significativa. Da come avvengono le transazioni a come causano cambiamenti significativi nel comportamento e nel sentiment del mercato, le interessanti dinamiche del mercato possono essere studiate; con guadagni e perdite vissuti in prima persona. 
+
+Le prime metriche on-chain di attività rappresentano una delle attività più precoci e potenti che rivela la direzione e il movimento del mercato, nonché l'attività degli investitori e i possibili cambiamenti che si verificheranno nel prossimo futuro nel mondo cripto. Inoltre, se rilevati per tempo, questi segnali possono aiutare gli investitori ad accedere al profitto, in particolare se combinati con fattori off-chain come l'analisi del sentiment sui social media. 
+Secondo la Messari ZEC Dashboard, CoinMetrics e Blockchair, l'analisi dell'attività di rete di ZEC fornisce informazioni concrete su se i grandi movimenti delle whale corrispondano a picchi di attività social come il volume di tweet e un più ampio interesse online. In particolare, i grafici di Messari rivelano un netto aumento del volume giornaliero delle transazioni on-chain e degli afflussi verso gli exchange durante il periodo dal 1 al 22 luglio 2025, con un picco intorno al 22 luglio; coincidente con un elevato chiacchiericcio social e movimento del prezzo .
+I dati di Blockchair mostrano che la quota di ZEC detenuta in indirizzi schermati è salita da circa il 18% al 20% durante la stessa finestra, indicando un crescente utilizzo di transazioni che tutelano la privacy.  (Vedi Figura 1)
+
+# Figura 1. Quota di ZEC detenuta in Indirizzi Schermati - Luglio 2025
+(Fonte: Blockchair (2025). Percentuale di offerta schermata per il 1-22 luglio 2025.)
+
+Inoltre, le serie pubbliche di rete di CoinMetrics confermano che sia gli indirizzi attivi giornalieri sia le metriche dell'offerta schermata hanno avuto un trend al rialzo a metà luglio, permettendo confronti quantitativi tra il comportamento on-chain e gli indicatori social.  (Vedi Figura 2)
+
+
+# Figura 2. Indirizzi Attivi Giornalieri e Offerta Schermata di Zcash - Metà Luglio 2025
+(Fonte: CoinMetrics (2025). Indirizzi attivi giornalieri per il 1-22 luglio 2025.)
+
+Tutti questi dati mostrano il movimento delle monete, l'adozione della privacy e il coinvolgimento degli utenti; il picco nei grandi volumi on-chain e negli afflussi verso gli exchange suggerisce che le whale erano attive, forse spostando fondi o preparandosi a un impatto sul mercato; l'aumento dell'offerta schermata dimostra una continua preferenza per le transazioni che migliorano la privacy, anche durante periodi di maggiore attenzione, e il crescente numero di indirizzi attivi indica che l'utilizzo della rete si stava espandendo insieme a questi movimenti delle whale e alla domanda di privacy.  (Vedi Figura 3)
+
+
+# Figura 3. Quota di ZEC detenuta in Indirizzi Schermati - Luglio 2025
+(Fonte: Zechub (2025). Grafico della dashboard di Zechub per il periodo 2016-2025)
+
+### Zcash come privacy coin
+
+Zcash è una delle criptovalute sviluppate pensando alla privacy degli utenti, che usa prove a conoscenza zero (zk-SNARKs) ed è derivata dal codice di Bitcoin come fork; gli utenti possono ora effettuare sia transazioni trasparenti che schermate. Sebbene l'obiettivo sia aiutare a proteggere la privacy degli utenti, averne troppa rende più difficile monitorare i segnali che possono rendere il trading e gli investimenti molto più facili. Non è tuttavia impossibile.  
+
+A differenza di Monero e DASH, che vengono spesso raggruppate come “privacy coin”, DASH si è ufficialmente allontanata dalla classificazione di privacy coin a seguito di cambiamenti nelle funzionalità e dell'evoluzione delle definizioni normative (CoinTelegraph, 2024) . ZEC affronta ancora concorrenza e scrutinio, ma il suo momentum può essere misurato attraverso l'attività on-chain, la correlazione con i movimenti delle whale, il volume di tweet e il coinvolgimento della rete senza affidarsi unicamente alla speculazione sul prezzo.
+
+L'attività on-chain si riferisce a tutte le interazioni che avvengono direttamente su una blockchain, come i trasferimenti da wallet a wallet, gli scambi di token, le interazioni con gli smart contract, i depositi e i prelievi dagli exchange, il minting o i trasferimenti di NFT e gli eventi di staking/sblocco. I pattern di comportamento dei principali attori, in particolare whale, cluster retail, sviluppatori o wallet istituzionali, possono essere dedotti quando questi dati vengono analizzati e sarà possibile comprendere appieno come si relazionino nel determinare il mercato.
+
+Secondo la Messari ZEC Dashboard (Messari), tra il 1 e il 22 luglio 2025, ci sono state 12 transazioni superiori a 1.000 ZEC, la più grande pari a 5.200 ZEC (CoinMetrics, 2025). Questi volumi di ZEC limitati sono stati accompagnati da una notevole attività di afflusso verso gli exchange, suggerendo una potenziale attività di sell-off o di riorganizzazione del portafoglio.
+
+Allo stesso tempo, le transazioni schermate, una parte essenziale del framework di privacy di Zcash, vedevano ancora un'adozione significativa. Entro luglio, circa il 20% dell'offerta totale di ZEC era in indirizzi schermati. (Blockchair 2025) (vedi Figura 4) 
+
+
+# Figura 4. Crescita delle Transazioni Schermate - Luglio 2025
+(Fonte: Blockchair (2025). Percentuale di offerta schermata dal 1-22 luglio 2025, che mostra una crescita da ~18% a ~20%.)
+
+
+È interessante notare che il volume delle transazioni schermate è aumentato dell'8% rispetto al mese precedente, evidenziando una domanda costante di maggiore privacy finanziaria. Nel complesso, queste tendenze indicano un ecosistema in crescita guidato dalla privacy, dove sia le aziende che gli utenti attenti alla privacy influenzano attivamente il modo in cui la rete opera.
+
+## Sentiment Pubblico 
+
+Durante il luglio 2025, il volume medio di tweet che menzionavano ZEC era di circa 450 post al giorno con un picco di 1.200 il 22 luglio, la data della più grande transazione di una whale. Gli aggiornamenti tecnici e le funzionalità di privacy di ZEC hanno attirato sentiment positivo, come espresso da account di influencer come @MarcoPoloMaps. Questi dati offrono prova che l'attività delle whale potrebbe stimolare l'interazione della comunità online. 
+
+Le funzionalità di privacy e i recenti aggiornamenti tecnici, ovvero l'aggiornamento del protocollo Zcash 6.2.0 e il rilascio del wallet Zashi 2.0 (Zcash Foundation Blog, Electric Coin Co. Release Notes), hanno portato un sentiment positivo nel 55% dei 13.500 tweet analizzati. Il 30% dei tweet era neutro, concentrandosi su notizie o analisi tecniche, mentre il 15% era negativo, legato in gran parte al clima normativo speculativo come il proposto divieto delle privacy coin da parte dell'UE per il 2027. 
+
+Con più di 10.000 follower, account come @MarcoPoloMaps hanno contribuito a un quarto del volume totale di tweet e, quindi, sono stati significativi per il trend. Mentre l'aggiornamento 6.2.0 di Zcash e il rilascio di Zashi 2.0 hanno attirato attenzione, le discussioni attorno a questi eventi hanno amplificato la positività della comunità. I dati on-chain hanno supportato l'osservato aumento dell'attività degli utenti, con il numero di indirizzi attivi giornalieri che ha raggiunto un picco di 3.200; un aumento del 15% che si è allineato strettamente con i periodi di maggiore attività delle whale.
+
+Altre piattaforme come Discord, Reddit e lo Zcash Community Hub sono state osservate per cogliere il sentiment degli utenti e quanto fossero attive le persone. È stato esaminato come i merchant stanno adottando ZEC, in particolare con il suo uso in soluzioni di pagamento come Brave Wallet e Zashi. Oltre a ciò, è stato monitorato il progresso dello sviluppo del progetto attraverso i contributi su GitHub e i recenti aggiornamenti della rete, incluso il rilascio di Zcash v6.2.0. 
+
+## Correlazioni Tra Segnali On-Chain e Social
+
+È stata notata una connessione piuttosto forte tra le grandi transazioni e un picco nell'attività dei tweet. Questo sembra indicare che quando le whale si muovono, ciò cattura molta attenzione sul mercato. C'era anche una correlazione moderata che mostrava che quando il sentiment social è positivo, il numero di transazioni schermate tende a crescere, suggerendo che le conversazioni sulla privacy possono davvero potenziare l'effettiva attività on-chain.
+
+
+Esaminando Comunità, Adozione e Sviluppo, lo Zcash Community Hub ha messo in evidenza un'ondata di entusiasmo dal basso, con oltre 2.800 membri attivi su Discord e 2.000 iscritti su Reddit. È interessante notare che il coinvolgimento della comunità è cresciuto del 12% dopo il lancio di Zashi 2.0, con molte discussioni focalizzate sulle innovazioni in materia di privacy e su come affrontare gli ostacoli normativi. (Vedi Figura 5)
+
+# Figura 5. Snapshot del Traffico e delle Iscrizioni al Forum di Zcash da quando Zashi 2.0 è stato rilasciato il 28 aprile 2025. 
+(Fonte : Shawn; moderatore principale dello Zcash Community Forum (2025). Grafico relativo al periodo dal 9 aprile al 9 maggio 2025. )
+
+Comunità, Adozione e Sviluppo in cui lo Zcash Community Hub ha messo in mostra un crescente entusiasmo dal basso. Sul fronte dell'adozione, l'integrazione presso i merchant rimane limitata ma degna di nota. Sebbene l'utilizzo tra i merchant globali sia basso, stimato a 120, l'integrazione di ZEC nel Brave Wallet e l'esperimento di zk-proof in Google Wallet, rispettivamente ad aprile e maggio 2025, ne hanno aumentato l'esposizione. 
+Il lavoro della Electric Coin Company e della Zcash Foundation mostrato nel secondo trimestre del 2025 ha dimostrato un'attività sostenuta. Oltre 350 commit su Github hanno rivelato una significativa collaborazione su importanti progetti infrastrutturali come il codebase Zebra e il wallet Zallet, mettendo in mostra la comunità tecnica attiva dell'ecosistema Zcash e anche i grafici dei contributori.
+
+
+Per analizzare davvero le attuali dinamiche di Zcash, è meglio esaminare il punto di vista dell'utente nel tempo e confrontare il contesto storico di Zcash con altre privacy coin. Questa analisi illustrerà i movimenti storici del prezzo di ZEC, come il massimo di mercato del 2017 e l'evento di halving del blocco del 2020, e il confronto degli indicatori on-chain e social con Monero (XMR) e DASH (DASH) (es. volume delle transazioni, posizione per market cap e attività social). 
+
+Il massimo storico dei prezzi di mercato alla fine del 2017 ha coinciso con un generale balzo dei mercati cripto, e l'evento di halving di Zcash del 2020 è stato un fattore importante nel limitare l'offerta di ZEC. In termini di alcuni movimenti delle whale a luglio 2025, non è molto rispetto ai cicli di mercato precedenti in termini di attività on-chain visibile (cioè, hanno ovviamente scambiato valore, possiamo solo vedere cosa stanno combinando attraverso il chiacchiericcio social o la registrazione mensile dello stato). Tra le privacy coin, Monero ha il vantaggio con una vivace comunità di utenti e un'interazione utente giornaliera soddisfacente. Zcash sta attirando attenzione attraverso un netto aumento delle transazioni schermate.
+
+## Attenzione Cross-Chain: NEAR e Maya
+Ciò che ha iniziato ad attirare maggiore attenzione verso Zcash negli ultimi mesi non è solo l'ondata di transazioni delle whale o il chiacchiericcio delle comunità online, ma il modo in cui ZEC ha varcato i propri confini. L'integrazione con l'infrastruttura Intents di NEAR ha aperto le porte a scambi fluidi e senza permessi tra ZEC e asset come Bitcoin, Ethereum e lo stesso NEAR. Per la prima volta, le transazioni che tutelano la privacy potevano muoversi tra catene senza l'attrito degli exchange o il peso di commissioni elevate. Per gli utenti di Zcash questo significava più che comodità; era un invito silenzioso a una conversazione più ampia dove i sistemi basati sugli intent e il denaro privato convergono. L'hackathon che ha segnato questa collaborazione non è stato solo un evento tecnico ma un segnale di intenti. Sviluppatori e sostenitori della privacy si sono riuniti per immaginare come potrebbe essere ZEC in un futuro cross-chain. L'atmosfera sui forum in seguito portava con sé un senso di momentum. Le persone parlavano di questo come l'inizio di una nuova serie di possibilità e di un'opportunità per Zcash di smettere di essere trattato come un esperimento isolato. Stava invece diventando una valuta che poteva muoversi ovunque ci sia liquidità.
+L'arrivo di Maya Protocol ha dato a ZEC un altro tipo di attenzione. Qui l'enfasi non era su eleganti transazioni IA ma sulla promessa di liquidità decentralizzata. Ancorando Zcash all'interno dell'AMM cross-chain di Maya, i detentori potevano fare trading privatamente senza cedere autonomia agli exchange centralizzati. In un'epoca in cui i regolatori girano attorno alle privacy coin e i delisting sono diventati di routine, questo contava profondamente. Per molti nella comunità, Maya sembrava meno un'integrazione e più un'ancora di salvezza. Era un promemoria che ZEC poteva ancora esistere in un mercato senza inchinarsi ai custodi. La roadmap punta verso un'integrazione più profonda di ZEC nell'ecosistema di Maya, e già gli utenti ne parlano come di un modo per mantenere intatta la propria autonomia finanziaria indipendentemente dal clima politico.
+Insieme, queste integrazioni hanno fatto qualcosa di sottile ma profondo. Hanno trascinato Zcash in conversazioni con altre comunità. Gli sviluppatori di NEAR che forse non avrebbero mai guardato due volte una privacy coin ora la vedono come un partner nel design guidato dagli intent. Gli utenti di Maya, familiari con il linguaggio della liquidità e degli scambi, stanno incontrando per la prima volta gli indirizzi schermati e la filosofia della conoscenza zero. ZEC non parla più solo ai suoi credenti. Sta iniziando a risuonare in nuovi ambienti dove la privacy non è solo una funzionalità ma un ponte tra reti, protocolli e le persone che li usano.
+
+# Conclusione
+Per riassumere il tutto, questo studio mostra che i segnali on-chain e social di Zcash, sebbene talvolta sottili, rivelano un ecosistema dinamico e in evoluzione.
+Ci sono limiti; l'anonimato che circonda i wallet delle whale che rende difficile determinare se le grandi transazioni on-chain fossero una vendita di mercato o semplicemente un movimento di mercato, e la mutevole politica normativa, come il divieto delle privacy coin dell'UE per il 2027, che potrebbe già influenzare il sentiment degli utenti; inoltre, l'affidamento a social come X probabilmente non racchiude le opinioni degli individui attenti alla privacy, che potrebbero essere inclini a scegliere altri metodi di comunicazione basati sull'anonimato o sicuri.
+
+
+Zcash potrebbe non vantare una comunità grande come quella di Monero o un'ampia base di merchant per ora, ma i suoi continui progressi tecnici; come l'aggiornamento del protocollo v6.2.0 che migliora l'efficienza delle transazioni schermate, il rilascio del wallet Zashi 2.0 con migliore usabilità mobile e supporto schermato di default, e le integrazioni cross-chain attraverso NEAR Intents e Maya Protocol lo distinguono come una privacy coin che approfondisce costantemente la propria infrastruttura ed espande la propria portata. È degno di nota che il luglio 2025 ha segnato una rinascita per Zcash, accendendo conversazioni su X con sostanziali transazioni delle whale. Inoltre, il costante aumento delle transazioni schermate dimostra che la privacy ha ancora un valore significativo per gli utenti. C'è una netta correlazione tra eventi on-chain e discorso social, che rivela come entrambi i mondi si influenzino a vicenda. Sebbene navigare gli ostacoli normativi rimanga una sfida, tenere d'occhio questi segnali iniziali migliorerà la nostra comprensione della potenziale traiettoria di ZEC, senza bisogno di prevedere i prezzi.
+
+
+# Riferimenti
+- Blockchair. (2025). Zcash shielded transactions data. https://blockchair.com/zcash/charts/shielded-supply
+- CoinMetrics. (2025). Zcash network data metrics. https://coinmetrics.io/
+- CoinTelegraph. (2024). Dash is no longer a privacy coin under evolving regulations. https://cointelegraph.com/news/dash-no-longer-privacy-coin
+- Electric Coin Company. (2025). Zcash 6.2.0 release notes. https://electriccoin.co/blog/
+- Messari. (2025). Messari ZEC dashboard. https://messari.io/asset/zcash
+- Shawn; Lead moderator Zcash Community Forum. (2025). 
+- X Platform Sentiment Analysis. (2025, July). Internal dataset. 
+- Zcash Community Hub. (2025). Community updates and engagement statistics. https://z.cash
+- Zcash Foundation. (2025). Zashi 2.0 wallet release. https://zcashfoundation.org/blog/
+- Zechub. (2025).  Zechub dashboard chart.

--- a/translations/it/site/Research/ZK_Shielded_Asset_Platforms.md
+++ b/translations/it/site/Research/ZK_Shielded_Asset_Platforms.md
@@ -1,0 +1,99 @@
+---
+published: 2024-01-12 
+---
+
+<a href="https://github.com/Zechub/zechub/edit/main/site/Research/ZK_Shielded_Asset_Platforms.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# Piattaforme di Asset a Conoscenza Zero
+
+
+
+**[Firn Protocol](https://app.firn.cash/)**: Firn è la primissima piattaforma di privacy a conoscenza zero nel modello basato su account, e introduce una privacy modulare e flessibile alle chain basate su Ethereum. Usando prove a conoscenza zero, Firn offre una privacy dei fondi sicura ed efficiente per gli utenti di Ethereum e degli L2 basati su Ethereum. **COME FUNZIONA?**
+Per usare Firn, deposita ETH nel protocollo. Una volta che hai un saldo Firn, puoi trasferire fondi in modo privato ad altri utenti Firn, oppure interagire con altri protocolli, come Uniswap. Puoi anche prelevare privatamente i fondi di nuovo sulla rete. Firn applica una piccola commissione, dello 0,79%, su tutti i prelievi di ETH. Queste commissioni vengono distribuite proporzionalmente ai detentori del FIRN Token - [Whitepaper](https://firn.cash/whitepaper.pdf) 
+
+
+**[RAILGUN](https://railgun.org/):** In quanto smart contract di livello 1, Railgun esiste per essere un'infrastruttura per trasferimenti privati e DeFi, dovendo la propria esistenza a Ethereum, Polygon, Binance Smart Chain e Arbitrum.
+Configura il tuo RAILGUN Wallet non-custodial, schermando qualsiasi token ERC-20 in un indirizzo 0zk a tua scelta. Una volta schermati, token, saldi e transazioni sono cifrati  - [Whitepaper](https://docs.railgun.org/wiki) 
+
+
+**[StarkEX](https://starkware.co/starkex/):** Un motore di scalabilità di livello 2, attivo su Ethereum Mainnet. Le transazioni vengono raggruppate off-chain e inviate ai servizi StarEX. StarEX convalida le transazioni e i saldi pertinenti vengono aggiornati; genera prove STARK basate sulla validità della transazione. Uno smart contract verificatore on-chain riceve e verifica la prova STARK - [Whitepaper](https://docs.starkware.co/starkex-v4/)
+
+
+**[Manta Network](https://www.manta.network/):** Privacy On-Chain per Web 3, DeFi e altro.  Manta Atlantic, la più veloce chain ZK L1, porta la privacy programmabile a web3 attraverso privacy e identità on-chain conformi. $MANTA ha un'offerta fissa di 1.000.000.000 senza alcun programma di inflazione. I token $MANTA verranno bruciati automaticamente non appena vengono riscattati - [Whitepaper](https://docs.manta.network/) 
+
+**[Boltz](https://boltz.exchange/):**  Boltz è una soluzione di livello 2. Boltz è un exchange di bitcoin privacy-first e non-custodial costruito per fare da ponte tra i diversi livelli di Bitcoin come la liquid e la lightning network. Con Boltz, gli utenti possono scambiare senza problemi i loro bitcoin tra i livelli. Gli Swap di Boltz sono non-custodial, il che significa che gli utenti possono sempre stare tranquilli di avere il pieno controllo dei propri bitcoin durante l'intero flusso di uno swap  [Whitepaper](https://docs.boltz.exchange/en/latest/) 
+
+
+**[ShadeProtocol](https://shadeprotocol.io/)**: Shade Protocol è un array di livello 2 di applicazioni DeFi connesse che preservano la privacy, costruite su Secret Network. Queste applicazioni chiave sono stablecoin, governance, bond, derivati di staking, assicurazioni, sintetici, prestiti, DEX e altro  - [Whitepaper]
+
+**[PantherProtocol](https://www.pantherprotocol.io/)**: Un livello a conoscenza zero e cross-protocollo che protegge i tuoi dati on-chain e abilita l'accesso conforme alla DeFi. **Come funziona?** Deposita i tuoi asset in Panther per usare asset schermati collateralizzati 1:1 chiamati zAsset. Conserva più tipi di asset nei Panther Pool, proteggendo al contempo i tuoi dati on-chain con prove a conoscenza zero. Con molte blockchain di Livello 1 e 2, tutte che propongono valori, idee e meccanismi diversi, Panther crea l'infrastruttura per connetterle privatamente, anziché aspettarsi che una di esse prenda il sopravvento su tutto. - [Whitepaper](https://docs.pantherprotocol.io/) 
+
+
+**[Sienna Network](https://sienna.network/)**: Sienna.network è un frontend open source decentralizzato e privacy-first dove puoi interagire con contratti di swap e prestito sulla chain Secret Network. Guadagna rendimento fornendo secret token affinché altri possano prenderli in prestito, oppure prendi token in prestito fornendo una garanzia. I mercati in fase di lancio sono sBTC, sETH, sSCRT, sXMR, sLUNA, sUST, sUSDT, sUSDC e altri. È stata sviluppata Sienna Network (protocollo di Livello 2). SiennaLend è il primo protocollo di prestito privato ad abilitare il prestito privato per molteplici ecosistemi blockchain mantenendo al contempo la tua privacy. È permissionless e non ha requisiti di registrazione, nessun limite ai depositi, nessuna parte centralizzata che possa congelare il tuo account, ed è governato dal token di governance SIENNA - **Asset Swap**: Sì - [Whitepaper](https://sienna.network/whitepaper/) - ![Sienna Logo](https://miro.medium.com/v2/resize:fit:1400/format:webp/1*51y4R6V7JALmXtG_ZAsdcw.jpeg)
+***
+
+
+
+**[Light Shield](https://shield.lightprotocol.com/)**: Light è uno zkLayer di livello 2 open-source che abilita l'esecuzione privata di programmi, costruito appositamente per Solana. Light Protocol consente di cifrare lo stato on-chain. Solo l'utente può decifrare il proprio stato privato; di conseguenza, in sostanza, lo "possiede". Lo stato privato può essere posseduto da un singolo utente o da un insieme di utenti che condividono una chiave di decifratura.
+Per esempio, considera un annuncio di NFT su Solana; il suo stato pubblico (es. il prezzo) è visibile a tutti, incluso il fatto che è in vendita. Ma le offerte e gli scambi dovrebbero rimanere privati - **Asset Swap**: Sì - [Whitepaper](https://shield.lightprotocol.com/) - ![Light Shield Logo](https://miro.medium.com/v2/resize:fit:1358/1*C4Pe23afCwS05seCeZWBLA.png)
+***
+
+**[Conceal Network](https://conceal.network/wiki/doku.php)**: La Conceal Network è stata costruita per fornire agli individui la possibilità di comunicare e interagire finanziariamente tra loro in modo anonimo e decentralizzato. Con Conceal, le transazioni non possono essere collegate tra mittente e destinatario. Inoltre, Conceal usa le firme ad anello (ring signature) e indirizzi monouso per pagamenti realmente anonimi - **Asset Swap**: Sì - [Whitepaper](https://conceal.network/wiki/doku.php) - ![Conceal.png](https://conceal.network/images/media/media_articles_01.png)
+***
+
+**[Namada](https://namada.net/testnets)**: In breve: Namada è una Layer 1 proof-of-stake per la privacy interchain agnostica rispetto agli asset. Namada interopera nativamente con chain a finalità rapida tramite IBC e con Ethereum tramite un bridge bidirezionale trustless. Per la privacy, Namada implementa una versione aggiornata del circuito multi-asset shielded pool (MASP) che permette a tutti gli asset (fungibili e non fungibili) di condividere un insieme schermato comune – in questo modo, trasferire un CryptoKitty è indistinguibile dal trasferire ETH, DAI, ATOM, OSMO, NAM (l'asset nativo di Namada) o qualsiasi altro asset su Namada. **Asset Swap**: Sì - [Whitepaper](https://docs.namada.net/) - ![Namada.png](https://pbs.twimg.com/profile_images/1775529113102561281/y4D30_VO_400x400.jpg)
+***
+
+
+ **[FairySwap](https://fairyswap.finance/swap)**: Fairyswap è un DEX di privacy di livello 1 di nuova generazione e guidato dalla comunità, impegnato a essere permissionless e decentralizzato. Sfruttando la tecnologia delle prove a conoscenza zero integrata in Findora, i DEX di privacy e le Dapp come FairySwap danno agli utenti la possibilità di scegliere quali informazioni vogliono che siano visibili su una blockchain pubblica e quali preferiscono schermare. Le informazioni che vogliono mantenere invisibili possono comunque essere verificate pubblicamente con prove a conoscenza zero senza rivelare alcun dettaglio - **Asset Swap**: Sì - [Whitepaper](https://fairy-swap.gitbook.io/fairyswap-v2/) - ![FairySwap Logo](https://images.cointelegraph.com/images/1434_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS9zdG9yYWdlL3VwbG9hZHMvdmlldy8yOWE2NzFmMDFhOGIxN2M3MDg1ZjhkMDJhNjA4NzMzNS5qcGc=.jpg)
+***
+
+**[ZKSync](https://zksync.io/)**: zkSync è una soluzione di scaling di livello 2 su Ethereum che offre gas basso e transazioni veloci, senza compromettere la sicurezza. Le persone possono prelevare gli asset sul Livello 1 in qualsiasi momento. Per accedere all'intero ecosistema zkSync e per beneficiare di transazioni economiche e istantanee, hai prima bisogno di un [wallet come Argent](https://argent.link/zksync). Senza un wallet, non puoi entrare nella rete, poiché non è possibile accedere a zkSync tramite un exchange come Coinbase o Binance. I wallet ti danno un modo semplice per comprare, vendere e conservare crypto e sperimentare l'entusiasmante mondo della DeFi, degli NFT e molto altro - **Asset Swap**: Sì - [Whitepaper](https://era.zksync.io/docs/) - ![ZKSync.png](https://assets-global.website-files.com/636e894daa9e99940a604aef/63edde073465de1ef6bf89d3_zkSync%20Testnet%20Faucet%20Tokens.webp)
+***
+
+**[Penumbra](https://penumbra.zone/blog/valetudo-testnet/)**: Penumbra è una rete di livello 1 completamente schermata all'interno dell'ecosistema Cosmos. È una rete schermata e cross-chain che permette a chiunque di effettuare transazioni, fare staking, swap o market making in sicurezza senza diffondere al mondo le proprie informazioni personali. In quanto blockchain completamente schermata, Penumbra registra tutti i valori in un'unica shielded pool che può registrare qualsiasi tipo di asset. Penumbra ha la privacy per impostazione predefinita, senza transazioni transparent o pool di valore transparent - **Asset Swap**: Sì - ![Penumbra.png](https://pbs.twimg.com/profile_images/1456245067149103104/CrNB0cKl_400x400.jpg)
+***
+
+
+**[Ironfish Network](https://ironfish.network/)**: Ironfish cifra ogni transazione, schermando le informazioni sensibili sui tuoi asset dalla vista pubblica. Con le view key di sola lettura, rimani conforme e in controllo. Iron Fish è un progetto di blockchain di livello 1 decentralizzato, basato su proof-of-work (PoW), resistente alla censura e pubblicamente accessibile. È progettato per supportare forti garanzie di privacy su ogni transazione - **Asset Swap**: Sì - [Whitepaper](https://ironfish.network/learn/whitepaper) - ![Ironfish.png](https://pbs.twimg.com/profile_images/1367581984986296320/kxDDjheA_400x400.jpg)
+***
+
+
+**[ZKBOB](https://zkbob.com/)**: Proteggi la tua privacy con lo smart contract wallet zkBob. Con zkBob, il contenuto del tuo wallet e gli importi che spendi e ricevi sono completamente privati. Usa zkBob per inviare o ricevere stipendi, pagamenti, donazioni e altro con privacy e conformità integrata. Permette anche trasferimenti privati P2P usando la tecnologia delle prove a conoscenza zero per proteggere i destinatari e anonimizzare gli importi - **Asset Swap**: Sì -  ![ZKBOB.png](https://pbs.twimg.com/profile_images/1704381974700515328/aalptltf_400x400.jpg) - [Whitepaper](https://docs.zkbob.com/zkbob-overview/basic-concepts)
+***
+
+**[Firo](https://firo.org/)**: Firo, precedentemente noto come Zcoin, è una blockchain di privacy di livello 1 dedicata alla privacy e al mining delle criptovalute. Firo è all'avanguardia nella privacy delle criptovalute, con Lelantus e Lelantus Spark che forniscono privacy on-chain trustless con elevati insiemi di anonimato. La tecnologia Dandelion++ fornisce inoltre privacy a livello di rete. Firo è all'avanguardia nella privacy delle criptovalute, con Lelantus e Lelantus Spark che forniscono privacy on-chain trustless con elevati insiemi di anonimato. La tecnologia Dandelion++ fornisce inoltre privacy a livello di rete - **Asset Swap**: Sì - ![Firo.png](https://avatars.githubusercontent.com/u/22083410?s=200&v=4)
+***
+
+**[PIVX](https://pivx.org/)**: PIVX utilizza un secondo livello (Tier Two) nella sua rete, distribuendo masternode per aiutare a partecipare alla governance. PIVX è una valuta peer-to-peer open-source e decentralizzata caratterizzata da funzionalità avanzate di protezione dei dati degli utenti, meccanismi di governance comunitaria, algoritmo di consenso Proof of Stake e Masternode multiuso. Con PIVX, gli utenti sperimenteranno senza problemi la libertà del contante digitale globale con la protezione dei dati utente SHIELD. Sii la tua banca con il pieno controllo dei tuoi asset digitali - **Asset Swap**: Sì -[Whitepaper](https://pivx.org/whitepaper) - ![PIVX.png](https://s2.coinmarketcap.com/static/img/coins/64x64/1169.png)
+***
+
+**[BEAM](https://beam.mw/)**: Beam è la principale blockchain di privacy L1 Mimblewimble, che nasconde completamente le transazioni. Scarica Beam Wallet per la migliore esperienza DeFi confidenziale - **Asset Swap**: Sì - [Whitepaper](https://beam.mw/en/docs) - ![BEAM.png](https://pbs.twimg.com/profile_images/1925301915316809728/diZpv5uB_400x400.jpg)
+***
+
+**[Oxen](https://oxen.io/)**: Oxen (precedentemente noto come LOKI) è un progetto di tecnologia per la privacy con una missione. È una criptovaluta privata con transazioni istantanee. Una rete PoS enorme e potente. Una piattaforma di messaggistica sicura. L'app è in fase di transizione dalla chain Oxen di livello 1 a una chain compatibile con EVM, e la moneta OXEN diventerà Session Token: un nuovo token ERC-20 che girerà su una chain di livello 2 e sarà compatibile con la maggior parte delle applicazioni Web3 - **Asset Swap**: Sì - [Whitepaper](https://docs.oxen.io/) - ![Oxen.png](https://pbs.twimg.com/profile_images/1569912619443843072/GJAsdyzF_400x400.jpg)
+***
+
+**[Particl](https://particl.io/coin)**: Particl, una soluzione di livello 1 progettata per permettere agli individui di inviare e ricevere denaro privatamente senza restrizioni e senza intermediari. È facile, veloce e sicuro. È proprio come il contante, ma digitale! Mantieni private le tue finanze. Con PART, puoi scegliere di effettuare transazioni pubbliche o private completamente non tracciabili. La scelta è tua; qualunque siano le tue esigenze, c'è una soluzione per te - **Asset Swap**: Sì - [Whitepaper](https://raw.githubusercontent.com/particl/whitepaper/master/Particl%20Whitepaper%20Draft%20v0.3.pdf) - ![Particl.png](https://pbs.twimg.com/profile_images/1104121499777146883/WJ070Lrr_400x400.png)
+***
+
+**[Zano](https://zano.org/)**: Zano, una soluzione di livello 1 e una criptovaluta e un ecosistema open-source con privacy, sicurezza e scalabilità di livello enterprise, che opera come una solida base per asset confidenziali e applicazioni decentralizzate (dApp). La tua privacy conta. Scegli Zano, la piattaforma blockchain leader che dà priorità a confidenzialità e sicurezza. Le transazioni tra i membri della rete Zano sono rese non tracciabili tramite ring signature e indirizzi stealth. Inoltre, il modo in cui i dati delle transazioni sono memorizzati sulla blockchain consente l'accesso solo alle parti che hanno autorizzato le transazioni, e nessuno dei dati privati viene mai pubblicato pubblicamente. La confidenzialità di tutte le transazioni Zano è codificata nel core. Nascondendo tutti gli indirizzi di invio e ricezione abbiamo massimizzato il livello di privacy per ogni utente Zano - **Asset Swap**: Sì - [Whitepaper](https://docs.zano.org/) - ![Zano.png](https://pbs.twimg.com/media/FrSPUjYWIAMMWGJ?format=png&name=4096x4096)
+***
+
+
+
+**[Dark.fi](https://dark.fi/)**: DarkFi è una L1 anonima basata su conoscenza zero, calcolo multi-party e cifratura omomorfica. Il proof-of-stake anonimo garantisce che i validatori siano nascosti. DarkFi offre un ambiente anti-fragile per creare ed eseguire app anonime - **Asset Swap**: Sì - [Whitepaper](https://darkrenaissance.github.io/darkfi/) - ![Darkfi.png](https://miro.medium.com/v2/resize:fit:878/0*auQOzkLMfYdoXlRy)
+***
+
+
+**[Secret Network](https://scrt.network/)**: Secret Network è una blockchain di livello 1 costruita usando il Cosmos SDK ed è parte del più ampio universo interconnesso di Cosmos (IBC). Secret Network è la prima blockchain mainnet con smart contract che preservano la privacy, lanciata nel 2020. Questo rende possibile costruire app decentralizzate e permissionless—eppure private - **Asset Swap**: Sì - [Whitepaper](https://docs.scrt.network/) -
+![Secret.png](https://images.contentstack.io/v3/assets/blt38dd155f8beb7337/blt67f1d3f934bfa9b9/6229b0ba429f83163fd8ffbb/Untitled_(4).png)
+***
+
+
+
+**[TomoChain](https://tomochain.com/ecosystem/)**: TOMO è una blockchain pubblica di livello 1. Tomochain è un protocollo di privacy sviluppato su TomoChain e progettato per creare transazioni sicure e non tracciabili -**Asset Swap**: Sì- [Whitepaper](https://tomochain.com/files/technical-whitepaper-1.0.pdf) - ![TomoChain.png](https://s1.coincarp.com/logo/1/tomochain.png?style=200)
+***

--- a/translations/it/site/Research/zcash-foundations-series/article-0/article-0-shielded-transaction.md
+++ b/translations/it/site/Research/zcash-foundations-series/article-0/article-0-shielded-transaction.md
@@ -1,0 +1,254 @@
+# Come funziona davvero una transazione schermata di Zcash
+##### Ricerca originale di [Annkkitaaa](https://github.com/Annkkitaaa)
+
+![alt text](image.png)
+
+### L'intuizione prima della matematica: una spiegazione dei pagamenti privati senza formule
+
+> **Serie:** *Zcash dai primi principi* . **Articolo 0 . L'ancora**
+> **Pubblico:** principianti assoluti. Non si presuppone alcuna conoscenza di crittografia, blockchain o matematica.
+> **Cosa porterai con te:** un modello mentale corretto di come Zcash nasconde *chi ha pagato chi, e quanto*, pur consentendo al mondo intero di verificare che nessun denaro sia stato falsificato o speso due volte.
+
+Ogni articolo successivo di questa serie approfondisce una singola parte della macchina che stai per incontrare. Quindi, se una parola qui ti sembra vaga, *bene*. È la promessa che ci torneremo sopra e la spiegheremo per bene.
+
+---
+
+## 1. Perché dovrebbe interessarti?
+
+Immagina che il tuo estratto conto fosse inchiodato a un muro nella piazza del paese. Per sempre. Chiunque (il tuo padrone di casa, il tuo datore di lavoro, uno sconosciuto, un futuro datore di lavoro, un governo) potrebbe leggere ogni pagamento dell'affitto, ogni fattura medica, ogni donazione, ogni caffè, e risalire esattamente a chi hai inviato denaro e chi te ne ha inviato.
+
+Non è un'ipotesi distopica. **È più o meno così che funziona Bitcoin.**
+
+Bitcoin viene spesso definito "anonimo", ma non lo è. È *pseudonimo*: il tuo nome non compare nel registro, ma ogni transazione, importo e collegamento tra indirizzi è pubblico e permanente. L'intero settore della "analisi della catena" esiste per smascherare quel sottile pseudonimo e collegare gli indirizzi a persone reali. Una volta che uno dei tuoi indirizzi viene collegato a te, la tua storia finanziaria si dipana.
+
+Zcash è stato costruito per rispondere a una domanda ingannevolmente difficile:
+
+> **Possiamo avere denaro completamente privato, che nasconde mittente, destinatario e importo, pur consentendo a chiunque di verificare che le regole siano state rispettate?**
+
+Questi due obiettivi sono in conflitto tra loro. Un registro pubblico è verificabile *perché* tutti possono vederlo. La privacy significa che nessuno può vederlo. Quindi, come può il pubblico verificare qualcosa che non gli è permesso guardare?
+
+Risolvere questo paradosso è l'intera storia di questa serie. Cominciamo.
+
+---
+
+## 2. Ci sono due mondi dentro Zcash
+
+Prima di tutto, chiariamo un equivoco comune: **Zcash non è "la moneta privata". È una moneta che offre la privacy come opzione.** In realtà è nata come fork di Bitcoin, e porta con sé due sistemi paralleli sulla stessa blockchain.
+
+| | **Mondo trasparente** | **Mondo schermato** |
+|---|---|---|
+| Privacy | Pubblico, proprio come Bitcoin | Privato |
+| Gli indirizzi iniziano con | `t...` | `z...` o `u...` |
+| Mittente / destinatario / importo | **Visibile** a tutti | **Nascosto** a tutti |
+| Tecnologia sottostante | Registro pubblico in stile Bitcoin | Impegni crittografici + prove a conoscenza zero |
+
+Il denaro può persino attraversare il confine tra i due: spostare i fondi *dentro* il mondo schermato si chiama *schermatura* (shielding), e riportarli fuori si chiama *de-schermatura* (deshielding).
+
+Il mondo trasparente è "il Bitcoin che già più o meno comprendi". È il **mondo schermato** a contenere tutta la bella crittografia, ed è l'unico mondo di cui questa serie si occupa.
+
+![alt text](image-1.png)
+
+---
+
+## 3. L'intuizione: buste sigillate su una bacheca pubblica
+
+Ecco l'unica immagine mentale da portare avanti per il resto dell'articolo. Vi torneremo costantemente.
+
+Immagina un'enorme **bacheca pubblica** che tutti sulla Terra possono vedere in ogni momento.
+
+* **Ricevere denaro** significa che qualcuno appende una **busta sigillata e opaca** alla bacheca. Dentro la busta c'è *quanto denaro contiene* e *un segreto che solo il destinatario può leggere*, perché la busta è bloccata con la chiave personale di quel destinatario. Il mondo intero vede che *è apparsa una busta*. Nessuno tranne il proprietario può vedere cosa c'è dentro.
+
+* **La bacheca può solo crescere.** Le buste non vengono mai strappate o cancellate. Ne vengono appese di nuove sopra, per sempre.
+
+* **Spendere denaro** significa passare dietro una tenda, dimostrare *"possiedo una delle buste non spese su questa bacheca, e mi è permesso aprirla"*, poi lasciare un **gettone di annullamento** unico in un "cestino degli spesi" pubblico e appendere **nuove buste** per chi stai pagando.
+
+Questo piccolo rituale (appendere un gettone di annullamento, appendere nuove buste, tutto da dietro una tenda) *è* un pagamento Zcash. Tutto il resto è dettaglio.
+
+Ora diamo a questi elementi i loro nomi reali.
+
+---
+
+## 4. I cinque sostantivi
+
+Questi cinque termini sono l'intero vocabolario di Zcash schermato. Impara­li come una *storia*, non come un glossario, e ti rimarranno impressi.
+
+| Nella storia | Termine reale di Zcash | Cos'è realmente |
+|---|---|---|
+| Il contenuto della busta (importo + proprietario + un segreto) | **Note** (nota) | La "moneta" privata: un blocco di valore appartenente a qualcuno |
+| La busta sigillata e opaca sulla bacheca | **Note commitment** (impegno della nota) | Un sigillo crittografico che prova l'esistenza di una busta nascondendone il contenuto |
+| La bacheca stessa | **Note commitment tree** (albero degli impegni delle note) | Un registro ad aggiunta sola di *ogni nota mai creata* |
+| Il gettone di annullamento nel cestino degli "spesi" | **Nullifier** (annullatore) | Un marcatore unico che significa "questa nota è ora stata spesa" |
+| La magia "dietro la tenda" | **Zero-knowledge proof** (prova a conoscenza zero) | Una prova che l'intera spesa è valida, senza rivelarne nulla |
+
+Se non ricordi nient'altro di questo articolo, ricorda questa tabella. Tutto ciò che segue spiega semplicemente *perché* ciascun pezzo deve avere la forma che ha.
+
+---
+
+## 5. Perché ogni pezzo ha la forma che ha
+
+Questa è la parte che la maggior parte delle spiegazioni salta, ed è esattamente la parte che distingue "ho memorizzato alcune parole" da "ho capito il design". Ciascuno dei cinque pezzi esiste per risolvere **un problema specifico.**
+
+### Il note commitment: nascondere il contenuto, ma rendere impossibile la falsificazione
+
+Una busta ordinaria può essere aperta al vapore. Un **note commitment** crittografico no. Pensalo come una busta *magicamente* sigillata, completamente opaca, con due superpoteri:
+
+- **Occultamento (hiding)**: guardare la busta sigillata non ti dice *nulla* sull'importo o sul proprietario all'interno.
+- **Vincolo (binding)**: una volta sigillata, il contenuto non può essere scambiato. Non puoi in seguito sostenere che la busta contenesse un importo diverso.
+
+Come può un sigillo fare entrambe le cose contemporaneamente? È una domanda reale e a cui si può rispondere. È il tema dell'**Articolo 3 (impegni)**. Per ora, accetta la busta come magica e prosegui.
+
+### Il nullifier: la parte davvero ingegnosa
+
+Quando spendi una nota, pubblichi il suo **nullifier**, il "gettone di annullamento". Questo gettone viene calcolato a partire da *la nota stessa* **e** *dalla tua chiave segreta*. Questa ricetta garantisce tre proprietà simultaneamente, e ciascuna è importante:
+
+1. **Solo il proprietario può crearlo.** Hai bisogno della chiave segreta per calcolarlo, quindi nessuno può spendere le tue note al posto tuo.
+2. **È sempre lo *stesso* gettone per una data nota.** Prova a spendere la stessa nota due volte e produrresti il gettone di annullamento *identico* entrambe le volte, e il "cestino degli spesi" pubblico lo contiene già. Doppia spesa rifiutata.
+3. **Nessuno può ricollegarlo alla sua busta.** Il gettone di annullamento sembra del tutto scorrelato dalla busta da cui proviene.
+
+Quella terza proprietà è il **cuore della privacy di Zcash**, e merita una sua sezione qui sotto.
+
+### La zero-knowledge proof: la tenda stessa
+
+Tutto avviene dietro una tenda, e ciò che consegni al mondo dopo è una **zero-knowledge proof**, una sorta di certificato non falsificabile. Attesta silenziosamente tutto questo in una volta sola:
+
+- *la busta che sto spendendo è davvero appesa alla bacheca* (è una nota reale ed esistente),
+- *mi è davvero permesso aprirla* (possiedo la chiave giusta),
+- *il mio gettone di annullamento è calcolato correttamente* (nessun imbroglio sul controllo della doppia spesa),
+- *le mie nuove buste contengono esattamente tanto denaro quanto la vecchia*: **nessun denaro creato dal nulla.**
+
+Il miracolo è che la prova non rivela **nessuno** di questi fatti. Non l'importo, non gli indirizzi, non quale busta. Ti convince soltanto che *ogni affermazione qui sopra è vera*. Come ciò sia persino possibile è l'argomento dell'**Articolo 5 (prove a conoscenza zero)**, il culmine della serie.
+
+---
+
+## 6. La vita di una singola nota
+
+Una nota *nasce*, *vive* sulla bacheca e alla fine *muore*, e fondamentalmente la sua nascita e la sua morte sembrano scorrelate per chiunque la osservi.
+
+![alt text](image-2.png)
+
+---
+
+## 7. Un pagamento, dall'inizio alla fine
+
+Osserviamo Alice che paga Bob, con ogni passaggio pubblico e privato etichettato.
+
+![alt text](image-4.png)
+
+Nota l'asimmetria che fa funzionare la privacy:
+
+- **La vecchia nota di Alice** muore tramite un *nullifier* nel cestino degli spesi.
+- **La nuova nota di Bob** nasce tramite un fresco *commitment* sulla bacheca.
+- Per chiunque osservi, questi due eventi non hanno **alcuna connessione visibile.** La traccia del denaro si raffredda.
+
+> **Come fa Bob a sapere persino di essere stato pagato?** La sua nota è cifrata *con la sua chiave*. Lui scansiona continuamente la bacheca e solo le *sue* buste si aprono per lui, come avere l'unica chiave che combacia con uno specifico insieme di serrature. Il meccanismo dietro tutto questo sono le **viewing key**, un argomento successivo.
+
+---
+
+## 8. Cosa vede il mondo vs. cosa resta nascosto
+
+| Fatto sul pagamento | Visibile al pubblico? |
+|---|---|
+| Che *una* transazione schermata è avvenuta |  Sì |
+| Che ha rispettato tutte le regole (nessuna falsificazione, nessuna doppia spesa) |  Sì (tramite la prova) |
+| **Chi** ha inviato il denaro |  Nascosto |
+| **Chi** lo ha ricevuto |  Nascosto |
+| **Quanto** è stato inviato |  Nascosto |
+| **Quale** nota precedente è stata spesa |  Nascosto |
+
+Questa è la risoluzione del paradosso della Sezione 1. Il pubblico verifica le *regole*, non il *contenuto*. Verifica e privacy smettono di combattersi, perché la zero-knowledge proof ti permette di controllare la prima senza toccare la seconda.
+
+---
+
+## 9. Il cuore della questione: perché la busta e il gettone di annullamento non possono essere collegati
+
+Se comprendi questa sola idea, comprendi perché Zcash è privato. Leggila lentamente.
+
+- Una **busta (commitment)** viene appesa alla bacheca quando una nota **nasce**.
+- Un **gettone di annullamento (nullifier)** viene lasciato nel cestino quando quella stessa nota viene **spesa**, magari mesi dopo.
+- Sono prodotti da **ricette segrete diverse**, e non esiste **alcuna matematica pubblica** che trasformi l'uno nell'altro.
+
+Quindi un osservatore esterno vede un flusso di buste che compaiono e un flusso di gettoni di annullamento che compaiono, ma **non può accoppiarli**. Non può dire "il gettone di annullamento lasciato oggi corrisponde alla busta appesa lo scorso marzo". Il collegamento esiste *solo* all'interno della conoscenza segreta del proprietario della nota, e la zero-knowledge proof conferma che il collegamento è valido *senza rivelarlo.*
+
+Quel collegamento spezzato è ciò di cui le aziende di analisi della catena si nutrono in Bitcoin, ed è ciò che Zcash recide deliberatamente.
+
+> **Metti alla prova la tua intuizione:** Se i nullifier fossero invece calcolati *solo* a partire dalla nota (senza alcuna chiave segreta coinvolta), quale delle tre proprietà della Sezione 5 verrebbe meno, e perché ciò distruggerebbe silenziosamente la privacy? *(Risposta alla fine.)*
+
+---
+
+## 10. Una doverosa precisazione
+
+Questo è un **modello mentale**, non la specifica. Per mantenerlo accessibile ai principianti abbiamo silenziosamente semplificato diverse cose reali: Zcash ha avuto molteplici design schermati (Sprout, poi Sapling, ora Orchard); le transazioni reali possono spendere e creare *diverse* note in una volta; "la bacheca" è tecnicamente un tipo specifico di albero, non una letterale bacheca; e il bilancio del valore è imposto con un'ulteriore contabilità crittografica. Nessuno di questi dettagli cambia la storia che hai appena imparato; la perfeziona. Rimetteremo la precisione, un articolo alla volta, e lo segnaleremo chiaramente ogni volta che lo faremo.
+
+Un buon contenuto educativo si guadagna la fiducia dicendo cosa ha tralasciato. Questa sezione è quella promessa.
+
+---
+
+## 11. I fili che abbiamo aperto (la tua mappa della serie)
+
+Ogni "ci torneremo sopra" qui sopra è un filo. Ecco dove ciascuno viene annodato:
+
+![alt text](image-29.png)
+
+| Filo lasciato in sospeso da questo articolo | Dove viene risolto |
+|---|---|
+| Come può una busta sigillata essere sia nascondente *che* non falsificabile? | Articolo 3: impegni |
+| Da dove vengono le chiavi e le ricette segrete? | Articoli 1 e 2: campi e curve |
+| Cos'è esattamente "la bacheca"? | Articolo 4: alberi di Merkle |
+| Come puoi provare qualcosa senza rivelare nulla? | Articolo 5: prove a conoscenza zero |
+| Come si incastrano tutti e cinque i pezzi nel vero Zcash? | Articolo 6: il protocollo schermato |
+
+---
+
+## 12. Riepilogo
+
+- Bitcoin è **trasparente**; Zcash offre un mondo **schermato** in cui mittente, destinatario e importo sono nascosti.
+- L'apparente paradosso (*privato eppure pubblicamente verificabile*) è il punto centrale, ed è risolvibile.
+- Un pagamento schermato è composto da cinque pezzi che si incastrano: una **note** (la moneta), un **note commitment** (la busta sigillata), il **note commitment tree** (la bacheca pubblica), un **nullifier** (il gettone di annullamento che impedisce le doppie spese) e una **zero-knowledge proof** (la tenda che prova la validità senza rivelare nulla).
+- La privacy si fonda in ultima analisi su **un collegamento reciso**: nessuno all'esterno può connettere la nascita di una nota (commitment) alla sua morte (nullifier).
+- Il pubblico verifica le **regole**, mai il **contenuto**.
+
+Ora hai in mano la mappa. Il resto della serie la riempie.
+
+---
+
+## Glossario
+
+| Termine | Significato in parole semplici |
+|---|---|
+| **Note** | Un'unità privata di valore, l'equivalente Zcash di una moneta o di una banconota |
+| **Note commitment** | Un sigillo crittografico che prova l'esistenza di una nota senza rivelarla |
+| **Note commitment tree** | Il registro pubblico ad aggiunta sola di tutti i note commitment |
+| **Nullifier** | Un marcatore unico di "speso" pubblicato quando una nota viene usata, che impedisce le doppie spese |
+| **Zero-knowledge proof** | Una prova che un'affermazione è vera senza rivelare nulla oltre alla sua veridicità |
+| **Shielding / deshielding** | Spostare i fondi dentro / fuori dal mondo privato schermato |
+| **Viewing key** | La chiave che permette al proprietario di rilevare e leggere le note indirizzate a lui |
+
+---
+
+## FAQ
+
+**Zcash è sempre privato?**
+No. La privacy si applica al mondo *schermato* (indirizzi `z...`/`u...`). Le transazioni trasparenti (`t...`) sono pubbliche, come Bitcoin.
+
+**Se tutto è nascosto, cosa impedisce a qualcuno di stampare denaro gratis?**
+La zero-knowledge proof. Costringe matematicamente gli output di ogni transazione a essere coperti da input reali e non spesi, *pur* mantenendo segreti gli importi.
+
+**La stessa nota può essere spesa due volte?**
+No. Spendere una nota pubblica il suo nullifier; un secondo tentativo pubblicherebbe il nullifier identico, che è già nel "cestino degli spesi", quindi la rete lo rifiuta.
+
+**Gli osservatori esterni possono collegare un mittente a un destinatario?**
+No. Il commitment (nascita della nota) e il nullifier (morte della nota) non possono essere accoppiati da nessuno senza la conoscenza segreta del proprietario.
+
+---
+
+### Risposta al test di intuizione (Sezione 9)
+
+Se il nullifier fosse calcolato *solo* a partire dalla nota, senza alcuna chiave segreta, allora **chiunque** potrebbe calcolarlo, violando la proprietà #1 (solo il proprietario può spendere). Peggio ancora, il nullifier sarebbe ora derivabile direttamente da informazioni pubbliche sulla nota, il che potrebbe permettere agli osservatori di **collegare il nullifier al suo commitment**, violando la proprietà #3 e disfacendo silenziosamente la privacy dell'intero sistema. La chiave segreta è ciò che rende il gettone di annullamento al tempo stesso *esclusivamente tuo* e *non collegabile.*
+
+---
+
+### Cosa viene dopo
+
+**Articolo 1 . Campi finiti:** lo strano e bellissimo sistema numerico in cui l'aritmetica "si avvolge su se stessa", e il motivo per cui ogni pezzo di crittografia di questa serie vi risiede. Inizieremo, come sempre, con l'intuizione, senza formule finché non saranno meritate.
+
+*Parte della serie* Zcash dai primi principi *per [ZecHub](https://zechub.org). Concessa in licenza CC BY-SA 4.0.*

--- a/translations/it/site/Research/zcash-foundations-series/article-1/article-1-finite-fields.md
+++ b/translations/it/site/Research/zcash-foundations-series/article-1/article-1-finite-fields.md
@@ -1,0 +1,230 @@
+# Campi finiti: il sistema numerico in cui vive la crittografia
+##### Ricerca originale di [Annkkitaaa](https://github.com/Annkkitaaa)
+
+![alt text](image-5.png)
+
+### Perché il "ritorno ciclico" è il fondamento segreto di Zcash
+
+> **Serie:** *Zcash dai primi principi* . **Articolo 1 . Campi finiti**
+> **Pubblico:** principianti. Diamo per scontata solo la comune aritmetica scolastica (addizione, moltiplicazione, divisione). Nessuna conoscenza pregressa di crittografia o di matematica superiore.
+> **Cosa ti porterai a casa:** una comprensione intuitiva e corretta dei campi finiti, del perché i crittografi li usano e di dove compaiono all'interno di Zcash.
+
+Nell'[Articolo 0](article-0-shielded-transaction.md) abbiamo incontrato cinque personaggi: la nota, il commitment, l'albero dei commitment delle note, il nullifier e la prova a conoscenza zero. Abbiamo lasciato un filo in sospeso: *da dove arrivano davvero tutte le chiavi e le ricette segrete?* Arrivano dai numeri. Ma non i numeri ordinari con cui sei cresciuto. Arrivano da un sistema numerico speciale e autonomo chiamato **campo finito**, e quasi ogni pezzo di crittografia in Zcash è costruito su di esso.
+
+Questo articolo conquista questa idea lentamente. Come promesso, prima l'intuizione. Nessuna formula finché non si guadagna il proprio posto.
+
+---
+
+## 1. Perché dovrebbe interessarti?
+
+I numeri ordinari hanno un problema per la crittografia: ce ne sono infiniti e fanno trapelare informazioni.
+
+Pensa a cosa succede quando un numero diventa *più grande*. Se ti dico che un certo calcolo segreto ha prodotto `8.142.067`, già sai parecchio: è un numero di sette cifre, è dispari, è "abbastanza grande". La dimensione è un indizio. E gli indizi sono esattamente ciò che un sistema di privacy non può permettersi di rivelare.
+
+La crittografia vuole un sistema numerico dove:
+
+- ci sono **finitamente molti** valori, così che un computer possa memorizzarne uno qualunque esattamente, senza arrotondamenti e senza overflow,
+- i valori **non rivelano la loro dimensione**, perché il sistema non ha una vera nozione di "più grande",
+- puoi comunque **sommare, sottrarre, moltiplicare e dividere** liberamente e in modo reversibile, perché le ricette crittografiche hanno bisogno di vera algebra per funzionare, e
+- lo spazio può essere reso **astronomicamente grande**, così che indovinare sia senza speranza.
+
+Quella lista dei desideri ha un nome. È un **campo finito**. Costruiamo l'intuizione di uno prima di scrivere un singolo simbolo.
+
+---
+
+## 2. L'intuizione: un orologio
+
+Usi già un campo finito ogni giorno. È l'orologio sulla tua parete.
+
+Su un orologio a 12 ore, i numeri *tornano ciclicamente*. Parti dalle 10, aggiungi 5 ore, e non finisci sulle "15", finisci sulle **3**. L'orologio ha solo dodici posizioni, e contare oltre la cima semplicemente riporta all'inizio.
+
+![alt text](image-9.png)
+
+Sono appena successe tre cose che sono l'intero punto di questo articolo:
+
+1. **Il mondo è finito.** Ci sono esattamente dodici posizioni, per quanto a lungo si conti.
+2. **L'addizione funziona ancora.** Puoi sommare ore tutto il giorno; finisci sempre su una posizione valida dell'orologio.
+3. **La dimensione ha smesso di contare.** "Le 3" non ti dice se hai contato 3 ore o 15 o 27. Il ritorno ciclico *ha cancellato l'informazione sulla dimensione.* Quella cancellazione è esattamente la proprietà amica della privacy che volevamo.
+
+Questa aritmetica con ritorno ciclico ha un nome formale: **aritmetica modulare**. L'orologio funziona "modulo 12", scritto **mod 12**. I matematici preferiscono contare le posizioni partendo da 0, quindi un "orologio mod 12" ha in realtà le posizioni `0, 1, 2, ..., 11`. Un orologio mod 7 avrebbe le posizioni da `0` a `6`.
+
+> **L'unica regola:** per calcolare qualcosa "mod p", fai l'aritmetica ordinaria, poi dividi per `p` e tieni solo il resto.
+> Esempio mod 7: `5 + 4 = 9`, e `9` lascia resto `2` dopo la divisione per `7`, quindi `5 + 4 = 2 (mod 7)`.
+
+---
+
+## 3. Dall'orologio a un campo
+
+Un orologio ci permette di sommare. Un **campo** è il potenziamento: un sistema numerico in cui tutte e quattro le operazioni si comportano bene, compresa quella più insidiosa, la divisione.
+
+Informalmente, un **campo** è una qualsiasi collezione di "numeri" in cui puoi **sommare, sottrarre, moltiplicare e dividere** (per qualsiasi cosa tranne lo zero), e dove valgono ancora tutte le regole familiari: l'ordine non conta per l'addizione o la moltiplicazione, le parentesi possono essere raggruppate diversamente, ci sono uno `0` e un `1`, e ogni numero ha un opposto e (tranne lo `0`) un reciproco.
+
+I numeri razionali sono un campo. I numeri reali sono un campo. Ciò che vogliamo è uno *finito*.
+
+Ecco il risultato principale, ed è bellissimo:
+
+> **Prendi i numeri interi `0, 1, ..., p-1` e fai tutta l'aritmetica mod `p`. Se `p` è un numero primo, il risultato è un campo finito.** Lo scriviamo `F_p` (si legge "F sotto p").
+
+Quindi `F_7 = {0, 1, 2, 3, 4, 5, 6}` con l'aritmetica in stile orologio mod 7 è un autentico campo finito. Vediamolo respirare.
+
+### Moltiplicazione in F_7 (verificata)
+
+Ogni voce è `(riga x colonna) mod 7`:
+
+| x | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|---|---|
+| **0** | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| **1** | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
+| **2** | 0 | 2 | 4 | 6 | 1 | 3 | 5 |
+| **3** | 0 | 3 | 6 | 2 | 5 | 1 | 4 |
+| **4** | 0 | 4 | 1 | 5 | 2 | 6 | 3 |
+| **5** | 0 | 5 | 3 | 1 | 6 | 4 | 2 |
+| **6** | 0 | 6 | 5 | 4 | 3 | 2 | 1 |
+
+Guarda le righe da `1` a `6`: ognuna contiene ogni valore non nullo `1..6` esattamente una volta. Quel motivo "nessuna ripetizione, niente che manca" è l'impronta digitale visibile di un campo.
+
+### Divisione: la magia che richiede un primo
+
+La divisione è semplicemente "moltiplicare per il reciproco". In `F_7`, il reciproco (o **inverso**) di un numero `a` è il valore `a^(-1)` per cui `a x a^(-1) = 1`. Leggendoli direttamente dalla tabella:
+
+| `a` | 1 | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|---|
+| `a⁻¹` | 1 | 4 | 5 | 2 | 3 | 6 |
+
+Verifichiamone uno: `2 x 4 = 8 = 1 (mod 7)`.  Quindi "dividere per 2" in `F_7` significa "moltiplicare per 4". Ogni elemento non nullo ha un partner. **È questo che rende `F_7` un campo.**
+
+---
+
+## 4. Perché il modulo deve essere primo
+
+Questa è l'idea più importante in assoluto dell'articolo, quindi rendiamola concreta anziché astratta.
+
+Guarda cosa si rompe se proviamo ingenuamente a costruire un "campo" mod `6` (e `6` *non* è primo):
+
+> Esiste un qualche `x` con `2 x x = 1 (mod 6)`? Verificandoli tutti: `2x0=0, 2x1=2, 2x2=4, 2x3=0, 2x4=2, 2x5=4`. **La risposta `1` non compare mai.** Quindi `2` non ha reciproco mod 6. Peggio ancora, `2 x 3 = 6 = 0 (mod 6)`: due numeri non nulli moltiplicati danno zero.
+
+Quella seconda frase è una catastrofe per l'aritmetica. Due cose non nulle che si moltiplicano dando zero (chiamate **divisore dello zero**) significa che la divisione è rotta, e un sistema con la divisione rotta non è un campo. Succede proprio perché `6` si fattorizza come `2 x 3`.
+
+Un primo, per definizione, non ha tali fattori. Quindi mod un primo non possono comparire divisori dello zero, ogni elemento non nullo ottiene un reciproco pulito, e la struttura è un campo a tutti gli effetti.
+
+![alt text](image-8.png)
+
+> **Frase a effetto riutilizzabile per i tuoi articoli:** *modulo primo dentro, divisione pulita fuori.*
+
+---
+
+## 5. L'unica formula che vale la pena incontrare: come i computer trovano gli inversi
+
+Abbiamo letto gli inversi da una tabella per `F_7`, ma il primo di Zcash ha centinaia di cifre; nessuna tabella è possibile. C'è una classica scorciatoia, ed è l'unica formula di questo articolo.
+
+Il **Piccolo Teorema di Fermat** afferma che per un primo `p` e qualsiasi `a` non nullo:
+
+```
+a^(p-1) = 1   (mod p)
+```
+
+Riorganizzalo (stacca un fattore di `a`) e ottieni l'inverso gratis:
+
+```
+a^(-1) = a^(p-2)   (mod p)
+```
+
+Verifica in `F_7` (`p = 7`, quindi `p - 2 = 5`): l'inverso di `2` dovrebbe essere `2^5 = 32 = 4 (mod 7)`. E in effetti la nostra tabella diceva `2^(-1) = 4`.  I computer elevano a potenze grandi in modo estremamente veloce, quindi questo trasforma il "trovare il reciproco" in un calcolo rapido ed esatto anche per primi giganteschi.
+
+Non hai bisogno di memorizzare questo. Hai bisogno di sapere che **la divisione in un campo finito è un'operazione veloce ed esatta**, che è esattamente il motivo per cui i crittografi sono felici di costruire su di essa.
+
+---
+
+## 6. Perché la crittografia si è innamorata dei campi finiti
+
+Mettendo insieme l'intuizione, ecco l'intera tesi in una pagina.
+
+| Proprietà di `F_p` | Perché un sistema di privacy la desidera |
+|---|---|
+| **Finito** | Un computer memorizza qualsiasi elemento esattamente; niente arrotondamenti, niente overflow, niente imprecisione in virgola mobile |
+| **Ritorno ciclico** | Cancella la "dimensione", così un valore non rivela nulla su come è stato prodotto |
+| **Tutte e quattro le operazioni funzionano** | Le ricette crittografiche (chiavi, commitment, prove) hanno bisogno di vera algebra, non solo di conteggio |
+| **Dimensione scelta a piacere** | Scegli un primo a 255 bit o a 381 bit e il campo ha più elementi degli atomi nell'universo osservabile; indovinare è senza speranza |
+| **Esatto e deterministico** | Due parti oneste che calcolano la stessa cosa ottengono sempre risultati identici, da cui le prove dipendono |
+
+Un campo finito è, in una frase, **un parco giochi per l'aritmetica perfettamente chiuso, perfettamente esatto, perfettamente enorme.** Tutto il resto in Zcash è costruito giocando al suo interno.
+
+---
+
+## 7. Dove vive tutto questo in Zcash
+
+Non devi prendere per fede che "Zcash usa i campi finiti". Ecco la mappa concreta (il macchinario più profondo è per gli articoli successivi; questo serve solo a mostrare che le impronte sono reali).
+
+- **Sapling** (un design schermato più vecchio) costruisce le sue prove su una curva chiamata **BLS12-381**, il cui campo base usa un primo lungo **381 bit**. Ogni coordinata, chiave ed elemento di prova è un elemento di un campo finito costruito su quel primo.
+- **Orchard** (l'attuale design schermato) usa una coppia di curve chiamate **Pallas e Vesta** (le curve "Pasta"), i cui campi usano primi lunghi all'incirca **255 bit**.
+- Il **commitment della nota**, il **nullifier** e i numeri all'interno di una **prova a conoscenza zero** dell'Articolo 0 sono tutti, in fondo, elementi di uno di questi campi finiti. Quando il protocollo dice "calcola questo commitment", significa "fai questa aritmetica mod quel primo".
+
+![alt text](image-7.png)
+
+Quindi la risposta alla domanda aperta dell'Articolo 0, *"da dove arrivano le ricette segrete?"*, comincia qui: **tutto inizia come aritmetica in un campo finito.** Nel prossimo articolo prenderemo quel campo e costruiremo gli oggetti veri e propri, i punti su una curva ellittica, che diventano chiavi e commitment.
+
+---
+
+## 8. Una nota onesta
+
+Per rimanere amichevoli verso i principianti, abbiamo semplificato alcune cose vere. I campi finiti non vengono solo nella varietà `F_p`; puoi anche costruire campi con `p^n` elementi (chiamati **campi di estensione**), e quelli contano per gli "accoppiamenti" (pairings) su cui si basa il sistema di prove di Sapling. Abbiamo anche saltato la lista completa degli assiomi di campo e sorvolato su come si scelgono e si validano i primi di queste dimensioni. Niente di tutto ciò cambia l'intuizione che ora possiedi; la affina. Reintrodurremo la precisione, con dei segnalibri, quando un articolo successivo ne avrà bisogno.
+
+---
+
+## 9. Riepilogo
+
+- La crittografia ha bisogno di un sistema numerico che sia **finito, esatto, cieco alla dimensione, completamente invertibile ed enorme.** Quel sistema è un **campo finito**.
+- L'intuizione è un **orologio**: aritmetica che **torna ciclicamente** (aritmetica modulare), che convenientemente cancella la "dimensione" di un numero.
+- Fare aritmetica con i numeri `0..p-1` mod un **primo** `p` dà un vero campo `F_p`, dove puoi anche **dividere** perché ogni elemento non nullo ha un inverso.
+- Il modulo **deve essere primo**: un modulo composto crea divisori dello zero (come `2 x 3 = 0 mod 6`) e rompe la divisione.
+- I computer trovano gli inversi velocemente tramite il **Piccolo Teorema di Fermat** (`a^(-1) = a^(p-2)`).
+- In **Zcash**, ogni chiave, commitment, nullifier ed elemento di prova è in ultima analisi un elemento di un grande campo finito (campi Pasta a 255 bit per Orchard, un campo a 381 bit per la BLS12-381 di Sapling).
+
+---
+
+## Glossario
+
+| Termine | Significato in parole semplici |
+|---|---|
+| **Aritmetica modulare** | Aritmetica che torna ciclicamente dopo aver raggiunto un valore fisso, come un orologio |
+| **mod p** | "Dividi per `p` e tieni il resto" |
+| **Campo** | Un sistema numerico in cui addizione, sottrazione, moltiplicazione e divisione funzionano tutte |
+| **Campo finito `F_p`** | I numeri `0..p-1` con l'aritmetica fatta mod un primo `p` |
+| **Inverso (reciproco)** | L'elemento `a^(-1)` con `a x a^(-1) = 1`; "dividere per `a`" significa moltiplicare per esso |
+| **Divisore dello zero** | Due valori non nulli il cui prodotto è zero; la cosa che rovina i moduli composti |
+| **Primo** | Un numero intero maggiore di 1 senza fattori tranne 1 e sé stesso |
+
+---
+
+## FAQ
+
+**Perché non usare semplicemente gli interi ordinari o i decimali?**
+I decimali arrotondano e derivano; gli interi crescono senza limite e fanno trapelare la dimensione. I campi finiti sono esatti, limitati e ciechi alla dimensione, cosa che la crittografia richiede.
+
+**Il "ritorno ciclico" perde informazioni?**
+Di proposito, sì. Cancellare la dimensione dei valori intermedi è una funzionalità, non un difetto, per la privacy.
+
+**Un primo più grande è sempre più sicuro?**
+In senso lato, un campo più grande significa più valori possibili e un indovinare più difficile, ma la sicurezza dipende dall'intera costruzione, non dalla sola dimensione del campo. Gli articoli successivi rendono questo preciso.
+
+**Perché proprio questi primi (255 bit, 381 bit) in Zcash?**
+Sono scelti in modo che le curve costruite su di essi abbiano la struttura e l'efficienza giuste per il sistema di prove. Quella "struttura giusta" è l'argomento dei prossimi due articoli.
+
+---
+
+### Metti alla prova la tua intuizione
+
+In `F_7`, quanto fa `5 - 6`? (Ricorda: resta dentro `{0,...,6}` tornando ciclicamente.) *(Risposta sotto.)*
+
+<details><summary>Risposta</summary>
+
+`5 - 6 = -1`, e `-1` riportato in `F_7` è `6` (perché `6 + 1 = 7 = 0`). Quindi `5 - 6 = 6 (mod 7)`. La sottrazione non lascia mai il campo; torna semplicemente ciclicamente nell'altra direzione.
+</details>
+
+---
+
+### Cosa viene dopo
+
+**Articolo 2 . Curve ellittiche:** prendiamo il campo finito che abbiamo appena costruito e lo usiamo per disegnare uno strano tipo di curva i cui punti possono essere "sommati" tra loro. Quei punti diventano le chiavi e i commitment di Zcash, e nascondono una botola unidirezionale che rende possibile l'intero sistema di privacy. Prima l'intuizione, come sempre.
+
+*Parte della serie* Zcash dai primi principi *per [ZecHub](https://zechub.org). Concesso in licenza CC BY-SA 4.0.*

--- a/translations/it/site/Research/zcash-foundations-series/article-2/article-2-elliptic-curves.md
+++ b/translations/it/site/Research/zcash-foundations-series/article-2/article-2-elliptic-curves.md
@@ -1,0 +1,229 @@
+# Curve Ellittiche: Dove Nascono le Chiavi e gli Impegni di Zcash
+##### Ricerca originale di [Annkkitaaa](https://github.com/Annkkitaaa)
+
+![alt text](image-10.png)
+
+### Una strada a senso unico costruita con punti su una curva
+
+> **Serie:** *Zcash dai Primi Principi* . **Articolo 2 . Curve Ellittiche**
+> **Pubblico:** principianti. Presupponiamo solo l'[Articolo 1 (campi finiti)](article-1-finite-fields.md): aritmetica che si avvolge mod un primo. Nessun altro prerequisito necessario.
+> **Cosa porterai con te:** un'immagine intuitiva e corretta delle curve ellittiche, la "trapdoor" che le rende utili ed esattamente come Zcash le trasforma in chiavi e impegni.
+
+L'[Articolo 1](article-1-finite-fields.md) ci ha dato un terreno di gioco perfetto per l'aritmetica: il campo finito. Ma un campo di per sé è solo numeri. Per costruire le chiavi e le "buste sigillate" dell'[Articolo 0](article-0-shielded-transaction.md), Zcash ha bisogno di un oggetto con un tipo speciale di difficoltà unidirezionale: facile da calcolare in avanti, praticamente impossibile da invertire. Quell'oggetto è una **curva ellittica**. Questo articolo la costruisce da zero, l'intuizione prima dell'algebra.
+
+---
+
+## 1. Perché dovrebbe interessarti?
+
+Ogni sistema di privacy ha bisogno di una **strada a senso unico**: un'operazione banale da percorrere in avanti ed effettivamente impossibile da percorrere all'indietro.
+
+Ecco perché. La tua **chiave segreta** è un numero che tieni nascosto. La tua **chiave pubblica** (e il tuo indirizzo) viene derivata da essa e mostrata al mondo. L'intera sicurezza del sistema poggia su un fatto: *data la chiave pubblica, nessuno può risalire alla tua chiave segreta.* Se potessero, potrebbero spendere il tuo denaro.
+
+Quindi abbiamo bisogno di un'operazione matematica in cui:
+
+- andare **avanti** (segreta -> pubblica) sia veloce e facile, ma
+- andare **indietro** (pubblica -> segreta) sia così difficile che tutti i computer sulla Terra che lavorano per l'intera durata dell'universo non finirebbero.
+
+La semplice moltiplicazione nei campi finiti non è sufficiente; la divisione la annulla all'istante (era proprio questo il punto dell'Articolo 1). Ci serve qualcosa senza un comodo pulsante di "annulla". Le curve ellittiche forniscono esattamente questo e, come bonus, i loro punti si combinano in un modo perfetto per costruire impegni. Vediamo come.
+
+---
+
+## 2. L'intuizione: una curva i cui punti puoi "sommare"
+
+Dimentica la crittografia per un momento. Una **curva ellittica** è semplicemente l'insieme dei punti `(x, y)` che soddisfano un'equazione della forma:
+
+```
+y^2 = x^3 + ax + b
+```
+
+Sui numeri ordinari assomiglia a una curva liscia e ondulata, spesso con un cappio arrotondato e due code:
+
+![alt text](image-14.png)
+
+La parte davvero sorprendente: **puoi "sommare" due punti su questa curva per ottenere un terzo punto sulla stessa curva.** Non è l'ordinaria addizione di coordinate. È una regola geometrica, ed è più facile da *vedere* che da spiegare.
+
+### La regola della corda (sommare due punti diversi)
+
+Per sommare `P + Q`:
+
+1. Traccia una retta che passa per `P` e `Q`.
+2. Quella retta colpisce la curva esattamente in un altro punto. Chiamalo `R*`.
+3. **Rifletti `R*` rispetto all'asse orizzontale.** Quella riflessione è la risposta, `P + Q`.
+
+![alt text](image-11.png)
+
+### La regola della tangente (sommare un punto a se stesso)
+
+Per calcolare `P + P` (scritto `2P`), non c'è un secondo punto attraverso cui tracciare una retta, quindi usi invece la retta **tangente** in `P`, poi segui la stessa ricetta "terza intersezione, poi rifletti".
+
+Questa è l'intera operazione. Due regole geometriche. Con esse, i punti di una curva ellittica formano ciò che i matematici chiamano un **gruppo**: un insieme con un'"addizione" ben definita. Ha persino uno "zero".
+
+### Il punto all'infinito (lo zero della curva)
+
+Ogni sistema numerico ha bisogno di uno `0`, la cosa che non cambia nulla quando la sommi. Su una curva ellittica, quel ruolo è svolto da uno speciale punto extra chiamato **punto all'infinito**, scritto `O`. Puoi immaginarlo come "infinitamente in alto", il luogo dove le rette verticali si incontrano. Sommare `O` a qualsiasi punto lo lascia invariato, esattamente come sommare `0`.
+
+---
+
+## 3. Dalle immagini a un campo finito
+
+La curva liscia di sopra è l'*intuizione*. Ma Zcash non usa i numeri reali (arrotondano e fanno trapelare la dimensione, come da Articolo 1). Usa una curva ellittica **su un campo finito**: la stessa equazione `y^2 = x^3 + ax + b`, ma con tutta l'aritmetica eseguita mod un primo.
+
+Quando lo fai, la bella curva si frantuma in uno **sparpaglio di punti scollegati**, un punto per ogni coppia `(x, y)` che soddisfa l'equazione mod `p`. Smette del tutto di assomigliare a una curva. Ma ecco la cosa cruciale:
+
+> **L'algebra della regola della corda-e-tangente funziona ancora perfettamente.** Le stesse formule che trovavano `P + Q` geometricamente ora lo calcolano con l'aritmetica dei campi finiti. I punti formano ancora un gruppo, con lo stesso `0` (il punto all'infinito).
+
+Rendiamolo concreto con un esempio minuscolo e interamente verificato.
+
+### Una curva completa, calcolata esattamente
+
+Prendi `y^2 = x^3 + 2x + 2` sul campo finito `F_17`. Calcolando ogni punto valido si ottengono esattamente **18 punti, più il punto all'infinito = 19 in totale.** Alcuni di essi:
+
+```
+(0,6) (0,11) (3,1) (3,16) (5,1) (5,16) (6,3) (6,14) (7,6) (7,11) ...
+```
+
+Ora scegli il punto `G = (5, 1)` e continua a sommarlo a se stesso. Guarda cosa succede (ogni riga qui sotto è stata calcolata, non indovinata):
+
+| Passo | Punto | Passo | Punto |
+|---|---|---|---|
+| `1G` | (5, 1) | `11G` | (13, 10) |
+| `2G` | (6, 3) | `12G` | (0, 11) |
+| `3G` | (10, 6) | `13G` | (16, 4) |
+| `4G` | (3, 1) | `14G` | (9, 1) |
+| `5G` | (9, 16) | `15G` | (3, 16) |
+| `6G` | (16, 13) | `16G` | (10, 11) |
+| `7G` | (0, 6) | `17G` | (6, 14) |
+| `8G` | (13, 7) | `18G` | (5, 16) |
+| `9G` | (7, 6) | `19G` | **O (infinito)** |
+| `10G` | (7, 11) | | |
+
+Due cose da notare:
+
+- **Visita tutti i 18 punti finiti e poi atterra su `O`** al passo 19, dopodiché si ripeterebbe per sempre. Il punto di partenza `G` "genera" l'intero gruppo, quindi lo chiamiamo **generatore**.
+- È un gruppo verificato: per esempio `1G + 2G = (5,1) + (6,3) = (10,6)`, che è esattamente `3G`.  L'addizione è internamente coerente, proprio come richiede un gruppo.
+
+---
+
+## 4. La trapdoor: la moltiplicazione scalare
+
+Quella tabella di `1G, 2G, 3G, ...` è il cuore di tutto. Sommare ripetutamente un punto a se stesso si chiama **moltiplicazione scalare**: il punto `kG` significa "`G` sommato a se stesso `k` volte."
+
+Ora la magia. Considera le due direzioni:
+
+| Direzione | Domanda | Difficoltà |
+|---|---|---|
+| **In avanti** | Dati `k` e `G`, calcola `kG` | **Facile.** Anche per `k` astronomicamente enormi, un trucco chiamato *double-and-add* ci arriva in poche centinaia di passi |
+| **All'indietro** | Dati `G` e `kG`, recupera `k` | **Effettivamente impossibile** su una vera curva crittografica |
+
+Quell'asimmetria è la **strada a senso unico** di cui avevamo bisogno nella Sezione 1. Il problema all'indietro ("quale `k` ha prodotto questo punto?") si chiama **Problema del Logaritmo Discreto su Curva Ellittica (ECDLP)**, e sulle curve che Zcash usa, nessun metodo noto lo risolve prima della morte termica dell'universo.
+
+![alt text](image-12.png)
+
+> Nella nostra curva giocattolo `F_17` *potresti* semplicemente leggere `k` dalla tabella, perché ha solo 19 punti. Le curve reali hanno circa `2^(255)` punti. La tabella avrebbe più righe degli atomi presenti nell'universo, quindi "leggerlo dalla tabella" non è un'opzione. La piccolezza è ciò che rende la curva giocattolo didattica ed è anche il motivo per cui non è sicura.
+
+---
+
+## 5. Come nascono le chiavi (la ricompensa)
+
+Ora abbiamo tutto il necessario per spiegare una vera chiave crittografica, ed è sorprendentemente semplice:
+
+> **Scegli un numero segreto `k`. Pubblica il punto `kG`. Tutto qui.**
+> `k` è la tua **chiave privata**. `kG` è la tua **chiave pubblica**. La strada a senso unico (ECDLP) garantisce che nessuno possa ricondurre `kG` a `k`.
+
+Questa singola idea, *una chiave pubblica è uno scalare segreto moltiplicato per un generatore fisso*, è il seme delle chiavi di spesa, delle viewing key e degli indirizzi di Zcash. L'intero albero delle chiavi sovrappone più struttura a questo, ma ogni ramo cresce da questa radice.
+
+### Bonus: perché i punti della curva costituiscono impegni perfetti
+
+Ricorda la "busta sigillata" (impegno) dell'Articolo 0, che doveva **nascondere** il proprio contenuto pur essendo **impossibile da falsificare**. Le curve ellittiche ci offrono un modo pulito per costruirne uno. Prendi due punti generatori pubblici fissi `G` e `H`, un valore segreto `v` e un numero casuale di mascheramento (blinding) `r`, e forma:
+
+```
+Impegno  =  v.G  +  r.H
+```
+
+Questo è un **impegno di Pedersen**, e possiede entrambe le proprietà che volevamo:
+
+- **Occultamento:** il `r` casuale spalma il risultato su tutta la curva, quindi il punto non rivela nulla su `v`.
+- **Vincolo:** l'ECDLP rende impraticabile trovare una *diversa* coppia `(v, r)` che dia lo stesso punto, quindi non puoi cambiare idea su ciò a cui ti sei impegnato.
+
+Una proprietà bonus si rivela preziosissima più avanti: questi impegni **si sommano**. L'impegno a `v_1` più l'impegno a `v_2` è un impegno valido a `v_1 + v_2`. Quel comportamento "omomorfo" è il modo in cui Zcash dimostrerà più avanti che il denaro che *entra* in una transazione è uguale al denaro che ne *esce*, senza rivelare alcun importo. Lo metteremo a frutto intorno all'Articolo 6.
+
+---
+
+## 6. Dove vive tutto questo in Zcash
+
+Le impronte sono concrete e verificabili.
+
+| Design di Zcash | Curve che usa | Ruolo |
+|---|---|---|
+| **Sapling** (più vecchia) | **BLS12-381** più una curva embedded chiamata **Jubjub** | BLS12-381 porta il sistema di prove; Jubjub è costruita sul campo scalare di BLS12-381 in modo che le operazioni su chiavi e impegni siano economiche da eseguire *all'interno* di una prova a conoscenza zero |
+| **Orchard** (attuale) | **Pallas** e **Vesta** (il ciclo "Pasta") | Pallas porta le chiavi e gli impegni di Orchard; l'accoppiamento Pallas/Vesta è organizzato appositamente per rendere efficienti le prove avanzate |
+
+Le ragioni per cui una curva viene "embedded" all'interno del campo di un'altra, e perché un *ciclo* di due curve è utile, sono reali e importanti, ma appartengono agli articoli sui sistemi di prove. Per ora il messaggio da portare a casa è solido: **ogni chiave di Zcash è uno scalare moltiplicato per un generatore, e ogni impegno di Zcash è una somma di punti della curva**, che vivono su una di queste curve nominate.
+
+![alt text](image-13.png)
+
+---
+
+## 7. Un onesto disclaimer
+
+Alcune semplificazioni hanno mantenuto questo testo leggibile. Abbiamo usato la forma **Weierstrass corta** (`y^2 = x^3 + ax + b`); le curve di Zcash sono spesso scritte in altre forme equivalenti (Jubjub è una curva *twisted Edwards*) scelte per efficienza e sicurezza, ma l'idea di gruppo è identica. Non abbiamo definito le esatte formule di addizione dei punti (sono la versione algebrica di "terza intersezione, poi rifletti"), e abbiamo messo da parte sottigliezze come l'ordine della curva, i cofattori e i "pairing", che diventano importanti negli articoli sui sistemi di prove. Niente di tutto ciò cambia l'intuizione; la affina.
+
+---
+
+## 8. Riepilogo
+
+- Un sistema di privacy ha bisogno di una **strada a senso unico**: facile in avanti, impraticabile all'indietro. Le curve ellittiche ne forniscono una.
+- Una **curva ellittica** è l'insieme dei punti che soddisfano `y^2 = x^3 + ax + b`, e i suoi punti possono essere **sommati** tramite la regola geometrica della **corda-e-tangente**, con uno speciale **punto all'infinito** che funge da zero.
+- Su un **campo finito** la curva diventa uno sparpaglio di punti, ma la stessa addizione funziona ancora e i punti formano un **gruppo**. (Esempio verificato: `y^2 = x^3 + 2x + 2` su `F_17` ha 19 punti, e `G = (5,1)` li genera tutti.)
+- La **moltiplicazione scalare** `kG` è facile da calcolare ma impraticabile da invertire: l'**ECDLP**. Questa è la trapdoor.
+- **Chiavi:** chiave privata `k`, chiave pubblica `kG`. **Impegni:** forma di Pedersen `v.G + r.H`, che nasconde, vincola e convenientemente **si somma**.
+- In **Zcash**, Sapling usa **BLS12-381 + Jubjub** e Orchard usa le curve **Pallas/Vesta (Pasta)**; ogni chiave e ogni impegno vivono su queste.
+
+---
+
+## Glossario
+
+| Termine | Significato in parole semplici |
+|---|---|
+| **Curva ellittica** | Punti che soddisfano `y^2 = x^3 + ax + b`, con una speciale "addizione" di punti |
+| **Addizione di punti** | La regola della corda-e-tangente: retta per due punti, prendi la terza intersezione, rifletti |
+| **Punto all'infinito (`O`)** | Lo "zero" della curva; sommarlo non cambia nulla |
+| **Generatore (`G`)** | Un punto base i cui multipli alla fine coprono l'intero gruppo |
+| **Moltiplicazione scalare (`kG`)** | Sommare `G` a se stesso `k` volte; facile in avanti, difficile da invertire |
+| **ECDLP** | Il problema difficile di recuperare `k` da `kG`; il fondamento della sicurezza |
+| **Impegno di Pedersen** | `v.G + r.H`; una busta sigillata che nasconde, vincola e si somma |
+
+---
+
+## FAQ
+
+**Perché le curve invece di semplici grandi numeri mod un primo?**
+Entrambi possono fornire una strada a senso unico, ma le curve ellittiche raggiungono la stessa sicurezza con chiavi molto più piccole e operazioni più veloci, e la loro aritmetica dei punti è ideale per gli impegni.
+
+**È dimostrato che l'ECDLP è difficile?**
+Non è *dimostrato* impossibile, ma decenni di intensi sforzi non hanno trovato alcun attacco efficiente su curve ben scelte. La sicurezza poggia su questa assunzione ben collaudata.
+
+**Un computer quantistico potrebbe romperlo?**
+Un computer quantistico abbastanza grande potrebbe rompere l'ECDLP. Questa è una nota preoccupazione a lungo termine in tutto il settore e un'area di ricerca attiva; le curve di oggi rimangono sicure contro i computer classici.
+
+**Perché Zcash usa più di una curva?**
+Compiti diversi. Una curva porta il sistema di prove a conoscenza zero; un'altra (embedded nel campo della prima) rende efficienti le operazioni su chiavi e impegni all'interno della prova. I prossimi articoli spiegano perché quell'accoppiamento è importante.
+
+---
+
+### Metti alla prova la tua intuizione
+
+Usando la tabella verificata nella Sezione 3, quanto fa `9G + 10G` sulla nostra curva giocattolo? E cosa ti dice la risposta su `G`? *(Risposta sotto.)*
+
+<details><summary>Risposta</summary>
+
+`9 + 10 = 19`, e abbiamo visto che `19G = O`, il punto all'infinito. Quindi `9G + 10G = O`. Questo significa che `10G` è il **negativo** (inverso additivo) di `9G`: due punti che si sommano dando il punto "zero". Su una curva, il negativo di un punto è semplicemente la sua immagine speculare rispetto all'asse x, e infatti `9G = (7,6)` e `10G = (7,11)` condividono la stessa `x` e hanno valori di `y` la cui somma è `17 = 0 (mod 17)`. La struttura è perfettamente coerente, che è esattamente ciò che garantisce "è un gruppo".
+</details>
+
+---
+
+### Cosa viene dopo
+
+**Articolo 3 . Hashing e impegni:** apriremo per bene la "magica busta sigillata". Hai ora visto un modo per costruire un impegno a partire dai punti della curva; in seguito ci chiederemo cosa significhino davvero occultare e vincolare, incontreremo le funzioni hash e collegheremo entrambe agli impegni delle note che ancorano ogni pagamento Zcash.
+
+*Parte della serie* Zcash dai Primi Principi *per [ZecHub](https://zechub.org). Concesso in licenza CC BY-SA 4.0.*

--- a/translations/it/site/Research/zcash-foundations-series/article-3/article-3-hashing-commitments.md
+++ b/translations/it/site/Research/zcash-foundations-series/article-3/article-3-hashing-commitments.md
@@ -1,0 +1,187 @@
+# Hashing e impegni: la magica busta sigillata
+##### Ricerca originale di [Annkkitaaa](https://github.com/Annkkitaaa)
+
+![alt text](image-15.png)
+
+### Come bloccare un segreto in pubblico senza poter mai mentire al riguardo
+
+> **Serie:** *Zcash dai primi principi* . **Articolo 3 . Hashing e impegni**
+> **Pubblico:** principianti. Ci basiamo sull'[Articolo 1 (campi finiti)](article-1-finite-fields.md) e sull'[Articolo 2 (curve ellittiche)](article-2-elliptic-curves.md), ma l'intuizione si regge da sola.
+> **Cosa porterai con te:** una chiara comprensione delle funzioni hash, cosa significhino davvero "occultamento" e "vincolo", e come Zcash costruisce i note commitment che ancorano ogni pagamento privato.
+
+Nell'[Articolo 0](article-0-shielded-transaction.md) abbiamo descritto una "magica busta sigillata": qualcosa che puoi appendere a una bacheca pubblica che prova l'esistenza di una busta nascondendone il contenuto, e che non puoi mai sostituire in seguito. Avevamo promesso di spiegare come una cosa simile sia possibile. Questo è quell'articolo. Ci servono due ingredienti: le **funzioni hash** e gli **impegni** (commitment).
+
+---
+
+## 1. Perché dovrebbe interessarti?
+
+Immagina di prevedere l'esito di un'elezione e di voler dimostrare, *a posteriori*, di averlo previsto in anticipo. Non puoi semplicemente annunciare la tua previsione (questo influenza le persone, o ti espone all'accusa di averla cambiata). E non puoi tenerla del tutto segreta (allora non puoi dimostrare nulla in seguito).
+
+Quello che vuoi è un modo per **bloccare un valore ora, in pubblico, in modo tale che:**
+
+- nessuno possa capire cosa hai bloccato (resta segreto per ora), e
+- più tardi, quando lo riveli, tu **non possa mentire** su cosa fosse.
+
+Questo congegno "blocca ora, rivela dopo, niente bugie" si chiama **commitment** (impegno), ed è ovunque in Zcash. Il valore e il proprietario di una nota vengono bloccati in un commitment nel momento in cui la nota viene creata. Per costruire i commitment, ci serve prima il loro cavallo da tiro: la funzione hash.
+
+---
+
+## 2. L'intuizione: un'impronta digitale per i dati
+
+Una **funzione hash** prende qualsiasi dato, una singola lettera o un'intera biblioteca, e lo comprime in una stringa breve e di dimensione fissa chiamata **digest** o **hash**. Pensala come un'**impronta digitale per i dati.**
+
+![alt text](image-16.png)
+
+Una buona impronta digitale crittografica ha quattro proprietà. Tienile a mente come intuizioni, non come equazioni:
+
+| Proprietà | Significato semplice | Perché è importante |
+|---|---|---|
+| **Deterministica** | Lo stesso input dà sempre la stessa impronta | Puoi ri-verificare un'impronta in qualsiasi momento |
+| **Veloce in avanti** | Calcolare l'impronta è rapido | Pratica da usare ovunque |
+| **Unidirezionale (resistente alla preimmagine)** | Data un'impronta, non puoi trovare l'input che l'ha generata | Nasconde i dati originali |
+| **Resistente alle collisioni** | Non puoi trovare due input diversi con la stessa impronta | Nessuno può falsificare una corrispondenza |
+
+E un altro comportamento che fa sembrare le impronte quasi magiche:
+
+### L'effetto valanga (verificato)
+
+Cambia l'input della minima quantità e l'impronta cambia *completamente*, senza alcuna somiglianza con quella vecchia. Ecco due vere impronte SHA-256 di messaggi che differiscono per un solo carattere:
+
+```
+H("Pay Bob 5 ZEC") = 6e2dc1a954c70cc865f18ea8cb70b7b56eeaf6ca42b380824a55d65dc342f34b
+H("Pay Bob 6 ZEC") = 76abc346d8d3053f76a9ae18b617af71f02729a73ec6a51732d2d94934e4217f
+```
+
+Su 64 cifre esadecimali, **59 sono diverse.** Un carattere in entrata, un'impronta del tutto scorrelata in uscita. Ecco perché non puoi spingere un input verso un'impronta bersaglio: non c'è alcun segnale "più caldo / più freddo" da seguire.
+
+---
+
+## 3. Dall'impronta digitale all'impegno
+
+Ecco un'idea allettante ma fallace: per impegnarsi su un valore segreto `v`, basta pubblicarne l'impronta `H(v)`.
+
+Questo ti *vincola* bene (non puoi in seguito sostenere un `v` diverso, perché ciò richiederebbe una collisione). Ma **non riesce a nascondere.** Se l'insieme dei valori possibili è piccolo, un attaccante prende semplicemente l'impronta di ogni candidato e le confronta. Ti impegni su "sì" o "no"? Lui calcola l'hash di entrambi e scopre all'istante quale hai scelto. Il determinismo, nostro amico un attimo fa, ora fa trapelare il segreto.
+
+La soluzione è una sola parola: **casualità.**
+
+> **Un commitment è l'impronta digitale del tuo valore mescolata con un numero casuale fresco:**
+> `commitment = H(v, r)` dove `r` è un valore casuale segreto di "accecamento" (blinding).
+
+Ora lo stesso `v` produce un commitment dall'aspetto diverso ogni volta, perché `r` è diverso. Le due proprietà che volevamo finalmente valgono entrambe:
+
+![alt text](image-17.png)
+
+Per **aprire** (rivelare) il commitment in seguito, pubblichi `v` e `r`; chiunque ricalcola `H(v, r)` e verifica che corrisponda. Sei vincolato. Quella è la magica busta sigillata dell'Articolo 0, resa reale.
+
+> **Due concetti da portare con te per sempre:** il *vincolo* deriva dall'hash che è resistente alle collisioni; l'*occultamento* deriva dal fattore casuale di accecamento `r`.
+
+---
+
+## 4. Due modi per costruire la busta
+
+Ci sono due ricette comuni, e Zcash le usa entrambe.
+
+| | **Commitment basato su hash** | **Commitment di Pedersen** (dall'Articolo 2) |
+|---|---|---|
+| Ricetta | `H(v, r)` | `v.G + r.H` (punti su una curva) |
+| Occultamento da | l'`r` casuale | l'`r` casuale |
+| Vincolo da | resistenza alle collisioni | la trappola della curva ellittica (ECDLP) |
+| Potere speciale | semplice e veloce | i commitment **si sommano** (omomorfici) |
+
+Quest'ultima riga è il motivo per cui i commitment di Pedersen sono così importanti in Zcash. Poiché `commit(v_1) + commit(v_2)` è un valido `commit(v_1 + v_2)`, il protocollo può in seguito provare che **il denaro in entrata è pari al denaro in uscita** sommando i commitment, il tutto senza rivelare un solo importo. Ci stiamo mettendo da parte questo fatto per l'Articolo 6.
+
+---
+
+## 5. Una sottigliezza che plasma tutto Zcash: l'hashing ZK-friendly
+
+Ecco un'intuizione che la maggior parte delle introduzioni manca, ed è esattamente il punto "matematica incontra ingegneria" che vale la pena evidenziare.
+
+SHA-256 è un'eccellente impronta digitale per l'informatica di tutti i giorni. Ma Zcash non si limita a *calcolare* gli hash; deve **provare, all'interno di una prova a conoscenza zero, che un hash è stato calcolato correttamente** (l'Articolo 5 spiega perché). E qui sta il problema: una prova a conoscenza zero lavora nel linguaggio dell'**aritmetica su campi finiti** (Articolo 1), mentre SHA-256 è costruita a partire da operazioni di manipolazione dei bit (shift, AND, XOR). Esprimere tutta quella manipolazione dei bit in aritmetica su campi è enormemente costoso, rendendo le prove enormi e lente.
+
+Così i crittografi di Zcash hanno progettato funzioni hash i cui meccanismi interni sono *già* aritmetica su campi, rendendole economiche da provare:
+
+![alt text](image-18.png)
+
+Questa singola pressione ingegneristica, *"deve essere economico da provare"*, è il motivo per cui Zcash ha inventato e adottato funzioni hash speciali invece di ricorrere a SHA-256 ovunque.
+
+---
+
+## 6. Dove tutto questo vive in Zcash
+
+Zcash ha usato hash diversi nei suoi vari design, ciascuno scelto per il proprio compito:
+
+| Design | Hash usati | Dove |
+|---|---|---|
+| **Sprout** (il più antico) | **SHA-256** | Note commitment e l'albero |
+| **Sapling** | **Hash di Pedersen**, più **BLAKE2** | Pedersen per i note commitment e l'albero di Merkle; BLAKE2 per la derivazione delle chiavi e i nullifier |
+| **Orchard** (attuale) | **Sinsemilla**, più **Poseidon** | Sinsemilla per i note commitment e l'albero di Merkle; Poseidon per il nullifier, tutti progettati per circuiti aritmetici |
+
+I nomi da riconoscere sono **Pedersen** e **Sinsemilla** (hash in stile commitment costruiti a partire da punti di curva, così ereditano il superpotere del "si sommano" e si provano a basso costo) e **Poseidon** (un hash su aritmetica di campo costruito appositamente per i circuiti a conoscenza zero). Quando l'Articolo 0 diceva che il contenuto di una nota è sigillato in un commitment, *questo* è il meccanismo che esegue la sigillatura.
+
+Così il filo lasciato in sospeso dall'Articolo 0, *"come può una busta sigillata nascondere il proprio contenuto pur essendo impossibile da falsificare?"*, è ora annodato: **occultamento da un fattore casuale di accecamento, vincolo dalla resistenza alle collisioni o dalla trappola della curva.**
+
+---
+
+## 7. Una doverosa precisazione
+
+Abbiamo semplificato per mantenere le cose chiare. I veri schemi di commitment specificano esattamente come `v` e `r` sono codificati e quali generatori sono usati; "occultamento" e "vincolo" hanno ciascuno delle varianti (perfetto vs computazionale) con definizioni di sicurezza precise; e non abbiamo mostrato il funzionamento interno di Pedersen, Sinsemilla o Poseidon. Nulla di tutto ciò cambia l'intuizione: un commitment è un'impronta digitale più casualità che nasconde ora e vincola per sempre. I dettagli torneranno, segnalati, quando l'articolo sul protocollo ne avrà bisogno.
+
+---
+
+## 8. Riepilogo
+
+- Una **funzione hash** è un'**impronta digitale per i dati**: deterministica, veloce in avanti, unidirezionale, resistente alle collisioni, con un **effetto valanga** (un bit in entrata, un'impronta totalmente diversa in uscita).
+- Un **commitment** ti permette di **bloccare un valore in pubblico ora e rivelarlo dopo senza poter mentire.**
+- Pubblicare una nuda impronta `H(v)` vincola ma **non** nasconde. Aggiungere un fattore casuale di accecamento, `H(v, r)`, risolve il problema: **occultamento da `r`, vincolo dalla resistenza alle collisioni.**
+- Zcash usa sia commitment **basati su hash** sia commitment di **Pedersen**; i commitment di Pedersen inoltre **si sommano**, cosa che l'Articolo 6 sfrutterà per provare il bilancio del valore in modo privato.
+- Poiché gli hash devono essere **provati** all'interno delle prove a conoscenza zero, Zcash usa hash **ZK-friendly** costruiti a partire da aritmetica su campi (**Pedersen**, **Sinsemilla**, **Poseidon**) invece di SHA-256 ovunque.
+
+---
+
+## Glossario
+
+| Termine | Significato in parole semplici |
+|---|---|
+| **Funzione hash** | Comprime qualsiasi dato in una breve impronta digitale di dimensione fissa (digest) |
+| **Digest** | L'impronta digitale in uscita di una funzione hash |
+| **Resistenza alla preimmagine** | Non si può invertire un digest per risalire al suo input (unidirezionale) |
+| **Resistenza alle collisioni** | Non si possono trovare due input con lo stesso digest |
+| **Effetto valanga** | Una minima modifica all'input cambia completamente il digest |
+| **Commitment** | Bloccare un valore ora, rivelarlo dopo, senza poter mentire al riguardo |
+| **Fattore di accecamento (`r`)** | Il numero casuale fresco che fa sì che un commitment nasconda |
+| **Hash ZK-friendly** | Un hash costruito a partire da aritmetica su campi così da essere economico da provare |
+
+---
+
+## FAQ
+
+**Perché non cifrare semplicemente il valore invece di impegnarsi su di esso?**
+La cifratura riguarda la *segretezza che puoi in seguito decifrare*. Un commitment riguarda il *vincolo*: la garanzia che non puoi cambiare la tua risposta in seguito. Compiti diversi.
+
+**Se i commitment nascondono il valore, come fa qualcuno a verificare le regole?**
+Questo è il ruolo delle prove a conoscenza zero (Articolo 5): provano che il valore nascosto rispetta le regole senza rivelarlo.
+
+**SHA-256 è compromessa, dato che Zcash la evita in alcuni punti?**
+No. SHA-256 va bene e Zcash la usa ancora. È solo costosa da *provare all'interno di un circuito*, motivo per cui esistono gli hash ZK-friendly per quel compito specifico.
+
+**Da dove viene l'`r` casuale, e chi lo conserva?**
+Viene generato fresco quando la nota viene creata ed è noto al proprietario della nota. Fa parte di ciò che rende ogni nota unica e privata.
+
+---
+
+### Metti alla prova la tua intuizione
+
+Ti impegni sulla tua previsione elettorale come `H(v, r)` e la pubblichi. Un amico insiste che dovresti pubblicare solo `H(v)` per tenerla più semplice. In una frase, perché è una cattiva idea se ci sono solo due esiti possibili? *(Risposta sotto.)*
+
+<details><summary>Risposta</summary>
+
+Con solo due esiti, il tuo amico può semplicemente calcolare `H("vince")` e `H("perde")` da solo e confrontarli con il tuo digest pubblicato, scoprendo all'istante la tua previsione. L'hash nudo vincola ma non nasconde; l'`r` casuale è ciò che ferma questo attacco a forza bruta per tentativi.
+</details>
+
+---
+
+### Cosa viene dopo
+
+**Articolo 4 . Alberi di Merkle:** ora abbiamo milioni di commitment che si accumulano. L'Articolo 4 mostra come Zcash li organizza in un unico albero la cui minuscola impronta radice rappresenta l'intera storia, e come puoi provare che la tua nota è in quell'albero senza rivelare quale. Questa è la vera forma della "bacheca pubblica" dell'Articolo 0.
+
+*Parte della serie* Zcash dai primi principi *per [ZecHub](https://zechub.org). Concessa in licenza CC BY-SA 4.0.*

--- a/translations/it/site/Research/zcash-foundations-series/article-4/article-4-merkle-trees.md
+++ b/translations/it/site/Research/zcash-foundations-series/article-4/article-4-merkle-trees.md
@@ -1,0 +1,179 @@
+# Alberi di Merkle: come la blockchain ricorda ogni nota
+##### Ricerca originale di [Annkkitaaa](https://github.com/Annkkitaaa)
+
+![alt text](image-19.png)
+
+### Riassumere milioni di commitment in un'unica minuscola impronta
+
+> **Serie:** *Zcash from First Principles* . **Articolo 4 . Alberi di Merkle**
+> **Pubblico:** nuovi arrivati. Costruiamo a partire dall'[Articolo 3 (hashing e commitment)](article-3-hashing-commitments.md). Se sai cos'è un'impronta digitale e cos'è un commitment, sei pronto.
+> **Cosa porterai con te:** un quadro intuitivo e corretto degli alberi di Merkle, di come provare l'appartenenza senza rivelare a quale elemento ti riferisci, ed esattamente di come tutto questo diventa l'albero dei commitment delle note di Zcash.
+
+L'[Articolo 0](article-0-shielded-transaction.md) ha descritto una "bacheca pubblica" che contiene ogni nota mai creata e che si limita a crescere. Ormai puoi intuire cosa vi è appuntato: i **commitment** (Articolo 3), le buste sigillate. Ma una bacheca reale ne conterrebbe *centinaia di milioni*. Come fa la rete a memorizzarli, a verificarli e a permetterti di provare che la tua busta è sulla bacheca senza indicarla? La risposta è una delle strutture più eleganti dell'informatica: l'**albero di Merkle.**
+
+---
+
+## 1. Perché dovrebbe interessarti?
+
+Due problemi compaiono nel momento in cui si ha una gigantesca lista pubblica di commitment.
+
+**Problema uno: integrità su larga scala.** Se la lista ha 300 milioni di voci, come fa chiunque a confermare che *nemmeno una* sia stata segretamente alterata? Ricontrollare 300 milioni di elementi a ogni sguardo è impossibile.
+
+**Problema due: appartenenza privata.** Per spendere una nota (Articolo 0), devi provare che il tuo commitment è realmente sulla bacheca. Ma se lo indichi ("è la voce numero 4.201.337!"), ti sei appena deanonimizzato. Devi provare *"la mia busta è da qualche parte su questa bacheca"* senza rivelare **quale.**
+
+Un albero di Merkle risolve entrambi i problemi in un colpo solo. Comprime l'intera lista in un'unica impronta e ti permette di provare l'appartenenza con una prova minuscola che nasconde la posizione.
+
+---
+
+## 2. L'intuizione: un torneo di impronte digitali
+
+Immagina un tabellone a eliminazione di un torneo, ma invece di avanzare i giocatori, **vengono combinate le impronte digitali.**
+
+- In fondo, ogni pezzo di dato ottiene la propria impronta (il suo hash dell'Articolo 3). Queste sono le **foglie.**
+- Accoppiale. Le due impronte di ogni coppia vengono sottoposte ad hashing *insieme* in un'unica impronta genitore.
+- Accoppia i genitori, applica l'hash a ogni coppia insieme, e così via.
+- Continua finché un'**unica impronta** non si trova in cima. Quel campione è la **radice di Merkle.**
+
+![alt text](image-20.png)
+
+La proprietà più importante in assoluto deriva direttamente dall'effetto valanga (Articolo 3):
+
+> **La radice è un'impronta di *tutto* ciò che sta sotto di essa.** Cambia una qualsiasi foglia, anche di un solo bit, e la sua impronta cambia, il che cambia il suo genitore, che cambia *quel* genitore, fino in cima. **La radice cambia.** Quindi un piccolo valore di radice certifica l'integrità dell'intera lista. Questo risolve il Problema uno.
+
+---
+
+## 3. Un albero reale, calcolato esattamente
+
+Costruiamo l'albero a quattro foglie qui sopra con vere impronte SHA-256 sulle foglie `A, B, C, D` (i digest sono mostrati troncati per leggibilità):
+
+```
+hA = 559aead08264...     hB = df7e70e50215...
+hC = 6b23c0d5f35d...     hD = 3f39d5c348e5...
+
+hAB = H(hA , hB) = 63956f0ce48e...
+hCD = H(hC , hD) = 98a2fbfddbc7...
+
+ROOT = H(hAB , hCD) = 1b3faa3fcc5e...
+```
+
+Tutto si riduce a "fai l'hash di una cosa, poi fai l'hash di coppie di hash." Niente di più esotico dell'Articolo 3, disposto ad albero.
+
+---
+
+## 4. La parte ingegnosa: provare l'appartenenza senza rivelare la posizione
+
+Ora il Problema due. Diciamo che vuoi provare che la foglia `C` è nell'albero, a qualcuno che conosce solo la **radice**. *Non* gli consegni l'intero albero. Gli consegni solo le impronte necessarie per risalire da `C` alla radice, chiamate **percorso di autenticazione** (o **prova di Merkle**):
+
+> Per provare che `C` è nell'albero, fornisci:
+> - il suo fratello `hD`, e
+> - il suo zio `hAB`.
+
+Il verificatore, conoscendo solo la radice, ricalcola la risalita:
+
+```
+step 1:  H(hC , hD)        = hCD       (combine C with its sibling)
+step 2:  H(hAB , hCD)      = ROOT?     (combine with the uncle)
+```
+
+Calcolato per davvero: questo produce `1b3faa3fcc5e...`, che **corrisponde alla radice.**  La foglia è provata essere nell'albero.
+
+![alt text](image-21.png)
+
+Due cose rendono tutto questo potente:
+
+- **È minuscolo.** Per 4 foglie hai fornito 2 hash. Per un albero di `n` foglie ne fornisci solo circa **log_2(n)**. Per un miliardo di foglie, sono all'incirca **30 hash**, non un miliardo. La prova cresce a malapena anche quando l'albero esplode di dimensioni.
+- **È il seme della privacy.** La prova mostra che la tua foglia è *da qualche parte* nell'albero. Quando questo stesso controllo viene eseguito *all'interno di una prova a conoscenza zero* (Articolo 5), perfino il percorso stesso è nascosto, così provi "la mia nota è nell'albero" senza rivelare né la nota né la sua posizione. Questo risolve completamente il Problema due.
+
+---
+
+## 5. Dall'albero di Merkle all'albero dei commitment delle note di Zcash
+
+Ora possiamo dire con precisione cos'è davvero la "bacheca pubblica" dell'Articolo 0:
+
+> L'**albero dei commitment delle note** è un albero di Merkle le cui **foglie sono commitment di note.** Ogni volta che una nota viene creata in qualsiasi parte del mondo, il suo commitment viene aggiunto come foglia successiva e la radice viene aggiornata.
+
+Alcuni dettagli reali:
+
+- **Cresce soltanto.** Le foglie vengono aggiunte, mai rimosse. Questo si chiama **albero di Merkle incrementale.** (Corrisponde al "la bacheca non smonta mai nulla" dell'Articolo 0.)
+- **La radice è chiamata *anchor*.** Quando spendi, la tua transazione fa riferimento a un anchor recente e prova, a conoscenza zero, che il commitment della tua nota si trova nell'albero con quella radice.
+- **Profondità fissa.** Gli alberi schermati di Zcash hanno profondità **32**, il che significa che possono contenere fino a `2^(32)` (oltre quattro miliardi di) note.
+- **Hashing ZK-friendly.** L'albero non è costruito con SHA-256. Sapling effettua l'hash dell'albero con gli **hash di Pedersen** e Orchard usa **Sinsemilla** (entrambi dall'Articolo 3), proprio perché la risalita di appartenenza sia economica da provare all'interno di un circuito.
+
+![alt text](image-22.png)
+
+### Una cosa che l'albero *non* gestisce: le doppie spese
+
+L'albero prova che una nota **esiste**. Non impedisce di per sé di spendere la stessa nota due volte. Quel compito appartiene all'**insieme dei nullifier** dell'Articolo 0: una collezione separata di "gettoni di annullamento." Quando spendi, pubblichi il nullifier della nota e la rete rifiuta qualsiasi nullifier che abbia già visto.
+
+Quindi le due strutture pubbliche svolgono ruoli complementari, e tenerle separate è esattamente ciò che recide il legame tra la nascita di una nota e la sua morte:
+
+| Struttura | Domanda a cui risponde | Aggiornata quando |
+|---|---|---|
+| **Albero dei commitment delle note** | "Questa nota esiste?" | Una nota viene **creata** (commitment aggiunto) |
+| **Insieme dei nullifier** | "Questa nota è già stata spesa?" | Una nota viene **spesa** (nullifier pubblicato) |
+
+---
+
+## 6. Una dichiarazione onesta
+
+Semplificazioni, come al solito. I veri alberi di Merkle incrementali tengono traccia dei nodi di "frontiera" così che la radice possa aggiornarsi senza ricostruire tutto; la rete conserva una finestra di anchor recenti, non solo l'ultima, così che i wallet non si rompano a ogni nuovo blocco; e le foglie vuote usano un valore di padding definito. Abbiamo inoltre disegnato alberi binari con ordinate potenze di due. Niente di tutto questo cambia l'intuizione: foglie di commitment, sottoposte ad hashing a coppie fino a un'unica radice, con brevi prove di appartenenza. La contabilità esatta tornerà nell'articolo sul protocollo.
+
+---
+
+## 7. Riepilogo
+
+- Un **albero di Merkle** trasforma i dati in **foglie** tramite hashing, poi applica l'hash a **coppie verso l'alto** finché non resta un'unica **radice**.
+- Grazie all'effetto valanga, la **radice è un'impronta dell'intera lista**: cambia una foglia e la radice cambia. Un piccolo valore certifica un dataset enorme.
+- Una **prova di appartenenza (percorso di autenticazione)** è semplicemente l'insieme dei fratelli lungo la risalita verso la radice, circa **log_2(n)** hash, così le prove restano minuscole anche per miliardi di foglie.
+- Eseguito **all'interno di una prova a conoscenza zero**, quel controllo di appartenenza nasconde *quale* foglia intendi, provando "la mia nota è nell'albero" senza rivelare la nota o la sua posizione.
+- L'**albero dei commitment delle note** di Zcash è un albero di Merkle **incrementale** di commitment di note, profondità **32**, la cui radice è l'**anchor**; Sapling lo sottopone ad hashing con **Pedersen** e Orchard con **Sinsemilla**.
+- L'albero prova l'**esistenza**; il separato **insieme dei nullifier** previene le **doppie spese**. Tenerli separati è ciò che scollega la nascita di una nota dalla sua morte.
+
+---
+
+## Glossario
+
+| Termine | Significato in parole semplici |
+|---|---|
+| **Albero di Merkle** | Un albero di hash; le foglie sono impronte di dati, i genitori applicano l'hash ai propri figli |
+| **Foglia** | Un nodo in fondo; in Zcash, un commitment di nota |
+| **Radice di Merkle** | L'unica impronta in cima che riassume l'intero albero |
+| **Percorso di autenticazione / prova di Merkle** | Gli hash dei fratelli necessari a provare che una foglia è nell'albero |
+| **Albero di Merkle incrementale** | Un albero di Merkle solo in aggiunta (le foglie vengono solo aggiunte) |
+| **Anchor** | Una radice di Merkle a cui una spesa fa riferimento come "lo stato dell'albero contro cui sto provando" |
+| **Insieme dei nullifier** | La collezione separata di marcatori-di-spesa che blocca le doppie spese |
+
+---
+
+## FAQ
+
+**Perché un albero e non semplicemente una lunga lista di hash?**
+Una lista piatta ti costringerebbe a rivelare o elaborare ogni voce per provare l'appartenenza. Un albero ti dà prove di dimensione logaritmica e un'unica radice per l'integrità.
+
+**Il verificatore ha bisogno dell'intero albero?**
+No. Il verificatore ha bisogno solo della **radice** più il tuo breve percorso di autenticazione. È tutto qui.
+
+**Perché proprio profondità 32?**
+Limita l'albero a circa quattro miliardi di note, che è ampio margine, mantenendo al contempo la prova di appartenenza (e il suo costo in-circuito) di dimensione fissa e gestibile.
+
+**Se la radice cambia a ogni nuova nota, come fanno le vecchie prove a restare valide?**
+La rete ricorda una finestra di radici recenti (anchor), così che una prova fatta contro un anchor leggermente più vecchio sia comunque verificabile. L'articolo sul protocollo rende tutto questo preciso.
+
+---
+
+### Metti alla prova la tua intuizione
+
+Nel nostro albero a 4 foglie, supponi che un attaccante scambi segretamente la foglia `C` con un valore diverso ma lasci invariata la radice pubblicata. Cosa va storto per lui, e perché non può sistemarlo in silenzio? *(Risposta sotto.)*
+
+<details><summary>Risposta</summary>
+
+Cambiare `C` cambia `hC` (effetto valanga), che cambia `hCD = H(hC, hD)`, che cambia `ROOT = H(hAB, hCD)`. Quindi la radice ricalcolata non corrisponde più alla radice pubblicata, e la manomissione viene rilevata. Per "sistemarlo in silenzio" dovrebbe trovare un `C` diverso che produca lo *stesso* `hC`, ovvero una collisione di hash, irrealizzabile per l'Articolo 3. L'integrità regge.
+</details>
+
+---
+
+### Cosa viene dopo
+
+**Articolo 5 . Prove a conoscenza zero:** il crescendo. Abbiamo ora costruito note, commitment e l'albero, e continuiamo a dire "provato a conoscenza zero." L'Articolo 5 spiega finalmente come puoi provare che un'affermazione è vera, che la tua nota è nell'albero, che il tuo nullifier è corretto, che il denaro è bilanciato, senza rivelare nulla di tutto ciò.
+
+*Parte della serie* Zcash from First Principles *per [ZecHub](https://zechub.org). Licenza CC BY-SA 4.0.*

--- a/translations/it/site/Research/zcash-foundations-series/article-5/article-5-zero-knowledge-proofs.md
+++ b/translations/it/site/Research/zcash-foundations-series/article-5/article-5-zero-knowledge-proofs.md
@@ -1,0 +1,178 @@
+# Prove a conoscenza zero: dimostrare di avere ragione senza dire perché
+##### Ricerca originale di [Annkkitaaa](https://github.com/Annkkitaaa)
+
+![alt text](image-23.png)
+
+### Il sipario che permette al mondo di verificare ciò che non potrà mai vedere
+
+> **Serie:** *Zcash dai primi principi* . **Articolo 5 . Prove a conoscenza zero**
+> **Pubblico:** principianti. Attingiamo a ogni articolo precedente (campi finiti, curve, commitment, alberi di Merkle), ma ogni idea viene richiamata quando serve.
+> **Cosa porterai a casa:** una comprensione intuitiva e corretta di cosa sia una prova a conoscenza zero, le tre garanzie che fornisce, come si dimostrano enunciati arbitrari, e cosa alimenta Sapling e Orchard di Zcash.
+
+Questo è l'articolo verso cui l'intera serie ha puntato. Dall'[Articolo 0](article-0-shielded-transaction.md) in poi abbiamo continuato a dire che un pagamento viene validato "dietro un sipario", dimostrato corretto senza rivelare nulla. Una prova a conoscenza zero è quel sipario. È il pezzo che finalmente risolve il paradosso con cui abbiamo aperto: *come può il pubblico verificare una transazione che non gli è permesso vedere?*
+
+---
+
+## 1. Perché dovrebbe interessarti?
+
+Ricorda la contraddizione al cuore di Zcash:
+
+- Una blockchain è affidabile perché è **verificabile pubblicamente**.
+- I pagamenti Zcash sono **completamente privati**: importi, mittente, destinatario, tutto nascosto.
+
+Sembrano mutuamente esclusivi. La verifica sembra *richiedere* di guardare. La privacy *vieta* di guardare. Se non puoi conciliarli, non puoi avere denaro privato di cui chiunque si fidi.
+
+Una **prova a conoscenza zero (ZKP)** è la conciliazione. Permette a un **prover** (dimostratore) di convincere un **verifier** (verificatore) che un enunciato è vero **senza rivelare nulla oltre al fatto che è vero.** Nessun importo. Nessuna identità. Nessuna nota. Solo: *"tutto qui rispetta le regole."* Costruiamo l'intuizione prima di qualsiasi meccanismo.
+
+---
+
+## 2. L'intuizione: tre prove di tutti i giorni
+
+**Prova di conoscere una password, senza dirla.** Un sito web potrebbe verificare che conosci la tua password osservandoti sbloccare qualcosa che solo la password sblocca, senza mai vedere la password stessa. Dimostri *conoscenza* senza *divulgazione*.
+
+**L'amico daltonico e due palline.** Tieni in mano una pallina rossa e una verde che al tuo amico daltonico appaiono identiche. Vuoi convincerlo che sono di *colori diversi* senza dirgli quale sia quale. Lui nasconde entrambe dietro la schiena, facoltativamente le scambia, e te ne mostra una. Tu dici se le ha scambiate. Se le palline sono davvero diverse, hai sempre ragione. Se fossero identiche, staresti tirando a indovinare, indovinando solo metà delle volte. Dopo 20 round, la tua serie ininterrotta lo convince che sono diverse, eppure non scopre mai quale pallina sia rossa. **È convinto di un fatto senza imparare nient'altro.** Questa è la conoscenza zero in miniatura.
+
+**La caverna.** Una caverna ad anello ha una porta magica sul fondo che si apre solo con una parola segreta. Sostieni di conoscere la parola. Per dimostrarlo senza rivelarla: un verificatore aspetta fuori mentre tu entri e scegli a caso il passaggio di sinistra o di destra. Il verificatore poi grida da quale lato vuole che tu *esca*. Se conosci davvero la parola, puoi sempre obbedire (puoi aprire la porta per cambiare lato se necessario). Se stai bluffando, puoi uscire dal lato giusto solo per fortuna, 50/50 a ogni round. Ripeti 20 volte e le probabilità che un bluffatore sopravviva sono inferiori a una su un milione.
+
+Quella storia della caverna dimostra silenziosamente le **tre garanzie** che ogni prova a conoscenza zero deve fornire.
+
+---
+
+## 3. Le tre garanzie
+
+![alt text](image-24.png)
+
+| Garanzia | Nella storia della caverna | In Zcash |
+|---|---|---|
+| **Completezza** | Se conosci la parola, esci sempre dal lato giusto | Una transazione valida produce sempre una prova accettata |
+| **Solidità** | Un bluffatore viene scoperto con probabilità schiacciante | Una transazione fraudolenta (denaro contraffatto, doppia spesa) non può produrre una prova accettata |
+| **Conoscenza zero** | Il verificatore non sente mai la parola segreta | La rete non scopre mai importi, indirizzi o quale nota |
+
+Se anche solo una di queste fallisce, il sistema crolla: senza completezza gli utenti onesti vengono rifiutati; senza solidità i contraffattori stampano denaro; senza conoscenza zero la privacy svanisce.
+
+---
+
+## 4. Da una caverna a *qualsiasi* enunciato: circuiti e testimoni
+
+La caverna dimostra un solo fatto carino. Zcash deve dimostrare un enunciato ricco: *"Conosco una nota non spesa nell'albero, sono autorizzato a spenderla, il suo nullifier è calcolato correttamente, e i miei input eguagliano i miei output."* Come passiamo da palline e caverne a questo?
+
+Il ponte è un'idea che lega insieme tutta questa serie:
+
+> **Qualsiasi enunciato che puoi verificare con un calcolo può essere riscritto come un circuito aritmetico:** una rete di addizioni e moltiplicazioni su un campo finito (Articolo 1).
+
+Pensa al circuito come a un elenco di vincoli aritmetici che sono *tutti soddisfatti solo se l'enunciato è vero.* Gli input privati che fanno tornare tutto, la tua nota, la tua chiave, il percorso di Merkle, sono chiamati il **testimone** (witness).
+
+![alt text](image-25.png)
+
+Ecco perché abbiamo dedicato l'Articolo 1 ai campi finiti e l'Articolo 3 agli hash ZK-friendly: il circuito parla aritmetica dei campi, quindi ogni operazione all'interno dell'enunciato (incluso l'hashing e la risalita di Merkle dell'Articolo 4) deve essere espressa in quel modo. Più economica è l'espressione di ogni operazione, più piccola e veloce è la prova.
+
+---
+
+## 5. Renderla pratica: non interattiva e succinta
+
+La caverna richiedeva molti round di andata e ritorno. È impraticabile per una blockchain, dove una prova deve essere pubblicata una volta e verificata da tutti, per sempre. Due miglioramenti risolvono questo.
+
+**Non interattiva (l'idea di Fiat-Shamir).** Invece di un verificatore dal vivo che grida sfide casuali, il prover genera lui stesso le "sfide casuali" facendo l'*hash* della propria prova-finora. Poiché un buon hash è imprevedibile (Articolo 3), il prover non può manipolare le sfide a proprio favore. La conversazione prolissa collassa in un'**unica prova autosufficiente** che chiunque può verificare in seguito, senza interazione.
+
+**Succinta.** I migliori sistemi rendono la prova **minuscola e veloce da verificare, indipendentemente da quanto sia grande l'enunciato.** Questa è la parte davvero sbalorditiva.
+
+> Una prova Groth16 (il sistema che usa Sapling) è all'incirca **192 byte** e si verifica in millisecondi, *che l'enunciato che dimostra sia piccolo o enorme.* Poche centinaia di byte possono attestare un calcolo che coinvolge molte migliaia di vincoli.
+
+Metti insieme questi due aspetti e ottieni l'acronimo che vedrai ovunque:
+
+> **zk-SNARK** = **z**ero-**k**nowledge **S**uccinct **N**on-interactive **AR**gument of **K**nowledge. Conoscenza zero (non rivela nulla), succinta (minuscola e veloce), non interattiva (in un colpo solo), argomento di conoscenza (il prover *conosce* davvero un testimone valido).
+
+---
+
+## 6. L'unico inconveniente: il trusted setup
+
+Non esistono pasti gratis. Molti SNARK necessitano di un **setup** una tantum che produce parametri pubblici per il circuito. Il setup genera casualità segreta come sottoprodotto, e quel segreto deve essere **distrutto.** Se qualcuno lo conservasse, potrebbe contraffare prove, cioè **contraffare denaro** (anche se, cosa cruciale, comunque *non* potrebbe violare la privacy).
+
+Questo segreto residuo è soprannominato **rifiuto tossico** (toxic waste). Per smaltirlo in sicurezza, Zcash ha condotto elaborate **cerimonie multi-party** in cui molti partecipanti indipendenti hanno contribuito ciascuno con casualità; finché *anche uno solo* ha distrutto onestamente la propria parte, il rifiuto tossico è irrecuperabile.
+
+![alt text](image-26.png)
+
+I sistemi più recenti eliminano del tutto questo requisito, che è una delle ragioni più importanti per cui Zcash ha fatto evolvere il proprio sistema di prove nel tempo.
+
+---
+
+## 7. Dove vive tutto questo in Zcash
+
+| Design | Sistema di prove | Trusted setup? | Costruito su |
+|---|---|---|---|
+| **Sprout** (il primo) | primo zk-SNARK | Sì | cerimonia originale |
+| **Sapling** | **Groth16** | Sì (la multi-party "Powers of Tau" + la cerimonia Sapling) | **BLS12-381** (Articolo 2) |
+| **Orchard** (attuale) | **Halo 2** | **Nessun trusted setup** | **Pallas / Vesta** (Articolo 2) |
+
+La marcia da Sprout a Sapling a Orchard è in gran parte una storia di prove che diventano più piccole, più veloci e che si liberano del trusted setup. **Halo 2**, usato da Orchard, non necessita di alcuna cerimonia ed è costruito per supportare la *ricorsione* (prove che verificano altre prove), motivo per cui Orchard usa il **ciclo** di curve Pallas/Vesta dell'Articolo 2: ogni curva è ottimizzata per verificare prove scritte sull'altra.
+
+Questo chiude il loop più grande dell'Articolo 0. La magia del "dietro il sipario" è uno **zk-SNARK**: dimostra che la tua transazione soddisfa un circuito aritmetico che codifica tutte le regole, rivelando solo il singolo bit "valida".
+
+---
+
+## 8. Una doverosa precisazione
+
+Le prove a conoscenza zero sono un campo profondo e siamo rimasti di proposito al livello intuitivo. Non abbiamo definito i precisi limiti probabilistici nella solidità, la forma esatta di un circuito aritmetico (R1CS, PLONKish, e così via), come polinomi e commitment trasformano un circuito in una prova breve, o gli internals reali di Groth16 e Halo 2. La caverna è una prova *interattiva*; i sistemi di produzione sono non interattivi e molto più intricati. Niente di tutto ciò cambia il nocciolo: dimostrare che un circuito è soddisfatto da un testimone segreto, in modo completo, solido e senza rivelare nulla. Il meccanismo è un'intera serie a sé.
+
+---
+
+## 9. Riepilogo
+
+- Una **prova a conoscenza zero** permette a un prover di convincere un verificatore che un enunciato è vero **senza rivelare nient'altro**, risolvendo il paradosso verifica-vs-privacy.
+- Deve soddisfare tre garanzie: **completezza** (gli enunciati veri convincono), **solidità** (gli enunciati falsi non possono) e **conoscenza zero** (il verificatore impara solo che "è vero").
+- Gli enunciati arbitrari diventano **circuiti aritmetici** su un campo finito; gli input segreti che soddisfano il circuito sono il **testimone**. Ecco perché i campi finiti e gli hash ZK-friendly contavano.
+- **Fiat-Shamir** rende le prove **non interattive** (in un colpo solo); i migliori sistemi sono anche **succinti** (una prova Groth16 è circa **192 byte** e si verifica in millisecondi indipendentemente dalla dimensione dell'enunciato). Insieme: uno **zk-SNARK**.
+- Alcuni SNARK necessitano di un **trusted setup** il cui **rifiuto tossico** residuo deve essere distrutto (tramite cerimonie multi-party); una compromissione permetterebbe di contraffare denaro ma **non** di violare la privacy.
+- **Sapling** usa **Groth16** (trusted setup, BLS12-381); **Orchard** usa **Halo 2** (nessun trusted setup, Pallas/Vesta, adatto alla ricorsione).
+
+---
+
+## Glossario
+
+| Termine | Significato in parole semplici |
+|---|---|
+| **Prova a conoscenza zero** | Convincere qualcuno che un enunciato è vero senza rivelare nient'altro |
+| **Prover / Verifier** | Chi produce la prova / chi la verifica |
+| **Completezza** | Gli enunciati veri vengono sempre accettati (da un prover onesto) |
+| **Solidità** | Gli enunciati falsi vengono rifiutati (i bari non possono vincere se non per fortuna) |
+| **Testimone** | Gli input segreti che rendono vero l'enunciato |
+| **Circuito aritmetico** | Un enunciato riscritto come addizioni e moltiplicazioni su un campo finito |
+| **Non interattiva (Fiat-Shamir)** | Una prova in un colpo solo che non richiede scambi dal vivo |
+| **Succinta** | La prova è minuscola e veloce da verificare indipendentemente dalla dimensione dell'enunciato |
+| **zk-SNARK** | Zero-knowledge Succinct Non-interactive ARgument of Knowledge |
+| **Trusted setup / rifiuto tossico** | Generazione di parametri una tantum il cui segreto residuo deve essere distrutto |
+
+---
+
+## FAQ
+
+**Se la prova non rivela nulla, come può significare qualcosa verificarla?**
+Perché la matematica è organizzata in modo che *solo* un testimone reale e valido possa produrre una prova che supera il controllo. Superare il controllo è di per sé la prova, senza alcuna divulgazione.
+
+**Qualcuno potrebbe falsificare una prova?**
+La solidità rende questo infattibile. L'unica eccezione è uno SNARK il cui rifiuto tossico del trusted setup è stato conservato; ed è esattamente per questo che le cerimonie per distruggerlo contano.
+
+**Un trusted setup compromesso fa trapelare i miei dati privati?**
+No. Permetterebbe a un attaccante di contraffare *nuovo* denaro, ma **non** rivela importi, indirizzi o note. Privacy e solidità sono garanzie separate.
+
+**Perché Zcash ha cambiato sistema di prove nel tempo?**
+Per ottenere prove più piccole e veloci e, con Halo 2, per eliminare del tutto il trusted setup e abilitare la ricorsione.
+
+---
+
+### Metti alla prova la tua intuizione
+
+Nella caverna, perché è essenziale che il verificatore scelga il lato di uscita *dopo* che il prover è già entrato, invece di annunciarlo in anticipo? *(Risposta sotto.)*
+
+<details><summary>Risposta</summary>
+
+Se il verificatore annunciasse prima il lato, un bluffatore che non conosce la parola potrebbe semplicemente entrare da quel lato fin dall'inizio e tornare indietro, senza mai aver bisogno della porta. Scegliere *dopo* che il prover si è impegnato su un passaggio costringe un bluffatore ad affidarsi alla fortuna (50/50 a round), ed è questo che rende convincenti i round ripetuti. Questo ordine "impegnati prima, poi affronta la sfida" è esattamente ciò che Fiat-Shamir preserva derivando la sfida da un hash della prova già impegnata dal prover.
+</details>
+
+---
+
+### Cosa viene dopo
+
+**Articolo 6 . Il protocollo schermato, dall'inizio alla fine:** il finale. Prendiamo ogni pezzo, note, commitment, l'albero dei commitment delle note, i nullifier, il bilancio di valore e la prova a conoscenza zero, e assembliamo una transazione schermata Zcash completa, chiudendo ogni singolo loop aperto fin dall'Articolo 0.
+
+*Parte della serie* Zcash dai primi principi *per [ZecHub](https://zechub.org). Concesso in licenza CC BY-SA 4.0.*

--- a/translations/it/site/Research/zcash-foundations-series/article-6/article-6-shielded-protocol.md
+++ b/translations/it/site/Research/zcash-foundations-series/article-6/article-6-shielded-protocol.md
@@ -1,0 +1,206 @@
+# Il Protocollo Schermato, da Cima a Fondo
+##### Ricerca originale di [Annkkitaaa](https://github.com/Annkkitaaa)
+
+![alt text](image-27.png)
+
+### Assemblare ogni pezzo in un'unica transazione Zcash privata
+
+> **Serie:** *Zcash from First Principles* . **Articolo 6 . Il Protocollo Schermato** (finale)
+> **Pubblico:** i nuovi arrivati che hanno letto gli Articoli da 0 a 5. È qui che tutto si collega.
+> **Cosa porterai con te:** un modello mentale completo e corretto di una transazione Zcash schermata, con ogni concetto della serie al suo posto, e ogni filo aperto nell'Articolo 0 finalmente chiuso.
+
+Abbiamo iniziato, nell'[Articolo 0](article-0-shielded-transaction.md), con un paradosso e una storia di buste sigillate su una bacheca pubblica. Poi abbiamo trascorso cinque articoli a costruire le parti: campi finiti, curve ellittiche, impegni (commitment), alberi di Merkle e prove a conoscenza zero. Ora le mettiamo insieme e osserviamo un vero pagamento privato funzionare, dall'inizio alla fine.
+
+---
+
+## 1. Perché dovrebbe interessarti?
+
+Preso singolarmente, ogni pezzo che hai imparato è ingegnoso. Ma la *magia* di Zcash sta nel modo in cui questi pezzi si incastrano tra loro. Un nullifier da solo non garantisce privacy. Un commitment da solo non impedisce la contraffazione. Una prova da sola non prova nulla di utile. È l'**assemblaggio** che trasforma cinque componenti in denaro al contempo privato e affidabile.
+
+Questo articolo è l'assemblaggio. Alla fine, la frase *"la rete verifica una transazione che non può vedere"* non sembrerà più un paradosso, ma una conseguenza ovvia di parti che già comprendi.
+
+---
+
+## 2. Il cast, ricomposto
+
+Ecco l'intera serie in una sola pagina, mappata dalla storia dell'Articolo 0 al meccanismo reale.
+
+| Elemento della storia dell'Articolo 0 | Componente reale | Costruito da |
+|---|---|---|
+| Il denaro dentro una busta | **Nota** (valore, destinatario, casualità) | codificata come elementi di campo (Art 1) |
+| La busta opaca sigillata | **Commitment della nota** | commitment di Pedersen / Sinsemilla (Art 2, 3) |
+| La bacheca pubblica | **Albero dei commitment delle note** (anchor = la sua radice) | albero di Merkle incrementale (Art 4) |
+| Il gettone di annullamento | **Nullifier** | un hash ZK-friendly della nota + chiave segreta (Art 2, 3) |
+| "Il denaro in entrata uguaglia quello in uscita" | **Commitment di valore + controllo del bilancio** | commitment di Pedersen omomorfici (Art 2, 3) |
+| La magia dietro le quinte | **Prova a conoscenza zero** | zk-SNARK su un circuito aritmetico (Art 5) |
+| "Solo tu puoi leggere la tua busta" | **Nota cifrata + viewing key** | cifratura + gerarchia di chiavi (questo articolo) |
+
+---
+
+## 3. Da dove vengono le chiavi
+
+Tutto ciò che un utente può fare scaturisce da un singolo segreto, la **spending key**, attraverso una gerarchia unidirezionale (ogni freccia è una derivazione irreversibile, grazie alle trappole degli Articoli 2 e 3):
+
+![alt text](image-32.png)
+
+Due cose degne di nota, entrambe conseguenze degli articoli precedenti:
+
+- La separazione ti consente di consegnare una **viewing key** (per esempio, a un revisore) che rivela le tue transazioni **senza** concedere il potere di spendere. La privacy è selettiva, non tutto-o-niente.
+- Ogni derivazione è **unidirezionale**: possedere una viewing key non permette mai a nessuno di recuperare la spending key, esattamente la trappola della curva ellittica dell'Articolo 2 che svolge il suo compito.
+
+---
+
+## 4. Spendere una nota: le quattro affermazioni
+
+Per spendere una nota in modo privato, devi convincere la rete di quattro cose contemporaneamente **senza rivelare la nota, il suo valore, la sua posizione o la tua identità.** Ogni affermazione è soddisfatta da un componente che già conosci.
+
+![alt text](image-31.png)
+
+La prova non rivela **nessuno** dei fatti sottostanti (quale nota, di chi è la chiave, quale valore). Rivela solo che *tutte e quattro le affermazioni sono vere.* Questo è l'intero trucco di Zcash schermato, enunciato in un solo diagramma.
+
+---
+
+## 5. Il trucco del bilancio dei valori (il colpo che ci eravamo riservati)
+
+Negli Articoli 2 e 3 avevamo notato che i commitment di Pedersen **si sommano**: il commitment a `v_1` più il commitment a `v_2` è un commitment a `v_1 + v_2`. Ecco dove questo ripaga.
+
+Ogni nota di input e di output porta con sé un **commitment di valore**: un commitment di Pedersen `v.G + r.H` che nasconde il suo importo `v`. Poiché questi si sommano, la rete può calcolare:
+
+```
+(sum of input value commitments) − (sum of output value commitments)
+```
+
+Se la transazione è bilanciata (nessun denaro creato o distrutto), le parti `v` si annullano esattamente, lasciando solo un commitment a **valore zero**, offuscato dalla casualità residua. Il mittente prova di conoscere quella casualità residua producendo una piccola firma chiamata **binding signature.** Una binding signature valida è possibile solo quando i valori sono realmente bilanciati, **eppure non è stato rivelato un solo importo.**
+
+> Questa è l'illustrazione più chiara di tutta la serie del *perché* avessimo bisogno di commitment omomorfici basati sulle curve. La regola "denaro in entrata uguale a denaro in uscita" è imposta **sommando insieme le buste sigillate** e verificando che il risultato si sigilli a zero.
+
+---
+
+## 6. Una transazione completa, osservata da cima a fondo
+
+Assembliamo Alice che paga Bob. Useremo la chiara struttura "lato spesa / lato output" di Sapling come modello didattico.
+
+**Una transazione schermata raggruppa due tipi di descrizioni:**
+
+| Spend description (consuma una nota) | Output description (crea una nota) |
+|---|---|
+| commitment di valore dell'input | commitment di valore dell'output |
+| l'**anchor** contro cui prova (una radice dell'albero) | il nuovo **commitment della nota** (una nuova foglia) |
+| il **nullifier** della nota spesa | una **chiave effimera** per la cifratura |
+| una chiave pubblica ri-randomizzata + firma di autorizzazione alla spesa | la **nota cifrata** (testo cifrato per il destinatario) |
+| lo **zk-SNARK** che prova le quattro affermazioni | uno **zk-SNARK** che prova che l'output è ben formato |
+
+Più una **binding signature** sull'intero bundle, che impone il bilancio dei valori (Sezione 5).
+
+![alt text](image-30.png)
+
+Segui la privacy: la rete ha controllato l'anchor, ha verificato che il nullifier fosse nuovo, ha verificato la prova e ha verificato il bilancio. Ha accettato un pagamento valido **senza aver appreso alcun importo, alcun indirizzo, né quale nota sia stata spesa.** Nel frattempo il **nullifier** della nota spesa (la sua morte) e il nuovo **commitment** di Bob (la nascita della sua nota) si trovano in due strutture pubbliche diverse, senza alcun legame visibile tra loro, il legame reciso dell'Articolo 0.
+
+---
+
+## 7. Chiudere ogni filo aperto nell'Articolo 0
+
+L'Articolo 0 ha aperto deliberatamente delle domande. Eccole tutte, chiuse.
+
+| Filo aperto nell'Articolo 0 | Chiuso da |
+|---|---|
+| Come è possibile una busta sigillata-eppure-infalsificabile? | I commitment: nascosti grazie alla casualità, vincolanti grazie alla resistenza alle collisioni / la trappola della curva (Art 3) |
+| Da dove vengono le chiavi e le ricette segrete? | Aritmetica dei campi e moltiplicazione scalare su curva ellittica (Art 1, 2) |
+| Cos'è esattamente "la bacheca"? | Un albero di Merkle incrementale di commitment di note; la sua radice è l'anchor (Art 4) |
+| Perché il gettone di annullamento non può essere collegato alla sua busta? | Il nullifier è un hash con chiave conservato in un insieme separato dai commitment (Art 2, 3, 4) |
+| Come si prova la validità senza rivelare nulla? | Uno zk-SNARK su un circuito aritmetico che codifica tutte e quattro le affermazioni (Art 5) |
+| Come fa il destinatario a sapere di essere stato pagato? | La nota è cifrata verso il suo indirizzo; lui prova a decifrarla (trial-decrypt) con una viewing key (questo articolo) |
+| Come si impone "denaro in entrata = denaro in uscita" in modo privato? | Commitment di valore omomorfici + la binding signature (Sez 5) |
+
+Il paradosso della prima pagina, *verificare ciò che non puoi vedere*, è ora completamente dissolto. La rete verifica **affermazioni su dati nascosti**, mai i dati stessi.
+
+---
+
+## 8. Sapling vs Orchard, in un soffio
+
+Abbiamo insegnato con la struttura di Sapling perché la sua separazione è la più chiara. Il design attuale, **Orchard**, raffina queste idee anziché sostituirle:
+
+| | **Sapling** | **Orchard** |
+|---|---|---|
+| Unità di transazione | descrizioni separate di **Spend** e **Output** | **Action** unificate (ciascuna fa una spesa + un output) |
+| Sistema di prova | **Groth16** (trusted setup) | **Halo 2** (nessun trusted setup) |
+| Curve | BLS12-381 + Jubjub | Pallas / Vesta (Pasta) |
+| Hash dei commitment | Pedersen | Sinsemilla |
+
+Ogni concetto di questo articolo si trasferisce direttamente; Orchard principalmente raggruppa spesa-e-output insieme e sostituisce con un sistema di prova senza cerimonia. I cinque pilastri rimangono invariati.
+
+---
+
+## 9. Una dichiarazione onesta
+
+Questo è il quadro più completo della serie, ma resta pur sempre un modello. Abbiamo compresso le esatte codifiche di campo di una nota, le precise formule di derivazione delle chiavi, la ri-randomizzazione delle chiavi di spesa, gli indirizzi diversificati, i campi memo, la gestione delle commissioni, la differenza tra commitment di valore e commitment di note in tutti i dettagli, e il ruolo preciso di ciascuna firma. Abbiamo inoltre presentato un solo flusso canonico; le transazioni reali possono trasportare molte spese e output insieme e possono mescolare parti transparent e schermate. La fonte autorevole è la Specifica del Protocollo Zcash. Ciò che ora possiedi è la forma corretta; la specifica riempie ogni misura.
+
+---
+
+## 10. Riepilogo
+
+- Una transazione schermata incastra tutti e cinque i componenti: una **nota** (il valore), il suo **commitment** nell'**albero dei commitment delle note**, un **nullifier** per impedire la doppia spesa, **commitment di valore** per il bilancio, e uno **zk-SNARK** che lega tutto insieme.
+- Spendere prova **quattro affermazioni in una volta sola**, che la nota esiste, che sei autorizzato, che il suo nullifier è corretto e che il valore è bilanciato, a **conoscenza zero**, senza rivelare nessuno dei fatti sottostanti.
+- Il **bilancio dei valori** è imposto **sommando commitment omomorfici** e verificando che si sigillino a zero, tramite la **binding signature**, senza che alcun importo venga divulgato.
+- I poteri di un utente scaturiscono da un'unica **spending key** attraverso una **gerarchia unidirezionale**, abilitando **viewing key** che rivelano senza concedere il potere di spesa.
+- La rete **verifica affermazioni su dati nascosti**, dissolvendo il paradosso verifica-vs-privacy dell'Articolo 0. Ogni filo lì aperto è ora chiuso.
+- **Orchard** raffina **Sapling** (Action unificate, Halo 2 senza trusted setup, curve Pasta, Sinsemilla) senza modificare i cinque pilastri.
+
+---
+
+## Glossario
+
+| Termine | Significato in parole semplici |
+|---|---|
+| **Spending key** | L'unico segreto radice da cui derivano tutte le chiavi di un utente |
+| **Viewing key** | Rivela le tue transazioni a chi la detiene senza permettergli di spendere |
+| **Spend description** | La parte di una tx che consuma una nota (nullifier, anchor, prova) |
+| **Output description** | La parte di una tx che crea una nota (commitment, testo cifrato, prova) |
+| **Action (Orchard)** | Un'unità unificata che esegue insieme una spesa e un output |
+| **Commitment di valore** | Un commitment di Pedersen omomorfico a un importo |
+| **Binding signature** | La firma che prova che i valori sono bilanciati senza rivelarli |
+| **Anchor** | La radice dell'albero contro cui una spesa prova l'appartenenza |
+| **Trial decryption** | Un destinatario che testa i nuovi commitment per trovare le note destinate a lui |
+
+---
+
+## FAQ
+
+**La rete vede mai l'importo o chi ha pagato chi?**
+No. Verifica la prova, la freschezza del nullifier, l'anchor e la binding signature. Tutti i valori privati restano nascosti.
+
+**Cosa mi impedisce di spendere una nota due volte?**
+Il nullifier. Spendere lo pubblica; la rete rifiuta qualsiasi nullifier già presente nell'insieme dei nullifier. La stessa nota produce sempre lo stesso nullifier.
+
+**Come si può verificare il bilancio se gli importi sono nascosti?**
+I commitment di valore si sommano in modo omomorfico; i commitment di una transazione bilanciata si annullano in un commitment a zero, cosa che la binding signature prova.
+
+**Posso provare le mie transazioni a un revisore senza cedere il controllo?**
+Sì. Consegna una viewing key. Rivela la tua attività schermata ma non può autorizzare spese, grazie alla gerarchia di chiavi unidirezionale.
+
+**Sapling è ormai obsoleto adesso che esiste Orchard?**
+Entrambi sono esistiti sulla rete; Orchard è il design attuale. I concetti sono condivisi, quindi comprenderne uno ti dà l'altro.
+
+---
+
+### Metti alla prova la tua intuizione
+
+Un amico dice: "Poiché la prova nasconde l'importo, un ladro potrebbe semplicemente dichiarare che i suoi output valgono più dei suoi input e stampare denaro gratis." Usando la Sezione 5, spiega in due frasi perché questo fallisce. *(Risposta sotto.)*
+
+<details><summary>Risposta</summary>
+
+Gli importi sono nascosti, ma ciascuno è avvolto in un commitment di valore omomorfico, e la rete somma tutti i commitment di input e sottrae tutti i commitment di output; se i valori nascosti non fossero bilanciati, il risultato non si sigillerebbe a zero e **non si potrebbe produrre alcuna binding signature valida.** Il ladro può nascondere *quanto*, ma non può far passare valori non bilanciati al controllo del bilancio, quindi stampare denaro gratis è impossibile senza rivelare nulla e venendo comunque scoperto dall'aritmetica.
+</details>
+
+---
+
+### La serie, completa
+
+Hai ora viaggiato da un singolo paradosso fino a un pagamento privato completo:
+
+![alt text](https://github.com/user-attachments/assets/cd8bbb40-57b8-4854-b9cf-97f2485d126a)
+
+
+Da qui, l'arco naturale successivo va più in profondità: il funzionamento interno di Groth16 e Halo 2, le cerimonie di trusted setup, i circuiti di Sapling e Orchard nel dettaglio, la derivazione delle chiavi e gli indirizzi diversificati, e l'evoluzione del protocollo attraverso i network upgrade. Ma le fondamenta sono ora poste, e ognuno di quegli argomenti ha un posto a cui agganciarsi.
+
+*Parte della serie* Zcash from First Principles *per [ZecHub](https://zechub.org). Licenza CC BY-SA 4.0.*

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators.md
@@ -1,0 +1,124 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+![](https://i.ibb.co/x1nSS7b/image-2023-11-18-152209271.png)
+
+# Guide per i Creatori
+
+<a href="/ZFAV-Club/Guides-for-Creators/AI_tools">
+    <img src="https://i.ibb.co/mDZ7L2R/aitools.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---
+
+<a href="/ZFAV-Club/Guides-for-Creators/AI_tools_for_offline">
+    <img src="https://i.ibb.co/vsRhKmm/aitoolsoffline.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---
+
+<a href="/ZFAV-Club/Guides-for-Creators/Community_Broadcasting">
+    <img src="https://i.ibb.co/QPS6yZ2/communitybroadcasting.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---
+
+<a href="/ZFAV-Club/Guides-for-Creators/Creating_Zcon_Highlights">
+    <img src="https://i.ibb.co/7bb2C7m/zconhighlights.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---
+
+<a href="/ZFAV-Club/Guides-for-Creators/IPFS_File_Sharing">
+    <img src="https://i.ibb.co/hyV0nQt/ipfsfilesharing.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---
+
+<a href="/ZFAV-Club/Guides-for-Creators/Livestream_Setup">
+    <img src="https://i.ibb.co/4psKScH/livestreamsetup.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---
+
+<a href="/ZFAV-Club/Guides-for-Creators/Publish_Site_on_IPFS">
+    <img src="https://i.ibb.co/Vg6bLpv/publishipfs.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---
+
+<a href="/ZFAV-Club/Guides-for-Creators/Serve_Github_Repo_with_IPFS">
+    <img src="https://i.ibb.co/YTTCXQr/githubipfs.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---
+
+<a href="/ZFAV-Club/Guides-for-Creators/Video_Subtitle_Generation_with_Translation">
+    <img src="https://i.ibb.co/nRsBSCs/videosubs.png" alt="" width="400" height="200"/>
+</a>
+
+<aside>
+  
+#### Tempo di lettura
+| 2 min |
+
+</aside>
+
+---

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/AI_tools.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/AI_tools.md
@@ -1,0 +1,89 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/AI_tools.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Strumenti di IA: generazione di testo, immagini, video, audio (online)
+
+Ecco un elenco per rendere la vita più facile. Come usarli è un altro discorso.
+
+Scrivere i prompt migliori ha una curva di apprendimento. È possibile padroneggiare le basi piuttosto in fretta.
+
+## Generazione di testo / Assistenti
+
+[Analizzatore di prompt](https://novelai.net/tokenizer) (tokenizer) per imparare come funzionano i prompt e quanti token usano.
+
+Puoi sempre chiedere agli assistenti chatbot di aiutarti a generare un buon prompt.
+
+### Strumenti gratuiti:
+
+- [Claude di Anthropic](https://claude.ai/) - potrebbe servire una VPN per registrarsi (solo USA)
+- [ChatGPT 3.5](https://chat.openai.com/) - richiede un numero di telefono
+- [Bing Chat (GPT4)](https://www.bing.com/search?q=Bing+AI&showconv=1&FORM=hpcodx) - prompt limitati al giorno
+- [Llama 2 - 70B](https://www.llama2.ai/) - gratuito sul sito web
+
+### Strumenti a pagamento:
+
+- [Free2Z Chat2Z](https://free2z.com/ai) - Paga con ZEC / 2Z per GPT-3.5 e GPT-4 centesimi/prompt
+- [Chat GPT-4](https://chat.openai.com/auth/login) - 20 $/mese.
+
+## Generazione di immagini
+
+### Strumenti gratuiti:
+
+- [ImgnAI](https://imgnai.com/) bot su Discord o Telegram - [Guida introduttiva](https://imgnai.gitbook.io/imgnai/) e 
+ora anche [Webapp ImgnAI](https://app.imgnai.com/home) con login con account separato 
+accesso con X, Google, Discord, Telegram
+- [Bing Dalle3](https://www.bing.com/create) - la versione gratuita può essere lenta
+- [Adobe Firefly](https://www.adobe.com/ee/sensei/generative-ai/firefly.html) - quantità limitata gratuita
+- [Ideogram](https://ideogram.ai/login) - bravo a generare testo realistico e leggibile sulle immagini
+- [Playground AI](https://playgroundai.com/) - modalità gratuita, abbonamento da 15 $/mese
+- [Clipdrop di stability.ai](https://clipdrop.co/stable-diffusion)
+- [StarryAI](https://www.starryai.com) - 5 opere/giorno
+- [Dream by wombo](https://dream.ai/)
+- [Craiyon](https://www.craiyon.com/) (clone di DALL-E mini) - abbonamento a pagamento a partire da 5 $ aumenta la velocità
+- [DALL-E mini](https://huggingface.co/spaces/dalle-mini/dalle-mini) - vecchio e basilare
+
+### Strumenti a pagamento:
+
+- [Midjourney Bot](https://discord.com/invite/midjourney) su Discord - da 10 $/mese - [Guida introduttiva](https://docs.midjourney.com/docs/quick-start)
+puoi ottenere circa 100 generazioni gratuite valutando molte immagini di altri [qui](https://www.midjourney.com/app/rank-pairs/)
+(devi arrivare tra i primi 2000 valutatori - circa 15 minuti a valutare immagini)
+- [DALL-E 2](https://labs.openai.com/) [](https://openai.com/dall-e-2)- 15 $/115 generazioni - (15 generazioni gratuite/mese)
+- [DALL-E 3](https://openai.com/dall-e-3/) - incluso in ChatGPT-4 - 20 $/mese
+- [Nightcafe Creator](https://creator.nightcafe.studio/) (4 generazioni gratuite, a pagamento da 6 $/mese)
+
+## Generazione di video
+
+### Strumenti (di solito prova gratuita):
+
+- [RunwayML GEN-2](https://runwayml.com/) (prova gratuita, abbonamento da 15 $/mese)
+- [Pika labs Discord Bot](https://www.pika.art/) (gratuito al momento?)
+- [elai](https://elai.io/) (abbonamento da 23 $/mese)
+
+### Strumenti di traduzione video/audio:
+
+- [HeyGen Labs](https://labs.heygen.com/guest/video-translate) strumento di traduzione, doppiaggio e sincronizzazione labiale dei video
+- [Ezdubs Bot su X](https://twitter.com/ezdubs_bot) strumento di traduzione, doppiaggio e sincronizzazione labiale dei video
+
+## Roba audio
+
+### Correzione audio
+
+- [Adobe AI Clean up audio](https://podcast.adobe.com/enhance#): (gratuito con un account Adobe gratuito)
+
+### Generazione di musica
+
+- [Soundraw](https://soundraw.io/) - prova gratuita - (abbonamento da 16,99 $/mese)
+- [beatoven.ai](https://www.beatoven.ai/) - prova gratuita - (abbonamento da 3 $/mese o 1 $/minuto generato)
+- [soundful.com](https://soundful.com/) - prova gratuita - (abbonamento da 59,99 $/mese o 29,99/m annuale)
+- [boomy](https://boomy.com/) - prova gratuita - (abbonamento da 9,99 $/mese)
+- [Loudly](https://www.loudly.com/) - prova gratuita - (abbonamento da 7,99 $/mese)
+- [Mubert](https://mubert.com/) - prova gratuita - (abbonamento da 14 $/mese)
+
+### Generazione di voce
+
+- [play.ht](https://play.ht/) - gratuito - (abbonamento da 39 $/mese)
+- [ElevenLabs](https://elevenlabs.io/) - gratuito - (abbonamento da 5 $/mese)
+- [Murf](https://murf.ai/) - gratuito - (abbonamento da 29 $/mese)
+- [Resemble](https://www.resemble.ai/) - prova gratuita (poi 0,006 $ al secondo)
+- [Synthesia](https://www.synthesia.io/) - (abbonamento da 22,5 $/mese)

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/AI_tools_for_offline.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/AI_tools_for_offline.md
@@ -1,0 +1,51 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/AI_tools_for_offline.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Strumenti IA (locali, offline)
+
+<aside>
+*Stiamo ancora scrivendo e costruendo qui...*
+
+</aside>
+
+### Generazione di immagini
+
+Dove scaricare i modelli per la generazione di immagini? 
+Su [**HuggingFace**](https://huggingface.co/models?pipeline_tag=text-to-image&sort=trending) e [**Civitai](https://civitai.com/)** ci sono molti modelli diversi.
+
+## Windows - scaricare modelli personalizzati
+
+Di solito serve almeno una GPU con 4GB di memoria video per qualsiasi strumento IA.
+
+Le GPU Nvidia funzionano meglio.
+
+- [InvokeAI](https://invoke-ai.github.io/InvokeAI/) (richiede 4GB di memoria GPU)
+- [NMKD Stable Diffusion GUI](https://nmkd.itch.io/t2i-gui)
+- [EasyDiffusion 3.0](https://github.com/easydiffusion/easydiffusion)
+
+### Mac OS - scaricare modelli personalizzati
+
+- [Draw Things: AI Generation](https://apps.apple.com/ee/app/draw-things-ai-generation/id6444050820) dall'AppStore - gratuito
+(Può usare molti modelli StableDiffusion diversi)
+- [DiffusionBee](https://diffusionbee.com/) - gratuito
+(Può usare molti modelli StableDiffusion diversi)
+- [InvokeAI](https://invoke-ai.github.io/InvokeAI/) (richiede 4GB di memoria GPU)
+
+### Linux - scaricare modelli personalizzati
+
+- [InvokeAI](https://invoke-ai.github.io/InvokeAI/) (richiede 4GB di memoria GPU)
+
+## Generazione di testo
+
+### Windows - scaricare modelli personalizzati
+
+- [GPT4All](https://gpt4all.io/index.html) (min 8gb di RAM richiesti)
+
+### Mac OS - scaricare modelli personalizzati
+
+- [GPT4All](https://gpt4all.io/index.html) - (funziona piuttosto velocemente sui Mac M1, a seconda del modello GPT usato)
+
+## Linux - scaricare modelli personalizzati
+
+- [GPT4All](https://gpt4all.io/index.html) (min 8gb di RAM richiesti)

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/Community_Broadcasting.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/Community_Broadcasting.md
@@ -1,0 +1,97 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/Community_Broadcasting.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Trasmissioni comunitarie con VDO.Ninja e OBS Studio
+
+Questo breve tutorial è stato creato durante il [DWeb Camp 2023](https://dwebcamp.org/) da un gruppo di fellow e volontari. L'obiettivo di questo esercizio è sfruttare l'uso di dispositivi smartphone connessi a una rete MESH offline per la registrazione e lo streaming video collaborativi.
+
+Usiamo due software open source, [OBS Studio (Open Broadcaster software)](https://obsproject.com/) e [VDO.Ninja](https://vdo.ninja/). Questi software possono essere scaricati ed eseguiti localmente sul tuo computer.
+
+## OBS Studio (Open Boardcaster software)
+
+OBS Studio è un software gratuito e open source per la registrazione e lo streaming dal vivo, disponibile per più sistemi operativi. Il software è stato rilasciato per la prima volta nel 2012 e gode di un seguito piuttosto ampio nella community degli streamer di videogiochi e dei creator di contenuti video indipendenti.
+
+Le interfacce utente di OBS Studio possono sembrare piuttosto scoraggianti per chi le usa per la prima volta. OBS Studio è diviso in due finestre, "Preview" e "Broadcast". La finestra di anteprima mostra i video disponibili (varie telecamere come webcam, Iriun Webcam, OBS Virtual Camera, sorgenti video e browser) chiamati "Scene", mentre "Broadcast" mostra lo streaming dal vivo.
+
+Per fare streaming da una sorgente di telecamera remota di VDO.ninja in OBS Studio, inizi aggiungendo una nuova "Browser Source" con "Sources > Add > Browser". Nella nuova finestra, puoi fornire l'URL della sorgente da VDO.Ninja e selezionare "Make source visible".
+
+Ora puoi iniziare a trasmettere gli stream remoti.
+
+## VDO.Ninja
+
+[VDO.Ninja](https://vdo.ninja/) è un'applicazione web gratuita e open source che ti permette di trasformare i tuoi dispositivi mobili in una telecamera per lo streaming dal vivo. Il software può essere scaricato e distribuito sul tuo computer locale, oppure puoi usare direttamente la [versione online su https://vdo.ninja](https://vdo.ninja/).
+
+L'interfaccia di VOD.Ninja è semplice: apri semplicemente VDO.Ninja nel browser web dei tuoi dispositivi mobili e seleziona "Add your camera to OBS". A quel punto selezionerai la tua telecamera e il tuo dispositivo audio dall'elenco dei dispositivi e farai clic su "Start". Otterrai quindi un link "view" che puoi aggiungere a OBS Studio.
+
+## Dirigere una community call con VDO.Ninja
+
+Inizia andando su [VDO.ninja](http://VDO.ninja) con il tuo browser web su un desktop/laptop.
+
+<a href="">
+    <img src="https://images.spr.so/cdn-cgi/imagedelivery/j42No7y-dcokJuNgXeA0ig/8ded1b54-602b-4e66-af92-127990eff723/Screenshot_2023-08-23_162222/w=3840,quality=80" alt="" width="300" height="400"/>
+</a>
+
+
+Per creare una nuova stanza e dirigere il livestream della tua community call, fai clic su Create a Room.
+
+La schermata successiva ti chiederà le informazioni di base per configurare la tua stanza.
+
+<a href="">
+    <img src="https://images.spr.so/cdn-cgi/imagedelivery/j42No7y-dcokJuNgXeA0ig/ae698696-7b4d-458e-8de0-58a198c36e73/Screenshot_2023-08-23_183900/w=3840,quality=80" alt="" width="400" height="400"/>
+</a>
+
+Una volta creata una stanza, il regista ha a disposizione molte opzioni di controllo nella schermata seguente.
+
+<a href="">
+    <img src="https://images.spr.so/cdn-cgi/imagedelivery/j42No7y-dcokJuNgXeA0ig/35b43544-5114-4e74-ac41-9e8993fe62ea/Screenshot_2023-08-23_184015/w=3840,quality=80" alt="" width="400" height="400"/>
+</a>
+
+
+Quando le persone entrano nella tua stanza, tu, il regista, vedrai apparire tutte le opzioni e i controlli della sorgente insieme al loro video e audio.
+
+<a href="">
+    <img src="https://images.spr.so/cdn-cgi/imagedelivery/j42No7y-dcokJuNgXeA0ig/2247f187-b005-478e-9e5e-471cb8f070d3/Screenshot_2023-08-23_194136/w=3840,quality=80" alt="" width="400" height="300"/>
+</a>
+
+
+## FAQ
+
+- Che tipi di schede grafiche video sono necessari per OBS Studio?
+
+Puoi usare un personal computer con una buona scheda grafica e molta memoria, oppure in alternativa puoi usare un encoder hardware come il [Teradek VidiU](https://www.bhphotovideo.com/c/product/1609186-REG/teradek_10_0235_vidiu_x_modem.html?gclid=EAIaIQobChMIl4aIo7zX_wIVDhqtBh0PgwhxEAAYAiAAEgInufD_BwE)
+- OBS permette di fare traduzione e sottotitolazione in tempo reale?
+
+Ci sono alcuni plugin contribuiti dalla community che sembrano fornire una funzionalità del genere. [https://github.com/eddieoz/OBS-live-translation](https://github.com/eddieoz/OBS-live-translation)
+
+- Puoi sviluppare i tuoi plugin per OBS Studio?
+
+Sì, OBS supporta lo scripting in lua e python. Anche JavaScript per overlay e webview.
+
+- Usiamo dissolvenze al nero in tempo reale o transizioni?
+
+Sta a te, il produttore!
+
+- C'è latenza quando si fa streaming?
+
+Dipende per lo più dalla destinazione verso cui stai trasmettendo. Ad esempio, YouTube potrebbe avere un ritardo di un minuto o più a causa dell'elaborazione video effettuata sui loro server prima della trasmissione.
+
+- L'audio si interrompe usando OBS su una macchina lenta e mentre si fa green-screening
+
+Usa un encoder hardware oppure usa stream yard
+[https://support.streamyard.com/hc/en-us/articles/360056350852-How-to-Use-OBS-Virtual-Camera-with-StreamYard](https://support.streamyard.com/hc/en-us/articles/360056350852-How-to-Use-OBS-Virtual-Camera-with-StreamYard) oppure [RiverSide.FM](http://riverside.fm/)
+
+## Crediti
+
+- Ryan
+- Ajay
+- Arky
+
+## Risorse
+
+[https://obsproject.com/help](https://obsproject.com/help)
+
+[https://docs.vdo.ninja/](https://docs.vdo.ninja/)
+
+Office Hours: la community dei media e degli eventi digitali
+[https://alex4d.com/notes/item/media-and-digital-event-community](https://alex4d.com/notes/item/media-and-digital-event-community)

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/Creating_Zcon_Highlights.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/Creating_Zcon_Highlights.md
@@ -1,0 +1,21 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/Creating_Zcon_Highlights.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Guida rapida: creare i momenti salienti di Zcon
+
+Questa guida ti accompagnerà attraverso il processo di montaggio e pubblicazione di brevi clip usando come contenuto sorgente i video storici di Zcon.
+
+**Playlist video di Zcon:**
+
+- [Zcon0 - Privacy: From A to Zcon (2018)](https://www.youtube.com/playlist?list=PL40dyJ0UYTLK507afWUMgzUYeh-i4qQWS)
+- [Zcon1: Zero to Privacy Hero (2019)](https://www.youtube.com/playlist?list=PL40dyJ0UYTLLjPZaKjdhMoCNanb77_Ztj)
+- [Zcon2 Lite - Privacy all the way down (2021)](https://www.youtube.com/playlist?list=PL40dyJ0UYTLLa68H9ibpiSZqeevqKizg4)
+- [Zcon3: Code Alone Doesn't Cut It (2022)](https://www.youtube.com/playlist?list=PL40dyJ0UYTLJm-Cl7ez3UXp8R4IuUNDfb)
+- [Zcon4: The Future Has Not Been Written (2023)](https://www.youtube.com/playlist?list=PL40dyJ0UYTLII7oQRQmNOFf0d2iKT35tL)
+
+**Playlist dei momenti salienti di Zcon:**
+
+- [Zcon0 Highlights (2018)](https://www.youtube.com/playlist?list=PL9eB_cR4oMej_GykkZnQg0zH1SbZ9S67O)
+
+La durata target per i momenti salienti di Zcon è inferiore a un minuto, per essere conforme ai requisiti degli YouTube Shorts.

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/IPFS_File_Sharing.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/IPFS_File_Sharing.md
@@ -1,0 +1,26 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/IPFS_File_Sharing.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Condivisione File P2P con IPFS e Brave Browser
+
+Possiamo usare IPFS per condividere tra di noi file multimediali di grandi dimensioni in modalità Peer-to-Peer.
+
+Allora, qual è il problema: i gateway IPFS non funzionano per i file di grandi dimensioni, vanno in timeout.
+
+**Requisiti**: [IPFS Desktop](https://docs.ipfs.tech/install/ipfs-desktop/) + [Brave Browser](https://brave.com/)
+
+In breve, il video è alla fine.
+
+Possiamo usarlo tra di noi nel ZF AV Club per trasferire file multimediali di grandi dimensioni e lo documentiamo per tutti voi perché è divertente e super interessante!!
+
+*INOLTRE*, collaboreremo direttamente con il team di IPFS presso Protocol Labs per sviluppare questo caso d'uso.
+Un altro vantaggio nato dalle connessioni fatte al dWeb Camp!
+
+Senza IPFS installato sulla macchina ricevente E usando un browser che non sia Brave: dovrai aspettare che il gateway carichi il file. *Questo restituirà un errore 504 sui file di grandi dimensioni.*
+
+Prossimo passo: come fissare (pin) i file di altre persone sulla tua macchina in modo da non avere il problema del singolo punto di guasto quando il nodo originale va offline.
+
+[Il link di condivisione per il video in questo video è [https://ipfs.io/ipfs/QmU8SDV1ozFf2n7FVq52jxuQ3jKjHXj48V6k4xbDqojmNy?filename=MadBitcoinsOnABoat_kaiber.mp4](https://ipfs.io/ipfs/QmU8SDV1ozFf2n7FVq52jxuQ3jKjHXj48V6k4xbDqojmNy?filename=MadBitcoinsOnABoat_kaiber.mp4)](https://cdn.discordapp.com/attachments/1154434684558770237/1154435234276835338/IPFSdesktop_getStartedbrave_ZFAV_20230921.mp4)
+
+Il link di condivisione per il video in questo video è [https://ipfs.io/ipfs/QmU8SDV1ozFf2n7FVq52jxuQ3jKjHXj48V6k4xbDqojmNy?filename=MadBitcoinsOnABoat_kaiber.mp4](https://ipfs.io/ipfs/QmU8SDV1ozFf2n7FVq52jxuQ3jKjHXj48V6k4xbDqojmNy?filename=MadBitcoinsOnABoat_kaiber.mp4)

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/Livestream_Setup.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/Livestream_Setup.md
@@ -1,0 +1,22 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/Livestream_Setup.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Configurazione del Livestream
+
+**Cosa ti servirà:**
+
+- Videocamera con uscita HDMI senza overlay
+- Treppiede
+- Dispositivo di acquisizione video HDMI-to-USB (2x)
+- HDMI per catturare le slide della presentazione/la demo (meglio se wireless)
+- Feed audio dal mixer (meglio se wireless)
+- Un laptop in grado di eseguire OBS o software simile (meglio con ethernet)
+
+*Lo scopo di questo kit è qualità e portabilità.*
+
+Esistono modi per sostituire parte di questa attrezzatura con soluzioni più facilmente reperibili (come usare un telefono al posto di una videocamera), che verranno discussi in un altro articolo della wiki.
+
+![Esempio di schema su come collegare tutti i dispositivi per lo streaming. Autore: [decentralistdan](https://twitter.com/decentralistdan)](Livestream%20Setup%2078cbdbd99e4a42d7b5565978aa5e4488/stream-cable-setup.jpg)
+
+Esempio di schema su come collegare tutti i dispositivi per lo streaming. Autore: [decentralistdan](https://twitter.com/decentralistdan)

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/Publish_Site_on_IPFS.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/Publish_Site_on_IPFS.md
@@ -1,0 +1,131 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/Publish_Site_on_IPFS.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Pubblicare un sito su IPFS
+
+<a href="">
+    <img src="https://blog.desdelinux.net/wp-content/uploads/2020/04/IPFS-.jpg" alt="" width="800" height="400"/>
+</a>
+
+
+
+## Introduzione a IPFS
+
+IPFS (InterPlanetary File System) è un protocollo e una rete peer-to-peer progettati per creare un metodo decentralizzato di archiviazione e condivisione di file.
+
+A differenza del tradizionale modello client-server di Internet, IPFS consente agli utenti di condividere i file direttamente tra loro, anziché affidarsi a un server centralizzato per archiviare e distribuire i contenuti.
+
+I file in IPFS sono indirizzati tramite il *content-addressing*, il che significa che a ogni file viene assegnato un hash univoco o CONTENT IDENTIFIER (CID) basato sul suo contenuto, e questo hash viene usato per recuperare il file dalla rete.
+
+Quando un utente aggiunge un file a IPFS, il file viene suddiviso in piccole parti chiamate blocchi, e a ogni blocco viene assegnato un CID. Questi blocchi vengono poi memorizzati su diversi nodi della rete, in modo che il file possa essere facilmente recuperato da più fonti.
+
+Questo garantisce ridondanza e tolleranza ai guasti, rendendo al contempo difficile per un singolo nodo diventare un singolo punto di guasto o di controllo.
+
+**Leggi: [Un'introduzione a IPFS](https://blog.infura.io/post/an-introduction-to-ipfs)**
+
+## Creare il tuo sito
+
+Per questo esempio creiamo un semplice sito web.
+
+[Sito di esempio](https://squirrel.surf/)
+
+**Passo 1:** Se non hai familiarità con il web design, scrivi il contenuto principale del tuo sito web, inclusi il titolo, il corpo principale del testo, con link ad altre pagine/siti e i piè di pagina.
+
+**Passo 2:** Usa un [template HTML!](https://nicepage.com/html-templates) Incolla il testo che hai scritto di conseguenza. Facoltativamente, puoi anche creare un foglio di stile .CSS per il tuo sito web.
+
+**Passo 3:** Salva la tua directory. Tutte le pagine .html e le immagini devono trovarsi nella stessa cartella.
+
+## Configurare un nodo
+
+Scarica e installa IPFS dal [sito ufficiale](https://docs.ipfs.tech/install/ipfs-desktop/).
+
+### Inizializzare IPFS:
+
+Se usi l'applicazione Desktop non dovrai inizializzare.
+
+Usando un terminale o un prompt dei comandi, esegui il comando: ipfs init
+
+### **Aggiungere la cartella del sito a IPFS**:
+
+Seleziona la cartella con i file del tuo sito web e vai all'opzione Add Folder.
+
+
+<a href="">
+    <img src="https://i.ibb.co/ZHW4zsY/ipfs-site-folder.png" alt="" width="400" height="200"/>
+</a>
+
+–
+
+Se usi il terminale, esegui il comando: ipfs add -r folder_name per aggiungere l'intera cartella in modo ricorsivo a IPFS.
+
+### Effettuare il pin del sito su IPFS:
+
+Una volta aggiunti i file del tuo sito web a IPFS, devi effettuarne il **pin** per garantire che rimangano disponibili sulla rete.
+
+–
+
+Se usi il terminale, esegui il comando: Se usi il terminale, esegui il comando: ipfs pin add **hash**
+
+**hash** = CID della cartella che hai aggiunto nel passaggio precedente.
+
+In alternativa, puoi anche effettuare il pin delle directory usando servizi come [Pinata](https://pinata.cloud/) o [Dolpin](https://dolpin.io/)
+
+Fa risparmiare un sacco di tempo!
+
+–
+
+### Accedere al tuo sito web su IPFS:
+
+Il tuo sito web è ora pubblicato su IPFS ed è accessibile usando l'hash della cartella. Per accedere al tuo sito web, puoi visitare https://ipfs.io/ipfs/**hash**
+
+**hash** = CID della cartella.
+
+Nel nostro caso il CID = QmW2UEfap1vrRRvS5H9wed8qmsx4WsvXBk3GPGVVfWx3r3
+
+## IPNS
+
+L'Interplanetary Naming System (IPNS) ti consente di aggiornare i CID IPFS associati al tuo sito web mantenendo comunque un link statico. Viene fornito sotto forma di chiave.
+
+
+<a href="">
+    <img src="https://dnslink.io/assets/dns-query.a0134a75.png" alt="" width="400" height="100"/>
+</a>
+
+
+Nel menu delle impostazioni della cartella del tuo sito nell'applicazione IPFS desktop, seleziona Publish to IPNS.
+
+<a href="">
+    <img src="https://i.ibb.co/Ch25dKf/IPNS.png" alt="" width="400" height="200"/>
+</a>
+
+
+Chiave: “k51qzi5uqu5di670a6uxywo17b2be1eyhoa2cl0qlwpfxn5p9ypcu8jbzgnj4n”
+
+Può anche essere usata per visualizzare il nostro sito tramite un gateway: https://ipfs.io/ipns/k51qzi5uqu5di670a6uxywo17b2be1eyhoa2cl0qlwpfxn5p9ypcu8jbzgnj4n
+
+## DNS Link
+
+Il sito è stato creato, ora ci serve un modo per puntare un URL al contenuto.
+
+Se possiedi già un indirizzo web, puoi aggiungere un nuovo record usando il record TXT _dnslink(il tuo dominio). A seconda del provider, potrebbe compilarsi automaticamente.
+
+
+<a href="">
+    <img src="https://i.ibb.co/MgRxBHj/example.png" alt="" width="400" height="100"/>
+</a>
+
+
+Ci vorrà del tempo perché si propaghi attraverso la rete prima di poterlo visualizzare.
+
+*Congratulazioni! Ora hai un sito web resistente alla censura.*
+
+____
+
+**Risorse**
+
+[Documentazione IPFS](https://docs.ipfs.tech/)
+
+[Documentazione IPNS](https://docs.ipfs.tech/concepts/ipns/)
+
+[Documentazione DNS link](https://dnslink.io/#introduction)

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/Serve_Github_Repo_with_IPFS.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/Serve_Github_Repo_with_IPFS.md
@@ -1,0 +1,67 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/Serve_Github_Repo_with_IPFS.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Servire un repository GitHub con IPFS
+
+## Introduzione
+
+In questa guida impariamo a creare un URL clonabile con git per il tuo repository GitHub servito tramite un CID IPFS. 
+
+Questo è utile per garantire la disponibilità dei contenuti indipendentemente dalla regione geografica, per la resistenza alla censura e come backup persistente di informazioni preziose!
+
+Nota: i dati caricati su IPFS sono disponibili a tutti gli utenti della rete. Potresti voler cifrare localmente i dati personali/sensibili.
+
+## Installare IPFS Kubo
+
+Segui le istruzioni di installazione fornite [qui](https://docs.ipfs.tech/install/command-line/#install-official-binary-distributions)
+
+In questo esempio usiamo Linux, sono disponibili versioni per altri sistemi operativi.
+
+Verifica che l'installazione sia andata a buon fine usando   ipfs –version
+
+## Clonare il repository
+
+Per iniziare, seleziona un repository Git che vuoi ospitare e clonalo:
+
+Esegui il comando: “git clone https://github.com/zechub/zechub”
+
+![https://i.ibb.co/HxFX37b/Screenshot-from-2023-05-20-14-14-46.png](https://i.ibb.co/HxFX37b/Screenshot-from-2023-05-20-14-14-46.png)
+
+Ora, per prepararlo a essere clonato tramite IPFS.
+
+cd zechub git update-server-info
+
+Decomprimi gli oggetti di Git:
+
+![](https://i.ibb.co/25RwyWz/image-2024-04-20-175848513.png)
+
+Fare questo consentirà a IPFS di deduplicare gli oggetti se aggiornerai il repository Git in seguito.
+
+## Aggiungere a IPFS
+
+Una volta fatto questo, il repository è pronto per essere servito. Tutto ciò che resta da fare è aggiungerlo a IPFS:
+
+$ pwd
+
+/code/myrepo
+
+$ ipfs add -r 
+
+![https://i.ibb.co/LJgK1q3/Screenshot-from-2023-05-20-14-22-38.png](https://i.ibb.co/LJgK1q3/Screenshot-from-2023-05-20-14-22-38.png)
+
+Il CID risultante: Qmbgqox5g3614gjTb43s5mdSmmk95aGWWA9EHksL2T91A2
+
+![https://i.ibb.co/GvhCLwn/Screenshot-from-2023-05-20-14-26-34.png](https://i.ibb.co/GvhCLwn/Screenshot-from-2023-05-20-14-26-34.png)
+
+Ottimo! Ora il tuo repository è caricato sulla rete.
+
+## Clonare usando IPFS
+
+Ora dovresti essere in grado di recuperare il repository GitHub usando:
+
+git clone http://ipfs.io/ipfs/yourCID
+
+In alternativa, puoi cercare e recuperare usando il tuo nodo IPFS locale.
+
+Nota finale: la cartella del repo su IPFS non riceve aggiornamenti insieme al repository GitHub effettivo. Si consiglia di ricaricare la cartella a intervalli regolari.

--- a/translations/it/site/ZFAV_Club/Guides_for_Creators/Video_Subtitle_Generation_with_Translation.md
+++ b/translations/it/site/ZFAV_Club/Guides_for_Creators/Video_Subtitle_Generation_with_Translation.md
@@ -1,0 +1,26 @@
+<a href="https://github.com/Zechub/zechub/edit/main/site/ZFAV_Club/Guides_for_Creators/Video_Subtitle_Generation_with_Translation.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Generazione e traduzione dei sottotitoli dei video
+
+Strumenti usati in questa guida:
+
+1. CapCut
+2. [CapCut SRT Export](https://www.biyaoyun.com/capcutsrt)
+3. Editor di testo
+4. [Online Subtitle Translator & Editor](https://www.syedgakbar.com/projects/dst)
+
+Inizia importando il montaggio finale del tuo video in CapCut. In alternativa, puoi usare CapCut per montare il video prima di continuare questo processo.
+
+Con il video finale caricato in CapCut, usa [CapCut SRT Export](https://www.biyaoyun.com/capcutsrt) per ottenere il file dei sottotitoli, con i timestamp, dal progetto CapCut.
+
+Apri il file SRT in un editor di testo e guarda il video, leggendo contemporaneamente il file SRT, apportando modifiche al file SRT quando trovi degli errori. Usa la funzione cerca e sostituisci per **sostituire tutto** per ciascun errore.
+
+Suggerimento: guarda il video a 2x mentre controlli i sottotitoli
+
+Dopo aver controllato e corretto la trascrizione originale, carica il file SRT su [Online Subtitle Translator & Editor](https://www.syedgakbar.com/projects/dst) per tradurre il file SRT in qualsiasi altra lingua per una piccola commissione.
+
+Il file SRT tradotto dovrebbe essere controllato usando un software di montaggio video da qualcuno che comprende la lingua tradotta.
+
+I file SRT tradotti a volte necessitano di aggiustamenti ai timecode, che sono facili da trovare e correggere con la maggior parte dei software di montaggio video.

--- a/translations/it/site/Zcash_Organizations/Sovright.md
+++ b/translations/it/site/Zcash_Organizations/Sovright.md
@@ -1,0 +1,40 @@
+# Sovright
+![Sovright](https://i.ibb.co/vvZNvNDT/sovright.png)
+
+**Sovright** è un'organizzazione non profit statunitense 501(c3) dedicata al supporto dell'autonomia umana. Partendo da un focus sull'infrastruttura di Zcash, sul mining, sullo sviluppo del protocollo e sul supporto dell'ecosistema, il progetto costruisce strumenti e servizi pensati per rafforzare l'infrastruttura delle valute digitali private e sostenere la resilienza a lungo termine della rete Zcash.
+
+Sovright era precedentemente nota come **Bootstrap**. Il nome originale rifletteva l'obiettivo iniziale dell'organizzazione di creare da zero un'azienda di infrastruttura Zcash.
+
+[Visita il sito](https://sovright.com/)
+
+## Nome
+
+Il nome **Sovright** è una composizione di **sovereign** e **right**. Riflette l'attenzione dell'organizzazione per la sovranità individuale, la privacy e il diritto di scegliere come vengono controllati i dati personali, il denaro, le comunicazioni, il calcolo e l'attività online.
+
+Il lavoro di Sovright è iniziato con Zcash, una criptovaluta orientata alla tutela della privacy che utilizza la crittografia a conoscenza zero per supportare transazioni schermate. Nel tempo, il focus dell'organizzazione si è ampliato oltre il denaro privato per includere questioni infrastrutturali più ampie, comprese comunicazioni sicure, reti resilienti, calcolo privato e interazioni sicure con l'IA.
+
+## Mining Pool
+
+Sovright gestisce una mining pool Zcash su:
+
+[mining.sovright.com](https://mining.sovright.com/)
+
+La Mining Pool di Sovright è progettata per supportare la sovranità dei miner e ridurre la concentrazione delle mining pool. La concentrazione delle mining pool è una preoccupazione ricorrente nelle reti proof-of-work perché un numero ridotto di pool può finire per controllare una grande quota dell'hashrate della rete. Questo può indebolire la decentralizzazione e aumentare la dipendenza dal comportamento dei principali operatori di pool.
+
+La Mining Pool di Sovright è pensata per miner solitari, piccoli operatori e altri partecipanti che vogliono sostenere un ecosistema di mining Zcash più decentralizzato. La pool mette l'accento su una logica di pagamento trasparente, auditabilità e commissioni operative minime.
+
+L'attuale versione testnet non prevede pagamenti ed è destinata esclusivamente ai test.
+
+## (Prossimamente)
+
+### Resilienza della rete
+
+La resilienza della rete si riferisce all'affidabilità e alla robustezza dell'infrastruttura che trasporta le transazioni Zcash. Le transazioni private dipendono non solo dalla crittografia, ma anche dalla disponibilità e affidabilità dell'infrastruttura di rete sottostante.
+
+Sovright identifica la resilienza della rete come un'area di lavoro fondamentale per mantenere la sicurezza pratica e l'usabilità di Zcash.
+
+### Sovranità finanziaria
+
+La sovranità finanziaria si riferisce alla capacità degli individui di controllare e accedere ai propri fondi senza dipendere dal permesso di intermediari. Nel contesto di Zcash, questo include pagamenti privati, autocustodia e infrastrutture che consentono agli utenti di effettuare transazioni alle proprie condizioni.
+
+Sovright considera l'accesso finanziario e il denaro controllato dagli utenti come componenti centrali della sovranità individuale.

--- a/translations/it/site/Zcash_Social_Media/Cryptonote.md
+++ b/translations/it/site/Zcash_Social_Media/Cryptonote.md
@@ -1,0 +1,109 @@
+# Zero to Zero Knowledge: il protocollo CryptoNote
+
+**Serie:** Zero to Zero Knowledge
+
+Uno interessante oggi!  
+Il protocollo **CryptoNote** abilita una forte privacy on-chain. Oggi impariamo tutte le sue caratteristiche chiave e come è stato implementato da diversi progetti di privacy degni di nota.
+
+![CryptoNote intro](https://pbs.twimg.com/media/FrXr5P8WIAAvx36.jpg)
+
+---
+
+## Contesto
+
+Il whitepaper originale di CryptoNote fu pubblicato sotto lo pseudonimo di **"Nicolas van Saberhagen"**.  
+
+**Bytecoin** fu la prima criptovaluta a implementare il protocollo. Il progetto più conosciuto che lo usa oggi è **Monero (XMR)**. È stato usato anche in TurtleCoin, Aeon e diversi altri.
+
+---
+
+## Caratteristiche principali di CryptoNote
+
+Il protocollo CryptoNote fornisce tre caratteristiche principali:
+
+1. **Non tracciabilità e non collegabilità** delle transazioni
+2. **Egalitarian Proof of Work** (resistente agli ASIC) 
+3. **Emissione dinamica**
+
+---
+
+## 1. Non tracciabilità - Ring Signatures
+
+La non tracciabilità è raggiunta principalmente usando le **Ring Signatures**.
+
+Quando invii una transazione, la tua vera chiave pubblica viene mescolata con diverse chiavi esca (il "ring") - tutte contenenti la stessa quantità di monete. Questo rende estremamente difficile determinare chi ha effettivamente inviato le monete.
+
+La **dimensione del ring** influisce significativamente sull'anonymity set. Ring più grandi forniscono una privacy migliore.
+
+![Ring Signatures explanation](https://pbs.twimg.com/media/FrXteGHXgAANE0F.png)
+
+**Confronto con Zcash**:  
+L'anonymity set di Zcash è il numero totale di transazioni *mai* effettuate in un determinato pool schermato (molto più grande delle tipiche dimensioni dei ring di CryptoNote).
+
+---
+
+## Ring CT (Confidential Transactions)
+
+Il modello **Ring CT** ha migliorato notevolmente la privacy nelle monete basate su CryptoNote.
+
+Invece di nascondere solo il mittente, Ring CT **offusca anche gli importi delle transazioni** tra mittente e destinatario.
+
+![Ring CT diagram](https://pbs.twimg.com/media/FrXuivgWYAAze7B.png)
+
+Utilizza:
+- Elliptic Curve Cryptography
+- Pedersen Commitments
+- Homomorphic Encryption
+
+Le **prove** vengono usate per dimostrare che l'importo è maggiore di 0 ed entro intervalli validi **senza rivelare i valori effettivi**.
+
+Gli **Stealth Address** aggiungono inoltre indirizzi monouso per il destinatario.
+
+![Stealth Addresses + Proofs](https://pbs.twimg.com/media/FrXut5aWAAMhuRb.jpg)
+
+---
+
+## 2. Egalitarian Proof of Work (ePoW)
+
+CryptoNote mira a creare un sistema di mining più equo essendo resistente agli ASIC.
+
+Utilizza l'algoritmo **CryptoNight** (una funzione memory-hard). A differenza dello SHA256 di Bitcoin, CryptoNight è progettato per ridurre il divario tra miner CPU, GPU e ASIC.
+
+**Passaggi di CryptoNight:**
+1. Inizializza una grande area di memoria (scratchpad) con dati pseudocasuali
+2. Esegue numerose operazioni di lettura/scrittura sullo scratchpad
+3. Esegue l'hash dell'intero scratchpad per produrre il valore finale
+
+![CryptoNight mining](https://pbs.twimg.com/media/FrXvNs3XsAA37LG.jpg)
+
+(Nota: da allora Monero si è allontanato da CryptoNight verso altri algoritmi.)
+
+---
+
+## 3. Emissione dinamica
+
+Invece di eventi di halving improvvisi (come Bitcoin), CryptoNote usa una **ricompensa di blocco che decresce in modo graduale**.
+
+Questo crea una curva di emissione molto più graduale nel tempo.
+
+![Dynamic emission curve](https://pbs.twimg.com/media/FrXv8wpXoAEjUxW.png)
+
+**Connessione con Zcash**:  
+Gli sviluppatori di Zcash hanno discusso l'implementazione di una curva di emissione più graduale in futuro, potenzialmente attraverso un "Zcash Posterity Fund".
+
+---
+
+## Conclusione
+
+CryptoNote si è dimostrato un approccio forte e collaudato alla privacy on-chain. Molte delle sue innovazioni hanno influenzato il più ampio ecosistema delle privacy coin.
+
+Alcuni ricercatori ritengono che le caratteristiche di CryptoNote potrebbero alla fine essere combinate con pool schermati trustless a conoscenza zero.
+
+---
+
+**Thread originale di ZecHub (@ZecHub)**  
+https://x.com/ZecHub/status/1636473585781948416
+
+---
+
+*Questa pagina è stata compilata a partire dal thread originale di Zero to Zero Knowledge per la wiki di ZecHub.*

--- a/translations/it/site/Zcash_Social_Media/Hash_Functions.md
+++ b/translations/it/site/Zcash_Social_Media/Hash_Functions.md
@@ -1,0 +1,99 @@
+# Zero to Zero Knowledge: Hash Functions
+
+**Introduzione alla serie**  
+Benvenuti in una nuova serie: **Zero to Zero Knowledge**!  
+
+In questa serie impareremo i fondamenti di un'ampia gamma di tecnologie che entrano nei nostri protocolli per la tutela della privacy.
+
+---
+
+## Parte 1: Hash Functions
+
+Oggi iniziamo con le **Hash Functions** - un elemento chiave della crittografia usato nelle blockchain. Più avanti in questa serie tratteremo alcuni argomenti che si basano sulle loro proprietà.
+
+### Cos'è una Hash Function?
+
+Le Hash Functions prendono un input di qualsiasi lunghezza e producono un output di lunghezza fissa.
+
+- **Messaggio da sottoporre ad hashing** = Input  
+- **L'algoritmo che viene usato** = Hash Function  
+- **Output risultante** = Hash Value  
+
+
+![Hash Function diagram](https://pbs.twimg.com/media/Fn_NkFHXgAEtgse.png)
+
+### Provalo tu stesso!
+
+Acquisiamo una comprensione pratica usando questo strumento!  
+Inserisci un testo arbitrario qualsiasi per produrre un output di lunghezza fissa. Osserva come l'output varia a seconda del diverso algoritmo di hashing.
+
+**Provalo:** https://cryptii.com/pipes/hash-function
+
+---
+
+### Proprietà delle Cryptographic Hash Functions
+
+Le Cryptographic Hash Functions devono avere queste **3 proprietà**:
+
+1. **Unidirezionale** - Dovrebbe essere impraticabile invertire una hash function  
+2. **Resistente alle collisioni** - Due input diversi non devono produrre lo stesso output  
+3. **Deterministica** - Per qualsiasi input, una hash function deve sempre dare lo stesso risultato
+
+---
+
+### Hash Functions comuni
+
+Esistono diverse classi di Hash Functions. Alcuni esempi:
+
+- Secure Hashing Algorithm (**SHA-3**)  
+- Message Digest Algorithm 5 (**MD5**)  
+- **BLAKE2b** - Usato nella derivazione delle chiavi in Zcash
+
+**Un'introduzione a BLAKE2 di Zooko**: https://www.zfnd.org/blog/blake2/
+
+---
+
+### Usi reali delle Hash Functions
+
+#### 1. Integrity Hashing (controlli di integrità dei dati)
+I controlli di integrità dei dati sono un esempio di "Integrity Hashing". Vengono usati per generare checksum sui file di dati e fornire all'utente la garanzia di correttezza.
+
+![Integrity Hashing example](https://pbs.twimg.com/media/Fn_Or0MWIAI6sgx.png)
+
+#### 2. Merkle Trees (Hash Trees)
+Un **hash tree** o **Merkle tree** è composto da rami e nodi foglia etichettati con l'hash crittografico di un blocco di dati.
+
+![Merkle Tree diagram](https://pbs.twimg.com/media/Fn_O7ndWIAY5PA-.jpg)
+
+I Merkle tree sono un esempio di **commitment scheme crittografico**. La radice dell'albero è vista come un commitment e i nodi foglia vengono dimostrati far parte del commitment originale.
+
+Verificano i dati memorizzati o trasferiti sulle reti P2P, garantendo che i dati ricevuti dai peer siano inalterati.
+
+#### 3. Note Commitment Tree in Zcash
+Nei pool schermati **Sapling** e **Orchard** di Zcash, il **Note Commitment Tree** viene usato per verificare che le transazioni siano valide rispetto al consenso, nascondendo perfettamente mittente, destinatario e importi consumati.
+
+#### 4. Signature Hash (blocchi in stile Bitcoin)
+**SHA256** è un esempio di "Signature hash" usato per imporre l'immutabilità di ogni blocco nella chain di Bitcoin. I miner usano l'hash del blocco precedente + un hash di tutte le transazioni nel blocco corrente (hashMerkleRoot) + il timestamp + un valore casuale / la difficoltà di rete per i nuovi blocchi.
+
+![SHA256 block diagram](https://pbs.twimg.com/media/Fn_PaVZXoAApHPf.jpg)
+
+#### 5. Equihash (mining di Zcash)
+**Equihash** è l'algoritmo di hashing usato nel mining di Zcash. È usato anche da reti come Komodo e Horizen.
+
+**Blog originale di Zcash su Equihash**: https://electriccoin.co/blog/equihash/
+
+---
+
+### Approfondimenti
+
+Per costruire una comprensione più approfondita dei diversi tipi di hash function e dei loro usi associati, questa è un'ottima risorsa:  
+https://en.wikipedia.org/wiki/Hash_function
+
+---
+
+**Thread di ZecHub (@ZecHub)**  
+Thread X originale: https://x.com/ZecHub/status/1621240109663227906  
+
+---
+
+*Questa pagina è stata compilata a partire dal thread originale di Zero to Zero Knowledge per la wiki di ZecHub.*

--- a/translations/it/site/Zcash_Social_Media/Lelantus.md
+++ b/translations/it/site/Zcash_Social_Media/Lelantus.md
@@ -1,0 +1,129 @@
+# Zero to Zero Knowledge: il protocollo Lelantus
+
+**Serie:** Zero to Zero Knowledge
+
+Oggi diamo un'occhiata a **Lelantus**!
+
+Rilasciato nel 2019, questo protocollo si basa su Zerocoin. È usato nella valuta **Firo** (precedentemente Zcoin) per abilitare transazioni private on-chain. Per certi aspetti assomiglia a Zcash, ma è nettamente diverso nella maggior parte degli aspetti.
+
+![Lelantus intro](https://pbs.twimg.com/media/Fsk18DgXsAEc0Ob.jpg)
+
+---
+
+## Fondamenta dei protocolli Zcash vs Firo
+
+- **Zcash** - Si basa sul protocollo **Zerocash**  
+- **Firo (Zcoin)** - Si basa sul protocollo **Zerocoin**
+
+![Zerocash vs Zerocoin comparison](https://pbs.twimg.com/media/Fsk2Fk7WcAA81ty.png)
+
+---
+
+## Evoluzione dei protocolli di privacy di Firo
+
+Analogamente a Zcash, Firo usa indirizzi schermati per ottenere pagamenti anonimi.
+
+**Cronologia:**
+- **Zerocoin** - Solidità compromessa
+- **Sigma** - Sistema a denominazioni fisse
+- **Lelantus 1.0** - Mancava di prove di sicurezza corrette
+
+![Protocol evolution](https://pbs.twimg.com/media/Fsk2NdaWAAAKVgH.png)
+
+---
+
+## Limitazioni del protocollo Sigma
+
+Il protocollo Σ (Sigma) usato nelle versioni precedenti di Zcoin/Firo aveva una grossa limitazione: gli utenti potevano coniare solo denominazioni fisse.
+
+Questo creava insiemi di anonimato più piccoli e apriva la porta ad attacchi di timing tra le operazioni di mint e di redeem (oltre al problema del "tainted change", il resto contaminato).
+
+![Sigma denominations](https://pbs.twimg.com/media/Fsk2fxfWcAMUBDo.png)
+
+---
+
+## Come Lelantus migliora la privacy
+
+**Lelantus** risolve il problema delle denominazioni fisse consentendo mint da un unico insieme più grande.
+
+Vantaggi chiave:
+- Elimina gli insiemi di anonimato a denominazioni fisse
+- Riduce gli attacchi di timing tra burn/redeem
+- Rimuove il problema del tainted change
+
+**Limitazione**: la dimensione dell'insieme è attualmente limitata a **65.000 coin**.
+
+![Lelantus advantages](https://pbs.twimg.com/media/Fsk2wK3X0AA6MEe.png)
+
+---
+
+## Coin commitment
+
+Un **coin commitment** è un commitment a doppia cecità che codifica il numero seriale del coin e il valore del coin.
+
+Funzionano in modo simile alle **Note** in Zcash.
+
+Il coin commitment viene pubblicato e memorizzato sul ledger quando il coin viene creato (tramite transazioni Mint o Spend).
+
+![Coin commitment diagram](https://pbs.twimg.com/media/Fsk3AWNX0AIHya8.png)
+
+---
+
+## Modello basecoin < - > zerocoin
+
+Lelantus usa il classico modello **basecoin < - > zerocoin**.
+
+**Caratteristica importante**: ora sono possibili riscatti parziali mantenendo nascosti il resto e gli importi.
+
+Come in Zcash, le transazioni trasparenti devono essere selezionate esplicitamente dall'utente.
+
+![Lelantus flow](https://pbs.twimg.com/media/Fsk3HrjXgAMgqmX.png)
+
+---
+
+## One-of-Many Proofs
+
+Lelantus utilizza le **One-of-Many Proofs** per estrarre i valori di input necessari a dimostrare il bilancio senza rivelare l'origine degli input - e senza richiedere un trusted setup.
+
+Queste prove sono usate anche in **Triptych** (menzionato nel nostro thread su CryptoNote).
+
+![One-of-Many Proofs](https://pbs.twimg.com/media/Fsk3Z0nWIAAPD4k.jpg)
+
+---
+
+## Privacy a livello di rete: Dandelion++
+
+I nodi Firo usano lo stesso Network Magic del Magicbean di Zcash.
+
+Come Monero, Firo ha implementato **Dandelion++** per aggiungere privacy offuscando l'indirizzo IP di chi trasmette la transazione.
+
+**Fasi di Dandelion++:**
+- **Fase stem** - La transazione viene inoltrata a un singolo nodo casuale invece che a tutti i peer
+- **Fase fluff** - Avviata casualmente, poi passa alla normale modalità gossip
+
+Questo rende molto più difficile risalire all'origine di una transazione tramite l'analisi della rete.
+
+![Dandelion++ explanation](https://pbs.twimg.com/media/Fsk4A8VWcAU84MR.png)
+
+---
+
+## Futuro: Lelantus-Spark
+
+**Lelantus-Spark** (previsto per la seconda metà del 2023) introduce due livelli di visibilità opt-in usando una **derivazione in stile ZIP-32** e indirizzi diversificati.
+
+Aggiungerà inoltre il supporto per:
+- Multisig
+- Asset confidenziali definiti dall'utente
+
+Queste funzionalità sono parallele agli Shielded Assets di Zcash.
+
+![Lelantus-Spark announcement](https://pbs.twimg.com/media/Fsk4jXeXsAACQ3h.jpg)
+
+---
+
+**Thread originale di ZecHub (@ZecHub)**  
+https://x.com/ZecHub/status/1641902859800150017
+
+---
+
+*Questa pagina è stata compilata a partire dal thread originale Zero to Zero Knowledge per il wiki di ZecHub.*

--- a/translations/it/site/Zcash_Social_Media/Mnemonic_Seed_Phrases.md
+++ b/translations/it/site/Zcash_Social_Media/Mnemonic_Seed_Phrases.md
@@ -1,0 +1,105 @@
+# Zero to Zero Knowledge: frasi seed mnemoniche
+
+**Serie:** Zero to Zero Knowledge
+
+Le frasi seed mnemoniche sono alla base di uno degli aspetti più importanti delle criptovalute - la **auto-custodia**.  
+Oggi impariamo come una frase seed viene generata e usata nei wallet.
+
+---
+
+## Cosa sono le frasi seed mnemoniche?
+
+Le frasi di recupero sono definite dalla specifica **BIP-39**, il tipo di frase di recupero più comune usato oggi.
+
+La creazione delle frasi di recupero inizia generando **casualità**. Più entropia significa maggiore sicurezza. **128 bit** di entropia sono considerati sufficienti per la maggior parte degli utenti.
+
+![Seed phrase concept](https://pbs.twimg.com/media/FooM3qWWACgrwzn.jpg)
+
+A seconda della lunghezza dell'entropia iniziale, la frase di recupero sarà lunga da **12 a 24 parole**.
+
+---
+
+## Passo dopo passo: come viene generata una frase seed di 12 parole
+
+### 1. Genera l'entropia
+Iniziamo generando **128 bit** di entropia.
+
+### 2. Aggiungi il checksum
+Facciamo l'hash dell'entropia usando **SHA256**. I primi bit di questo hash diventano il checksum.  
+Questo ci dà un'impronta unica per la nostra entropia.
+
+![Entropy + Checksum diagram](https://pbs.twimg.com/media/FooNoOEXgAAu-g6.png)
+
+### 3. Suddividi in blocchi da 11 bit
+I 132 bit totali (128 di entropia + 4 di checksum) vengono separati in blocchi di 11 bit.
+
+### 4. Mappa sulla wordlist
+Ogni sequenza di 11 bit viene convertita in un numero decimale (0-2047).  
+Le wordlist BIP-39 contengono esattamente **2048 parole** (inglese, spagnolo, cinese, ecc.).
+
+Questi numeri vengono usati per trovare la parola corrispondente nella wordlist.
+
+![Word mapping example](https://pbs.twimg.com/media/FooN9rfXEBoQuU2.png)
+
+**Risultato:** ora abbiamo una frase di recupero di 12 parole, sicura e leggibile dall'uomo!
+
+---
+
+## Dalla frase di recupero -> al seed -> agli indirizzi di pagamento
+
+Usando la frase di recupero, un wallet può generare chiavi per creare indirizzi di pagamento e diversi account del wallet.
+
+Le chiavi generate sono **deterministiche** - lo stesso input produce sempre lo stesso output.
+
+### Generazione del seed
+Il seed del wallet viene derivato dalla frase mnemonica usando una **funzione di derivazione delle chiavi (KDF)**:
+
+- In **Bitcoin**: PBKDF2  
+- In **Zcash**: Blake2b-256/512
+
+Questo produce un seed di **64 byte (512 bit)**.
+
+![Seed to master keys](https://pbs.twimg.com/media/FooOuumXEAgcBm1.jpg)
+
+### Chiavi master
+Il seed viene suddiviso in due sequenze da 32 byte:
+- **Master Spending Key**
+- **Master Chain Code**
+
+Queste vengono usate nei **wallet deterministici gerarchici (HD)** per la derivazione delle chiavi figlie.
+
+---
+
+## Funzionalità specifiche di Zcash (ZIP-32)
+
+In Zcash, l'**autorità di visualizzazione** o l'**autorità di spesa** possono essere delegate in modo indipendente per i sotto-alberi senza compromettere il seed master.
+
+**ZIP-32** definisce lo standard di generazione deterministica gerarchica delle chiavi adattato alle funzionalità di privacy di Zcash.
+
+Da una **Expanded Spending Key** deriviamo:
+- Full Viewing Key
+- Incoming Viewing Key
+- Un insieme di indirizzi di pagamento
+
+Diversi meccanismi di derivazione producono indirizzi esterni adatti a essere distribuiti ai mittenti attraverso gli shielded pool (Sapling e Orchard).
+
+![Zcash key derivation hierarchy](https://pbs.twimg.com/media/FooPKd4XEBUQhJ6.jpg)
+
+Zcash supporta anche gli **indirizzi interni** per operazioni del wallet come l'Auto-Shielding.
+
+---
+
+## Risorse
+
+- [ZIP-32: Shielded Hierarchical Deterministic Wallets](https://zips.z.cash/zip-0032)  
+- [Zcash Protocol Specification (NU5)](https://zips.z.cash/protocol/protocol.pdf)  
+- [Panoramica sui wallet shielded-by-default](https://zechub.wiki)
+
+---
+
+**Thread originale di ZecHub (@ZecHub)**  
+https://x.com/ZecHub/status/1624125037945946145
+
+---
+
+*Questa pagina è stata compilata a partire dal thread originale Zero to Zero Knowledge per il wiki di ZecHub.*

--- a/translations/it/site/Zcash_Social_Media/Podcasts/Podcasts.md
+++ b/translations/it/site/Zcash_Social_Media/Podcasts/Podcasts.md
@@ -1,0 +1,392 @@
+# Riassunti degli Episodi del ZK Podcast
+
+## Episodi
+
+### Episodio 334 – Aggiornamento sulla Ricerca ZK con Joe Bonneau
+- **Data:** 31 luglio 2024
+- **Link:** [https://zeroknowledge.fm/334-2](https://zeroknowledge.fm/334-2)
+- **Riassunto:** Anna e Guille fanno il punto con Joe Bonneau, professore associato alla NYU e Research Partner presso a16z crypto research. Discutono del suo recente lavoro sulle Naysayer proofs, le Zero-Knowledge Middleboxes, le Sealed-Bid Auctions e altri progetti di ricerca legati alla ZK.
+- **Ospiti:**
+  - Joe Bonneau ([/josephbonneau](https://eprint.iacr.org/2023/1472.pdf))
+- **Conduttori:**
+  - Anna ([AnnaRRose](https://x.com/AnnaRRose))
+  - Guille ([GuilleAngeris](https://x.com/guilleangeris))
+
+### Episodio 333 – Verifiable SQL, Reckle Trees e ZK Coprocessing con Lagrange Labs
+- **Data:** 24 luglio 2024
+- **Link:** [https://zeroknowledge.fm/333-2](https://zeroknowledge.fm/333-2)
+- **Riassunto:** Anna chiacchiera con Ismael Hishon-Rezaizadeh, Fondatore e CEO di Lagrange Labs, e Charalampos (Babis) Papamanthou, Head of Research presso Lagrange. Rivisitano i coprocessori basati su zk, Verifiable SQL, Reckle Trees e discutono del loro nuovo marketplace di prover.
+- **Ospiti:**
+  - Ismael Hishon-Rezaizadeh ([ismael_h_r](https://x.com/ismael_h_r))
+  - Charalampos (Babis) Papamanthou ([chbpap](https://x.com/chbpap))
+- **Conduttore:**
+  - Anna ([AnnaRRose](https://x.com/AnnaRRose))
+
+### Episodio 332 – Aggiornamento da Bruxelles con Hart di Across
+- **Data:** 18 luglio 2024
+- **Link:** [https://zeroknowledge.fm/332-2](https://zeroknowledge.fm/332-2)
+- **Riassunto:** Anna e Tarun si siedono con Hart Lambur durante la settimana di EthCC a Bruxelles per discutere del suo progetto Across, una soluzione di interoperabilità cross-chain e progetto gemello di Uma. Esplorano la costruzione di Across, i compromessi e la confrontano con altre soluzioni di interoperabilità.
+- **Ospiti:**
+  - Hart Lambur ([hal2001](https://x.com/hal2001))
+- **Conduttori:**
+  - Anna ([AnnaRRose](https://x.com/AnnaRRose))
+  - Tarun ([tarunchitra](https://x.com/tarunchitra))
+
+### Episodio 331 – Farcaster con Varun Srinivasan
+- **Data:** 10 luglio 2024
+- **Link:** [https://zeroknowledge.fm/331-2](https://zeroknowledge.fm/331-2)
+- **Riassunto:** Anna e Tarun incontrano Varun Srinivasan, co-fondatore di Farcaster. Discutono del progetto Farcaster, della sua nascita e di ciò che lo distingue dalle reti di social media esistenti, esplorandone lo spazio di design e le potenziali applicazioni.
+- **Ospiti:**
+  - Varun Srinivasan ([varunsrin](https://x.com/varunsrin))
+- **Conduttori:**
+  - Anna ([AnnaRRose](https://x.com/AnnaRRose))
+  - Tarun ([tarunchitra](https://x.com/tarunchitra))
+
+### Episodio 330 – Framework per la Privacy Programmabile con Ying Tong e Bryan Gillespie
+- **Data:** 3 luglio 2024
+- **Link:** [https://zeroknowledge.fm/330-2](https://zeroknowledge.fm/330-2)
+- **Riassunto:** Anna e Guille chiacchierano con Ying Tong Lai di Geometry Research e Bryan Gillespie di Inversed Tech del loro lavoro su ‘SoK: Programmable Privacy in Distributed Systems’, esplorando nuove classificazioni e framework.
+- **Ospiti:**
+  - Ying Tong Lai ([therealyingtong](https://x.com/therealyingtong))
+  - Bryan Gillespie ([bryan_gillespie](https://x.com/bryan_gillespie))
+- **Conduttori:**
+  - Anna ([AnnaRRose](https://x.com/AnnaRRose))
+  - Guille ([GuilleAngeris](https://x.com/GuilleAngeris))
+
+### Episodio 329 – Costruire Prove Crittografiche con Funzioni Hash con Alessandro Chiesa & Eylon Yogev
+- **Data:** 26 giugno 2024
+- **Link:** [https://zeroknowledge.fm/329-2](https://zeroknowledge.fm/329-2)
+- **Riassunto:** Anna e Nico chiacchierano con Alessandro Chiesa, Associate Professor all'EPFL, e Eylon Yogev, Professor alla Bar-Ilan University, della loro pubblicazione sulla costruzione di prove crittografiche a partire da funzioni hash.
+- **Ospiti:**
+  - Alessandro Chiesa ([profile](https://ic-people.epfl.ch/~achiesa/))
+  - Eylon Yogev ([profile](https://eylonyogev.com/))
+- **Conduttori:**
+  - Anna ([AnnaRRose](https://x.com/AnnaRRose))
+  - Nico ([nico_mnbl](https://x.com/nico_mnbl))
+
+## ZL;DR Show
+ZL;DR è uno show che mette in luce tutto ciò che riguarda Zcash in formato video. Gli episodi coprono diversi argomenti su Zcash, la comunità, gli aggiornamenti dell'ecosistema e le notizie.
+
+- **Cambio di Nome:** Il nome è stato cambiato da ZecDaily a ZL;DR.
+
+## Playlist del Podcast di Zechub
+
+### L'Importanza della Privacy, le CBDC e l'Operation Chokepoint 2.0 | Kurt Opsahl – 11
+- **Data:** 29 marzo 2024
+- **Link:** [https://youtu.be/n0IxTUKLgd4?si=V3FCTYDcTYnzmnGN](https://youtu.be/n0IxTUKLgd4?si=V3FCTYDcTYnzmnGN)
+- **Riassunto:**
+  - **Timestamp:**
+    - 00:00 – Introduzione & Background
+    - 04:09 – Web 1.0, Web 2.0 e Web3
+    - 09:00 – Perché la cifratura è utile
+    - 13:40 – Operation Chokepoint 2.0
+    - 19:18 – La lezione della storia sulla raccolta dati
+    - 23:25 – Micro Targeting / Psicografica
+    - 27:44 – Zero Knowledge & Zcash
+    - 32:10 – Le CBDC
+    - 37:00 – Forze dell'ordine & Tecnologie per il Miglioramento della Privacy
+    - 39:30 – La politica non può agire da sola
+    - 44:00 – Il Manifesto Cypherpunk & Filecoin
+    - 48:20 – Outro
+
+### Privacy per il Bene Pubblico con Amber Baldet
+- **Data:** 7 febbraio 2023
+- **Link:** [https://youtu.be/ILdMTGtVOD4?si=PUgZhnnaeryNIIMB](https://youtu.be/ILdMTGtVOD4?si=PUgZhnnaeryNIIMB)
+- **Riassunto:**
+  - **Timestamp:**
+    - 0:00​ – Intro
+    - 4:40​ – Decentralizzazione e creazione di una società opt-in
+    - 15:20​ – L'opportunità delle cripto di abilitare libertà economica e agency
+    - 26:30​ – Il modello di finanziamento di Zcash, la cattura normativa e la diversificazione dell'ecosistema
+    - 33:39​ – Colmare i divari economici e sociali attraverso le tecnologie decentralizzate
+    - 42:50​ – Il voto basato sulle monete come meccanismo per la governance on-chain
+    - 50:25​ – Sviluppo open-source e capitalizzazione nei mercati cripto
+    - 59:30​ – Il futuro di Zcash e outro
+
+### Lo ZFAV Club con Ryan Taylor (alias AdjyLeak)
+- **Data:** 25 gennaio 2023
+- **Link:** [https://youtu.be/BYnhTNkQ-3M?si=Uck8wegKCae2bSuX](https://youtu.be/BYnhTNkQ-3M?si=Uck8wegKCae2bSuX)
+- **Riassunto:**
+- - **Link:** [https://youtu.be/18-xowScNpw?si=3qRPR59wcuPlYQaw](https://youtu.be/18-xowScNpw?si=3qRPR59wcuPlYQaw)
+- **Riassunto:** Taylor Hornby è il Zcash Ecosystem Security Lead.
+  - **Timestamp:**
+    - 0:00​ – Intro
+    - 6:11​ – La vulnerabilità InternalH Collision
+    - 12:05​ – Il bug preferito che Taylor abbia mai trovato
+    - 15:50​ – Lasciare ECC per un grant di sicurezza indipendente
+    - 22:30​ – Il processo di un audit di sicurezza, l'esempio di Ywallet
+    - 31:25​ – I compromessi di sicurezza di lightwalletd
+    - 45:10​ – I compromessi di sicurezza e usabilità di Zcashd
+    - 52:06​ – I compromessi di sicurezza dei fornitori di pagamenti di terze parti
+    - 1:00:20​ – Riepilogo della sicurezza operativa di Zcash
+    - 1:04:40​ – Quali sono i più grandi malintesi su sicurezza e privacy di Zcash
+
+### Zcash FUD con Josh Swihart
+- **Data:** 12 gennaio 2023
+- **Link:** [https://youtu.be/a6TQt6rmwXU?si=ONa7aR50GR6b6pKO](https://youtu.be/a6TQt6rmwXU?si=ONa7aR50GR6b6pKO)
+- **Riassunto:** Josh Swihart è il Senior Vice President of Growth, Product Strategy and Regulatory Relations presso la Electric Coin Company.
+  - **Timestamp:**
+    - 0:00​ – Intro
+    - 6:00​ – Il Dev Fund
+    - 15:22​ – Relazioni normative e politiche
+    - 28:24​ – La privacy di Zcash vs. altri metodi
+    - 42:38​ – L'auditabilità dell'offerta di Zcash
+    - 48:06​ – La privacy è una funzionalità che si può aggiungere in seguito
+    - 53:58​ – L'attacco di sandblasting alla blockchain di Zcash
+    - 58:29​ – L'affermazione che Zcash non sia cypherpunk
+    - 1:04:17​ – Domande rimanenti e outro
+
+### L'ultima Proposta di Grant di Zcash Brasil con Samara
+- **Data:** 28 dicembre 2022
+- **Link:** [https://youtu.be/F5_DXXFSEsQ?si=gUcwUzynrfNIlgZq](https://youtu.be/F5_DXXFSEsQ?si=gUcwUzynrfNIlgZq)
+- **Riassunto:** Samara è una professionista delle PR e membro del team di Zcash Brasil.
+  - **Timestamp:**
+    - 0:00​ – Intro
+    - 2:50​ – Perché c'è una buona opportunità per Zcash in Brasile?
+    - 6:10​ – Riflessioni sull'attuale output di Zcash Brasil vs. l'output potenziale
+    - 8:00​ – Perché i brasiliani hanno bisogno di privacy finanziaria?
+    - 12:19​ – Quali sono i migliori canali per raggiungere la comunità brasiliana?
+    - 17:25​ – Qual è il principale caso d'uso di ZEC in Brasile?
+    - 21:50​ – Che tipo di contenuti ed eventi creerà la comunità brasiliana per guidare l'adozione?
+    - 26:20​ – In quali altri stati vuole espandersi Zcash Brazil?
+    - 28:50​ – Come pensa il team di collaborare con altre comunità Zcash?
+    - 32:05​ – Cosa ispira gli sforzi di design di Zcash Brasil?
+    - 35:30​ – Come possono altre organizzazioni Zcash supportare gli sforzi di Zcash Brasil?
+    - 38:58​ – Outro
+
+### Il nuovo Zcash Podcast con Joel Valenzuela
+- **Data:** 21 dicembre 2022
+- **Link:** [https://youtu.be/TE1ILZankdM?si=KQYhA0tmqyEqfYMP](https://youtu.be/TE1ILZankdM?si=KQYhA0tmqyEqfYMP)
+- **Riassunto:** Joël Valenzuela è un content creator, scrittore e conduttore del podcast Zcash sulla Digital Cash Network.
+  - **Timestamp:**
+    - 0:00​ – Intro
+    - 7:33​ – Quando è cambiata la narrativa di Bitcoin
+    - 17:04​ – Zcash FUD & Massimalismo Cripto
+    - 29:25​ – Vivere di criptovaluta
+    - 38:30​ – Cosa aspettarsi dal nuovo podcast Zcash
+    - 57:40​ – Imparare Zcash e rispondere ai malintesi che lo circondano
+    - 1:09:30​ – Potenziali ospiti per il podcast Zcash di DCN
+    - 1:18:50​ – Dove guardare e seguire il nuovo podcast Zcash di DCN
+    - 1:21:52​ – Outro
+
+### Le Narrative di Zcash con David di Zcash Media
+- **Data:** 20 settembre 2022
+- **Link:** [https://youtu.be/gl5qxA4Q6yk?si=SJ63J0ApDXixXqNV](https://youtu.be/gl5qxA4Q6yk?si=SJ63J0ApDXixXqNV)
+- **Riassunto:** David è un Zcasher di lunga data e scrittore / produttore presso Zcash Media.
+  - **Timestamp:**
+    - 0:00​ – Intro, perché Zcash & la genesi di Zcash Media
+    - 12:00​ – La necessità di molteplici canali mediatici
+    - 17:50​ – Allinearsi alla missione originale di Bitcoin
+    - 27:00​ – Educare su Zcash nel libero mercato
+    - 35:45​ – Imparare da Bitcoin
+    - 37:20​ – Perché la qualità dell'educazione conta
+    - 48:20​ – La differenza tra Zcash media e ZecHub
+    - 55:45​ – Cosa possiamo imparare dagli sforzi di marketing della comunità Bitcoin
+    - 1:06:35​ – Comunicare Zcash al mondo
+    - 1:14:30​ – Incontrare i nomi più importanti delle cripto
+    - 1:28:55​ – Ed Snowden
+    - 1:36:55​ – Uno sguardo retrospettivo sui contenuti precedenti di Zcash Media
+    - 1:43:00​ – Il pubblico di riferimento di Zcash
+    - 1:51:06​ – Opting out e Zcash come bene comune
+    - 1:57:20​ – Il futuro di Zcash
+
+### DeFi e Privacy Con Railgun
+- **Data:** 29 agosto 2022
+- **Link:** [https://youtu.be/jLd7J5BY_aM?si=rDKvg61D9jQLZmrC](https://youtu.be/jLd7J5BY_aM?si=rDKvg61D9jQLZmrC)
+- **Riassunto:** Railgun è un sistema di smart contract che abilita invii, scambi & DeFi privati, su ETH, BSC & Polygon.
+  - **Timestamp:**
+    - 0:00​ – Intro
+    - 5:30​ – Cos'è Railgun
+    - 8:10​ – Cos'è la finanza decentralizzata (DeFi)
+    - 17:30​ – Svantaggi della DeFi
+    - 24:00​ – Pseudonimi e privacy
+    - 32:55​ – La storia delle origini di Railgun
+    - 38:08​ – Railgun vs. altre soluzioni
+    - 45:00​ – Transazione Railgun su un block explorer
+    - 49:52​ – Relayer
+    - 58:51​ – Tokenomics di Rail
+    - 1:04:00​ – La Comunità di Railgun
+    - 1:07:04​ – La privacy cripto tra 5 anni
+
+### NFT Musicali, Privacy e Libertà Economica con Xcelencia
+- **Data:** 22 agosto 2022
+- **Link:** [https://youtu.be/nrtoRgb7g28?si=jVOri_8TfykI4ufq](https://youtu.be/nrtoRgb7g28?si=jVOri_8TfykI4ufq)
+- **Riassunto:** Xcelencia è un'artista reggaeton nell'ecosistema musicale Web3.
+  - **Timestamp:**
+    - 0:00​ – Intro
+    - 0:47​ – Opportunità per gli artisti musicali nel Web3
+    - 3:30​ – Definire la proprietà degli NFT musicali
+    - 5:20​ – Differenze tra le edizioni di NFT musicali
+    - 7:50​ – Panoramica dell'industria dello streaming
+    - 13:48​ – Collezionisti vs. ascoltatori
+    - 18:10​ – Mercati musicali globali
+    - 20:30​ – Gli NFT musicali livellano il campo di gioco
+    - 23:45​ – Artisti LATAM di punta nel Web3
+    - 28:05​ – Come Xcelencia si è avvicinata alle cripto
+    - 30:15​ – Riflettere sulla libertà economica
+    - 34:05​ – Privacy e Zcash
+    - 43:50​ – Educazione della comunità nel Web3
+    - 46:40​ – Presentare Zcash ad altre comunità
+    - 50:27​ – Consigli per i nuovi utenti
+
+### Cripto
+
+  - **Timestamp:**
+    - 0:00​ – Intro e i primi giorni di Bitcoin
+    - 10:58​ – La genesi dello ZFAV Club
+    - 17:38​ – Rischi di mandare in onda pubblicità e avere sponsor
+    - 23:42​ – L'obiettivo finale dello ZFAV Club
+    - 29:35​ – Come lo ZFAV Club abilita i contributori non tecnici
+    - 34:50​ – La decentralizzazione risolve il problema di PR di Zcash
+    - 42:10​ – I disaccordi come funzionalità, non come difetto
+    - 49:32​ – I protocolli cripto hanno bisogno di molteplici identità
+    - 54:35​ – Perché le persone dovrebbero lasciare un exchange
+    - 1:01:40​ – Come lo ZFAV Club abilita i contributori globali
+    - 1:08:00​ – Outro
+
+### Zcash # Riassunti del Podcast Zcash
+
+## Sicurezza di Zcash e Light-walletd con Taylor Hornby
+- **Data:** 18 gennaio 2023
+- **Link:** [Guarda su YouTube](https://youtu.be/18-xowScNpw?si=3qRPR59wcuPlYQaw)
+- **Riassunto:** Taylor Hornby è il Zcash Ecosystem Security Lead.
+  - **Timestamp:**
+    - 0:00 – Intro
+    - 6:11 – La vulnerabilità InternalH Collision
+    - 12:05 – Il bug preferito che Taylor abbia mai trovato
+    - 15:50 – Lasciare ECC per un grant di sicurezza indipendente
+    - 22:30 – Il processo di un audit di sicurezza, l'esempio di Ywallet
+    - 31:25 – I compromessi di sicurezza di lightwalletd
+    - 45:10 – I compromessi di sicurezza e usabilità di Zcashd
+    - 52:06 – I compromessi di sicurezza dei fornitori di pagamenti di terze parti
+    - 1:00:20 – Riepilogo della sicurezza operativa di Zcash
+    - 1:04:40 – Quali sono i più grandi malintesi su sicurezza e privacy di Zcash
+
+## Zcash FUD con Josh Swihart
+- **Data:** 12 gennaio 2023
+- **Link:** [Guarda su YouTube](https://youtu.be/a6TQt6rmwXU?si=ONa7aR50GR6b6pKO)
+- **Riassunto:** Josh Swihart è il Senior Vice President of Growth, Product Strategy and Regulatory Relations presso la Electric Coin Company.
+  - **Timestamp:**
+    - 0:00 – Intro
+    - 6:00 – Il Dev Fund
+    - 15:22 – Relazioni normative e politiche
+    - 28:24 – La privacy di Zcash vs. altri metodi
+    - 42:38 – L'auditabilità dell'offerta di Zcash
+    - 48:06 – La privacy è una funzionalità che si può aggiungere in seguito
+    - 53:58 – L'attacco di sandblasting alla blockchain di Zcash
+    - 58:29 – L'affermazione che Zcash non sia cypherpunk
+    - 1:04:17 – Domande rimanenti e outro
+
+## L'ultima Proposta di Grant di Zcash Brasil con Samara
+- **Data:** 28 dicembre 2022
+- **Link:** [Guarda su YouTube](https://youtu.be/F5_DXXFSEsQ?si=gUcwUzynrfNIlgZq)
+- **Riassunto:** Samara è una professionista delle PR e membro del team di Zcash Brasil.
+  - **Timestamp:**
+    - 0:00 – Intro
+    - 2:50 – Perché c'è una buona opportunità per Zcash in Brasile?
+    - 6:10 – Riflessioni sull'attuale output di Zcash Brasil vs. l'output potenziale
+    - 8:00 – Perché i brasiliani hanno bisogno di privacy finanziaria?
+    - 12:19 – Quali sono i migliori canali per raggiungere la comunità brasiliana?
+    - 17:25 – Qual è il principale caso d'uso di ZEC in Brasile?
+    - 21:50 – Che tipo di contenuti ed eventi creerà la comunità brasiliana per guidare l'adozione?
+    - 26:20 – In quali altri stati vuole espandersi Zcash Brazil?
+    - 28:50 – Come pensa il team di collaborare con altre comunità Zcash?
+    - 32:05 – Cosa ispira gli sforzi di design di Zcash Brasil?
+    - 35:30 – Come possono altre organizzazioni Zcash supportare gli sforzi di Zcash Brasil?
+    - 38:58 – Outro
+
+## Il nuovo Zcash Podcast con Joel Valenzuela
+- **Data:** 21 dicembre 2022
+- **Link:** [Guarda su YouTube](https://youtu.be/TE1ILZankdM?si=KQYhA0tmqyEqfYMP)
+- **Riassunto:** Joël Valenzuela è un content creator, scrittore e conduttore del podcast Zcash sulla Digital Cash Network.
+  - **Timestamp:**
+    - 0:00 – Intro
+    - 7:33 – Quando è cambiata la narrativa di Bitcoin
+    - 17:04 – Zcash FUD & Massimalismo Cripto
+    - 29:25 – Vivere di criptovaluta
+    - 38:30 – Cosa aspettarsi dal nuovo podcast Zcash
+    - 57:40 – Imparare Zcash e rispondere ai malintesi che lo circondano
+    - 1:09:30 – Potenziali ospiti per il podcast Zcash di DCN
+    - 1:18:50 – Dove guardare e seguire il nuovo podcast Zcash di DCN
+    - 1:21:52 – Outro
+
+## Le Narrative di Zcash con David di Zcash Media
+- **Data:** 20 settembre 2022
+- **Link:** [Guarda su YouTube](https://youtu.be/gl5qxA4Q6yk?si=SJ63J0ApDXixXqNV)
+- **Riassunto:** David è un Zcasher di lunga data e scrittore / produttore presso Zcash Media.
+  - **Timestamp:**
+    - 0:00 – Intro, perché Zcash & la genesi di Zcash Media
+    - 12:00 – La necessità di molteplici canali mediatici
+    - 17:50 – Allinearsi alla missione originale di Bitcoin
+    - 27:00 – Educare su Zcash nel libero mercato
+    - 35:45 – Imparare da Bitcoin
+    - 37:20 – Perché la qualità dell'educazione conta
+    - 48:20 – La differenza tra Zcash media e ZecHub
+    - 55:45 – Cosa possiamo imparare dagli sforzi di marketing della comunità Bitcoin
+    - 1:06:35 – Comunicare Zcash al mondo
+    - 1:14:30 – Incontrare i nomi più importanti delle cripto
+    - 1:28:55 – Ed Snowden
+    - 1:36:55 – Uno sguardo retrospettivo sui contenuti precedenti di Zcash Media
+    - 1:43:00 – Il pubblico di riferimento di Zcash
+    - 1:51:06 – Opting out e Zcash come bene comune
+    - 1:57:20 – Il futuro di Zcash
+
+## DeFi e Privacy Con Railgun
+- **Data:** 29 agosto 2022
+- **Link:** [Guarda su YouTube](https://youtu.be/jLd7J5BY_aM?si=rDKvg61D9jQLZmrC)
+- **Riassunto:** Railgun è un sistema di smart contract che abilita invii, scambi & DeFi privati, su ETH, BSC & Polygon.
+  - **Timestamp:**
+    - 0:00 – Intro
+    - 5:30 – Cos'è Railgun
+    - 8:10 – Cos'è la finanza decentralizzata (DeFi)
+    - 17:30 – Svantaggi della DeFi
+    - 24:00 – Pseudonimi e privacy
+    - 32:55 – La storia delle origini di Railgun
+    - 38:08 – Railgun vs. altre soluzioni
+    - 45:00 – Transazione Railgun su un block explorer
+    - 49:52 – Relayer
+    - 58:51 – Tokenomics di Rail
+    - 1:04:00 – La Comunità di Railgun
+    - 1:07:04 – La privacy cripto tra 5 anni
+
+## NFT Musicali, Privacy e Libertà Economica con xcelencia
+- **Data:** 22 agosto 2022
+- **Link:** [Guarda su YouTube](https://youtu.be/nrtoRgb7g28?si=jVOri_8TfykI4ufq)
+- **Riassunto:** Xcelencia è un'artista reggaeton nell'ecosistema musicale Web3.
+  - **Timestamp:**
+    - 0:00 – Intro
+    - 0:47 – Opportunità per gli artisti musicali nel Web3
+    - 3:30 – Definire la proprietà degli NFT musicali
+    - 5:20 – Differenze tra le edizioni di NFT musicali
+    - 7:50 – Panoramica dell'industria dello streaming
+    - 13:48 – Collezionisti vs. ascoltatori
+    - 18:10 – Mercati musicali globali
+    - 20:30 – Gli NFT musicali livellano il campo di gioco
+    - 23:45 – Artisti LATAM di punta nel Web3
+    - 28:05 – Come Xcelencia si è avvicinata alle cripto
+    - 30:15 – Riflettere sulla libertà economica
+    - 34:05 – Privacy e Zcash
+    - 43:50 – Educazione della comunità nel Web3
+    - 46:40 – Presentare Zcash ad altre comunità
+    - 50:27 – Consigli per i nuovi utenti
+
+## Regolamentazione delle Cripto e Privacy Finanziaria Con J. W. Verret
+- **Data:** 10 agosto 2022
+- **Link:** [Guarda su YouTube](https://youtu.be/20oCI7XAR08?si=3T6awsAesidmjJIS)
+- **Riassunto:** J.W. Verret è un professore alla George Mason University. È un esperto di diritto societario, dei titoli e bancario. È anche un consulente legale e di contabilità forense, e il fondatore del Crypto Freedom Lab.
+  - **Timestamp:**
+    - 0:00 – Incontrare uno dei tuoi idoli
+    - 0:40 – Il primo podcast Zcash
+    - 1:45 – L'Op-Ed di J.W. sul WSJ
+    - 5:35 – Il momento migliore per scrivere
+    - 8:35 – La privacy cripto & il nuovo libro di J.W.
+    - 18:00 – La legalità dei mixer
+    - 22:14 – La guerra al contante
+    - 26:00 – La volatilità di ZEC e l'inflazione fiat
+    - 29:25 – Il mining di Bitcoin e l'energia
+    - 31:50 – Proof-of-Stake e leggi sui titoli
+    - 43:10 – KYC & privacy
+    - 44:50 – Bitcoiner, Zcash e Monero
+    - 54:10 – Consigli sulla privacy cripto per i nuovi arrivati
+    - 56:05 – Non usare i pass-through
+    - 1:01:05 – Crypto Freedom Lab

--- a/translations/it/site/Zcash_Social_Media/Podcasts/Shielded_Transaction_Podcast.md
+++ b/translations/it/site/Zcash_Social_Media/Podcasts/Shielded_Transaction_Podcast.md
@@ -1,0 +1,14 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Social_Media/Podcasts/Shielded_Transaction_Podcast.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Shielded Transactions Podcast del Foresight Institute
+
+Il Foresight Institute è un'organizzazione di ricerca e no-profit che supporta lo sviluppo benefico di tecnologie ad alto impatto. Dalla nostra fondazione nel 1987 su una visione di guida delle tecnologie potenti, abbiamo continuato a evolverci in un'organizzazione dai molti rami che si concentra su diversi campi della scienza e della tecnologia troppo ambiziosi perché le istituzioni tradizionali li supportino. 
+
+- [Shielded Transactions #1 | Who Will Own Your Privacy & Identity In the Future? (with Andrew Miller)](https://www.youtube.com/watch?v=UVlPHlm1I3o&list=PLH78wfbGI1x0QS-1GIjARHRWjVBKF-ofB&index=37)
+- [Shielded Transactions #2 | Bitcoin’s Privacy Problem (with Zooko Wilcox)](https://www.youtube.com/watch?v=WXXVoK92zN8)
+- [Shielded Transactions #3 | Who Should Control Your Privacy? (with Whyrusleeping)](https://www.youtube.com/watch?v=BgLXB_L3STQ)
+- [Shielded Transactions #4 | Marta Belcher, Filecoin Foundation | Privacy & Law in the Age of AI](https://www.youtube.com/watch?v=fzsKiQKvLWU)
+- [Shielded Transactions #5 | Avichal Garg, Electric Capital | What does the future hold for shielded transactions?](https://www.youtube.com/watch?v=TZPHhgPIcYw)
+- [Shielded Transactions #6 | Zaki Manian, Iqlusion](https://www.youtube.com/watch?v=7UI94ybEkpw)

--- a/translations/it/site/Zcash_Social_Media/Podcasts/The_ZK_Podcast.md
+++ b/translations/it/site/Zcash_Social_Media/Podcasts/The_ZK_Podcast.md
@@ -1,0 +1,10 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Social_Media/Podcasts/The_ZK_Podcast.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zero Knowledge Podcast
+![Screenshot_2023-01-22_22-21-35](https://user-images.githubusercontent.com/81990132/213977155-36efc11d-a1a5-46c3-b382-23993a8da4b4.png)
+
+Se vuoi imparare le prove a conoscenza zero, la crittografia avanzata e la zktech per la privacy, sei nel posto giusto! Pubblichiamo i nostri episodi [qui](https://zeroknowledge.fm/) così come eventi, study club, sessioni zk whiteboard, materiale educativo e altro. Includiamo anche contenuti dei nostri partner ZK Hack e ZKValidator!
+
+[ZK Playlist](https://www.youtube.com/playlist?list=PLj80z0cJm8QEUVSlofe1Zd7wyaoZrixFM)

--- a/translations/it/site/Zcash_Social_Media/Podcasts/The_Zcash_Podcast.md
+++ b/translations/it/site/Zcash_Social_Media/Podcasts/The_Zcash_Podcast.md
@@ -1,0 +1,29 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Social_Media/Podcasts/The_Zcash_Podcast.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# The Zcash Podcast sulla Digital Cash Network
+![Screenshot_2023-01-22_21-50-14](https://user-images.githubusercontent.com/81990132/213973803-b0629c92-08d4-459b-99f1-594854a7db3a.png)
+
+The Zcash Podcast ospita contenuti come aggiornamenti, approfondimenti su argomenti specifici, ecc. da far fruire e condividere alla comunità Zcash esistente, oltre a dare l'opportunità agli abbonati esistenti del canale Digital Cash Network di familiarizzare più a fondo con Zcash. 
+
+Nello specifico, questo canale si concentra su:
+
+* la prospettiva di vivere senza banche, di criptovaluta, e di decentralizzare tutta la propria vita.
+* la cura di una comunità molto più propensa a interessarsi ai principi e alla tecnologia di Zcash rispetto al pubblico cripto medio.
+
+Inoltre, il formato live crea un senso di connessione con il pubblico, che può partecipare e fare domande in diretta al conduttore e agli ospiti, ideale per raggiungere nuovi fan, pur consentendo di fruire dei contenuti long-form in un secondo momento.
+
+
+[Playlist attuale](https://youtube.com/playlist?list=PLBFOSRGoT80W5EAebpT9zwXu6OTS1mq8w)
+
+
+  * Zcash Podcast 1 con Nathan Wilcox: Zcash's Evolution Past to Present | [YouTube](https://youtu.be/tCrFmK-5Enc) | [Odysee](https://odysee.com/@DigitalCashNetwork:c/Zcash-Podcast-2:a) |
+  * Zcash Podcast 2 con Aditya Bharadwaj: End-User Apps and Zcash Adoption | [YouTube](https://youtu.be/sK13gwtTaCQ) | [Odysee](https://odysee.com/@DigitalCashNetwork:c/Zcash-Podcast-1:8) |
+  * Zcash Podcast 3 con Ian Sagstetter: ZecHub and Zcash's Growing Community Initiatives | [YouTube](https://www.youtube.com/watch?v=0tIK6vBM3-s) | [Odysee](https://odysee.com/@DigitalCashNetwork:c/Zcash-Podcast-3:a) |
+  * Zcash Podcast 4 con Seth For Privacy: An Outside Perspective on Zcash and Privacy | [YouTube](https://www.youtube.com/watch?v=C8ItmDFjczQ&list=PLBFOSRGoT80W5EAebpT9zwXu6OTS1mq8w&index=4) | [Odysee](https://odysee.com/@DigitalCashNetwork:c/Zcash-Podcast-4:3) |
+
+  * Zcash Podcast 5 con Naomi Brockwell: How to Live a Modern Privacy-Conscious Lifestyle | [YouTube](https://www.youtube.com/watch?v=GpZAY5O2nJQ&list=PLBFOSRGoT80W5EAebpT9zwXu6OTS1mq8w&index=6) | [Odysee](https://odysee.com/@DigitalCashNetwork:c?view=content) |
+  * Zcash Podcast 6 con Zooko Wilcox: Governance and Zcash's Path Ahead | [YouTube](https://www.youtube.com/watch?v=VZeM7bvWWPg&list=PLBFOSRGoT80W5EAebpT9zwXu6OTS1mq8w&index=6&pp=iAQB) | [Odysee](https://t.co/MDW7FoXgxm)|
+  * Zcash Podcast 7 con Jake di ZecSpends: Using Zcash As Digital Cash Today | [YouTube](https://www.youtube.com/live/yZ1Y1qMu3UE) | [Odysee](https://odysee.com/@DigitalCashNetwork:c/Zcash-Podcast-7:0)|

--- a/translations/it/site/Zcash_Social_Media/Podcasts/The_z2z_Podcast.md
+++ b/translations/it/site/Zcash_Social_Media/Podcasts/The_z2z_Podcast.md
@@ -1,0 +1,44 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Social_Media/Podcasts/The_z2z_Podcast.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Il podcast Z2Z
+
+Il podcast Z2Z ospita conversazioni in formato esteso tra Ian Sagstetter (di Electric Coin Company) e altri membri della comunità Zcash.
+
+Il podcast tratta una varietà di argomenti diversi, ma si concentra principalmente su Zcash e sull'esperienza dei suoi utenti.
+
+Resta aggiornato sui prossimi episodi:
+
+[Playlist YouTube di z2z](https://www.youtube.com/playlist?list=PL6_epn0lASLHlNCMtUErX8UfaJK6N9K5O)
+
+[Odysee](https://odysee.com/@ZecHub:4)
+
+[Spotify](https://open.spotify.com/show/3teWxE0EQaeohCM268Lpnf)
+
+[Spotify for Podcaster](https://podcasters.spotify.com/pod/show/zec-hub/episodes/Zcash-narratives-with-David-from-Zcash-Media-e1o2b36)
+
+
+**Elenco degli episodi**
+
++ Episodio 1 - Regolamentazione delle criptovalute e privacy finanziaria con J.W. Verret [Youtube](https://www.youtube.com/watch?v=20oCI7XAR08) |  [Odysee](https://odysee.com/@ZecHub:4/z2zpodcast1:4) | [Spotify](https://open.spotify.com/episode/4bgn6g1vcVXOqTZ71IN6HE)
+
++ Episodio 2 - NFT musicali, privacy e libertà economica con Xcelencia [Youtube](https://www.youtube.com/watch?v=nrtoRgb7g28) | [Odysee](https://odysee.com/@ZecHub:4/xcelencia:4) | [Spotify](https://open.spotify.com/episode/0a0Fad1H2vJ4JO1edJCKuC)
+
++ Episodio 3 - DeFi e privacy con Railgun [Youtube](https://www.youtube.com/watch?v=jLd7J5BY_aM) | [Odysee](https://odysee.com/@ZecHub:4/railgun:f) | [Spotify](https://open.spotify.com/episode/6dlRiUjEzFOogTrwdVhnhd)
+
++ Episodio 4 - Le narrazioni di Zcash con David di Zcash Media [Youtube](https://www.youtube.com/watch?v=gl5qxA4Q6yk) | [Odysee](https://odysee.com/@ZecHub:4/z2z-podcast_untitled-recording_david-law50vmad_cfr_2022-sep-15-2320pm-utc-riverside_1:e) | [Spotify](https://open.spotify.com/episode/1tgtIAGiOLnb1toGj2cmDQ)
+
++ Episodio 5 - Il nuovo podcast su Zcash con Joël Valenzuela [Youtube](https://www.youtube.com/watch?v=TE1ILZankdM) | [Odysee](https://odysee.com/@ZecHub:4/podcast-with-joe%CC%88l:6) | [Spotify](https://open.spotify.com/episode/1GHzC6aNA8DIxA84yDtQ8W)
+
++ Episodio 6 - L'ultima proposta di grant di Zcash Brasil con Samara [Youtube](https://www.youtube.com/watch?v=F5_DXXFSEsQ) | [Odysee](https://odysee.com/@ZecHub:4/zcash-brazil-podcast:e) | [Spotify](https://open.spotify.com/episode/5t3lz27CrWFvIWN2K3hKSN)
+
++ Episodio 7 - Le FUD su Zcash con Josh Swihart [Youtube](https://www.youtube.com/watch?v=a6TQt6rmwXU) | [Odysee](https://odysee.com/@ZecHub:4/podcast-Josh:9) | [Spotify](https://open.spotify.com/episode/5GGUGjYQWgxwe5y1PGzMLJ)
+
++ Episodio 8 - Sicurezza di Zcash e Lightwalletd con Taylor Hornby [YouTube](https://www.youtube.com/watch?v=18-xowScNpw) | [Odysee](https://odysee.com/@ZecHub:4/Taylor-Podcast:e) | [Spotify](https://open.spotify.com/episode/2KMp034ipnkdLOXmGVTXfu)
+
++ Episodio 9 - Lo ZFAV Club con Ryan Taylor (alias AdjyLeak) [Youtube](https://www.youtube.com/watch?v=BYnhTNkQ-3M) | [Odysee](https://odysee.com/@ZecHub:4/podcast-ryan-taylor:c) | [Spotify](https://open.spotify.com/episode/1TJ6Nycq9nyW2b62ytI3O2)
+
++ Episodio 10 - La privacy per il bene pubblico con Amber Baldet [Youtube](https://www.youtube.com/watch?v=ILdMTGtVOD4) | [Odysee](https://odysee.com/@ZecHub:4/Podcast-Amber-Baldet-(1):6) | [Spotify]()
+
+Se hai qualche consiglio su chi vorresti vedere come prossimo ospite del podcast, non esitare a contattarci! Manda un DM a @zechub su Twitter

--- a/translations/it/site/Zcash_Social_Media/Podcasts/Zcast_Podcast.md
+++ b/translations/it/site/Zcash_Social_Media/Podcasts/Zcast_Podcast.md
@@ -1,0 +1,17 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Social_Media/Podcasts/Zcast_Podcast.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zcast Podcast
+
+[Zcast - Zcash en Español](https://zcashesp.com/zcast/)
+
+
+
+* [🎙️ ¿Cómo y por qué surgió Zcast? 🎙️ - EP 000](https://www.youtube.com/watch?v=I4qMRmY-7Rg)
+* [Zcash y su impacto en la comunidad hispana 🔥 - EP 001](https://www.youtube.com/watch?v=fdAKb-0nJXs)
+* [🎙️ Primer invitado misterioso en Zcast 👨‍💻 - EP 002](https://www.youtube.com/watch?v=eOQUsFLERGI)
+* [🎙️ El perfil de un verdadero Zcasher 💪 - EP 003](https://www.youtube.com/watch?v=uBeE1p3dDJw)
+* [ 😎 #ZookoEnZcast ¡Lo logramos! 💪 - EP 004 ](https://www.youtube.com/watch?v=M5qkbFPeISw)
+* [🎙️ Rumbo a la Zcon4 ✈️ - EP 005](https://www.youtube.com/watch?v=Svi0GyQ2JJc)
+* [🎙️ Cómo aprovechar el ecosistema de Zcash 💪 - EP 006](https://youtu.be/eecILLGwHrQ)

--- a/translations/it/site/Zcash_Social_Media/Podcasts/pgp_for_crypto_podcast.md
+++ b/translations/it/site/Zcash_Social_Media/Podcasts/pgp_for_crypto_podcast.md
@@ -1,0 +1,29 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Social_Media/Podcasts/pgp_for_crypto_podcast.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# PGP* for Crypto Podcast
+![bannerpgp](https://user-images.githubusercontent.com/81990132/221758326-06cea3f5-4c9e-4466-b9ee-73854628a6aa.png)
+
+Benvenuti al "PGP* (Pretty Good Policy) for Crypto Podcast", un'iniziativa di Electric Coin Co.!
+
+Esploriamo l'intersezione tra tecnologia blockchain, politiche pubbliche e tematiche regolatorie globali. Il nostro obiettivo è fornire al nostro pubblico approfondimenti dettagliati e prospettive di esperti sulle questioni chiave che plasmano il futuro della blockchain e delle criptovalute.
+
+Ascolterai interviste con leader del settore, funzionari governativi e accademici in prima linea nel plasmare il contesto delle politiche pubbliche per la tecnologia blockchain. I nostri ospiti condivideranno le loro prospettive uniche sulle sfide e le opportunità che il settore affronta e sull'impatto delle normative e degli approcci politici attuali e proposti sulla crescita e lo sviluppo dell'ecosistema blockchain.
+
+
+* [PGP for Crypto Podcast #1 - Amanda Wick](https://www.youtube.com/watch?v=m7tvz-U1kJU)
+* [PGP for Crypto Podcast #2 - Kristin Smith](https://www.youtube.com/watch?v=fpT-f82Wzc8)
+* [PGP for Crypto Podcast #3 - Luke Hogg](https://www.youtube.com/watch?v=467EFsIx4yg)
+* [PGP for Crypto Podcast #4 - Jennifer Schulp](https://www.youtube.com/watch?v=Cgnye-QYV7Q)
+* [PGP for Crypto Podcast #5 - Cleve Mesidor](https://www.youtube.com/watch?v=sS35aykvf6E)
+* [PGP for Crypto Podcast #6 - Brett Quick](https://www.youtube.com/watch?v=im0sXlnaGmU)
+* [PGP for Crypto Podcast #7 - Miller Whitehouse-Levine](https://www.youtube.com/watch?v=-utatp0lK6s)
+* [PGP for Crypto Podcast #8 - Peter Van Valkenburgh](https://www.youtube.com/watch?v=mMoAph6CBWA)
+* [PGP for Crypto Podcast #9 - Ron Hammond](https://youtu.be/wdODEjbi41o)
+* [PGP for Crypto Podcast #10 - Seth Hertlein and Ian Rogers](https://www.youtube.com/watch?v=1tgNKdiKUHQ)
+* [PGP for Crypto Podcast #11 - Miller Whitehouse-Levine and Amanda Tuminelli](https://youtu.be/VwRJ1Ia3h6A)
+* [PGP for Crypto Podcast #12 - Bart Stephens, Founder and Managing Partner, Blockchain Capital](https://youtu.be/Ce58qD5SXzw)
+* [PGP for Crypto Podcast #13 - Marisa Coppel, Senior Counsel, Blockchain Association](https://youtu.be/etqA9xwuCOg)
+* [PGP for Crypto Podcast #14 - Zcon4 Special Edition featuring Jay Stanley (ACLU), Kurt Opsahl (Filecoin), and Jake Wiener](https://www.youtube.com/watch?v=Ior4r0YtBUE)

--- a/translations/it/site/Zcash_Social_Media/TEEs.md
+++ b/translations/it/site/Zcash_Social_Media/TEEs.md
@@ -1,0 +1,126 @@
+# Zero to Zero Knowledge: Trusted Execution Environments (TEE)
+
+**Serie:** Zero to Zero Knowledge
+
+Zero to Zero Knowledge è tornata con un nuovo argomento!  
+Questa settimana esploriamo i **Trusted Execution Environments (TEE)** - come vengono usati nelle privacy coin e in altre applicazioni blockchain.
+
+![Introduzione ai Trusted Execution Environments](https://pbs.twimg.com/media/Fquj-h2WcAIgSnL.jpg)
+
+---
+
+## TEE e blockchain: proprietà complementari
+
+Le blockchain e i TEE hanno punti di forza molto complementari:
+
+- Le **blockchain** garantiscono disponibilità, persistenza dello stato e consentono la verifica pubblica dell'intero stato - ma hanno una potenza di calcolo limitata.  
+- I **TEE** possono eseguire compiti computazionali intensivi in modo privato - ma mancano di persistenza dello stato nativa.
+
+Insieme possono creare potenti sistemi che preservano la privacy.
+
+---
+
+## Secret Network: privacy basata su TEE
+
+**Secret Network** sfrutta la tecnologia TEE (in particolare Intel SGX) per eseguire calcoli su input, output e stato cifrati.
+
+Ogni nodo validatore esegue chip Intel SGX. I livelli di consenso e di calcolo sono combinati:
+
+- Le transazioni vengono elaborate all'interno di enclave sicure.  
+- I dati vengono decifrati solo **all'interno del TEE**.
+
+Questo è diverso da Zcash, che usa le **prove a conoscenza zero** per la privacy. In Zcash, le transazioni schermate vengono trasmesse e validate pubblicamente senza rivelare alcun dato aggiuntivo alla rete. Gli Zcash Shielded Assets seguono lo stesso principio.
+
+![Diagramma TEE di Secret Network](https://pbs.twimg.com/media/FqulPjNX0AEfjRp.png)
+
+Per una spiegazione dettagliata di come i TEE vengono implementati su Secret Network, leggi questo eccellente articolo di @l_woetzel:  
+https://carter-woetzel.medium.com/secret-network-tees-lets-talk-fud-vulnerability-33ca94b6df38
+
+---
+
+## Come Secret Network protegge le chiavi e lo stato
+
+- Il **seed di cifratura del consenso** della rete è memorizzato all'interno del TEE di ogni validatore.  
+- I contratti usano chiavi di cifratura uniche e non falsificabili.  
+- I secret contract vengono eseguiti sul modulo di calcolo del Cosmos SDK ma supportano input/output e stato cifrati.
+
+---
+
+## Remote Attestation
+
+La **Remote Attestation** è il processo che dimostra che un'enclave è in esecuzione in un ambiente hardware sicuro e genuino.
+
+Consente a una parte remota di verificare:
+- Che sia in esecuzione l'applicazione corretta  
+- Che l'applicazione non sia stata manomessa  
+- Che venga eseguita in modo sicuro all'interno di un'enclave Intel SGX
+
+![Spiegazione della Remote Attestation](https://pbs.twimg.com/media/FqumRjoWwAAeT-M.png)
+
+Le enclave contengono anche chiavi private di firma e di attestazione che non possono essere accedute dall'esterno.
+
+![Protezione delle chiavi dell'enclave](https://pbs.twimg.com/media/Fqumv83XoAQq-MO.png)
+
+---
+
+## Data Sealing
+
+Poiché le enclave sono stateless, i dati devono talvolta essere memorizzati all'esterno, in memoria non attendibile.  
+
+Il **Data Sealing** cifra i dati all'interno dell'enclave usando una chiave derivata dalla CPU. Il blocco cifrato può essere decifrato (unsealed) solo sullo **stesso sistema**.
+
+![Diagramma del Data Sealing](https://pbs.twimg.com/media/FqunBwyWYAA-TR3.jpg)
+
+---
+
+## Oasis Network
+
+Anche **Oasis Network** usa i TEE attraverso il suo ParaTime confidenziale (ad esempio Sapphire e Cipher).
+
+I dati cifrati entrano nel TEE insieme allo smart contract. Vengono decifrati, elaborati e ri-cifrati prima di lasciare l'enclave.
+
+![Flusso TEE di Oasis Network](https://pbs.twimg.com/media/FqunJRDXwAMt4Ob.png)
+
+---
+
+## I TEE nelle reti Proof-of-Stake
+
+Molte blockchain Proof-of-Stake (incluse Secret e Oasis) usano **Tendermint** come framework di consenso.
+
+Per i validatori PoS:
+- Le chiavi devono essere gestite in modo sicuro e mai esposte in chiaro.  
+- I validatori devono rimanere online (si applicano penalità per i tempi di inattività).  
+- Firmare messaggi in conflitto può portare allo slashing.
+
+I **TEE** sono ideali per generare e usare in modo sicuro le chiavi dei validatori.
+
+![Sicurezza di Tendermint e PoS](https://pbs.twimg.com/media/Fqun0HEX0AAooxW.jpg)
+
+---
+
+## Zcash e la ricerca sul Proof-of-Stake
+
+Zcash sta attivamente studiando una migrazione al Proof-of-Stake.
+
+- Leggi la ricerca: https://electriccoin.co/blog/zcash-proof-of-stake-research/  
+- Guarda questo segmento di una Community Call della Zcash Foundation che spiega i diversi design PoS e le loro implicazioni per la privacy:
+  
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/22a-ROcb3AQ"
+    title="PoS designs"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+---
+
+**Thread originale di ZecHub (@ZecHub)**  
+https://x.com/ZecHub/status/1633579659282587651
+
+---
+
+*Questa pagina è stata compilata a partire dal thread originale Zero to Zero Knowledge per la wiki di ZecHub.*

--- a/translations/it/site/Zcash_Social_Media/Zcash_Addresses.md
+++ b/translations/it/site/Zcash_Social_Media/Zcash_Addresses.md
@@ -1,0 +1,120 @@
+# Zero to Zero Knowledge: transazioni trasparenti vs schermate e Unified Address
+
+**Serie:** Zero to Zero Knowledge
+
+Se stai imparando a conoscere Zcash per la prima volta, scoprirai che sono disponibili due tipi di transazione: **Trasparenti** e **Schermate**.  
+
+Oggi le impariamo a conoscere e trattiamo una delle nuove funzionalità dell'ecosistema #Zcash, gli **Unified Address**.
+
+---
+
+## Transazioni trasparenti vs schermate
+
+- Le **transazioni trasparenti** usano gli **indirizzi-t** (codificati in Base58). Tutto è pubblicamente visibile, proprio come in Bitcoin.  
+- Le **transazioni schermate** usano indirizzi codificati per le pool **Sapling** o **Orchard**. Queste nascondono mittente, destinatario e importo usando prove a conoscenza zero.
+
+**Transazione schermata** si riferisce a qualsiasi transazione con indirizzi codificati per le pool Sapling/Orchard.
+
+![Transparent vs Shielded intro](https://pbs.twimg.com/media/FpmW00HWIAIZpQD.jpg)
+
+Gli **Unified Address (UA)** sono progettati per **unificare** le transazioni schermate o trasparenti in un unico indirizzo.
+
+---
+
+## Tipi di indirizzo in Zcash
+
+Ci sono 3 tipi di indirizzo in uso:
+
+1. **(T) Trasparente** – Base58  
+2. **(Z) Sapling** – Bech32  
+3. **(UA) Unified Address** – Bech32m  
+
+Il numero di caratteri (e quindi la dimensione del codice QR) aumenta con ciascun tipo.
+
+![Address types comparison](https://pbs.twimg.com/media/FpmXe5bXsAEFeLY.png)
+
+![QR code size comparison](https://pbs.twimg.com/media/FpmXmDwXoAIWxov.png)
+
+---
+
+## Come funzionano gli Unified Address
+
+Indirizzi e chiavi sono codificati come una sequenza di byte (**Raw Encoding**).  
+Una **Receiver Encoding** include tutte le informazioni necessarie per trasferire un asset usando uno specifico protocollo.
+
+La codifica grezza di un Unified Address è una combinazione di codifiche (typecode, lunghezza, addr) dei receiver:
+
+- UA: `0x03`  
+- Sapling: `0x02`  
+- Trasparente: `0x01`  
+
+**Importante**: deve esserci **almeno un indirizzo di pagamento schermato** in ogni UA. (Gli indirizzi Sprout non sono più supportati dopo l'aggiornamento Canopy.)
+
+![UA encoding structure](https://pbs.twimg.com/media/FpmYW1ZXgAAvALT.png)
+
+Specifica completa: **[ZIP-316: Unified Addresses](https://zips.z.cash/zip-0316)**
+
+---
+
+## Vantaggi degli Unified Address
+
+- **Più semplice per gli exchange** - Ora possono supportare in modo più sicuro depositi/prelievi schermati.  
+- **A prova di futuro** - È possibile aggiungere nuove pool schermate senza rompere i wallet.  
+- **Shielded-by-Default** - Ogni UA contiene almeno un indirizzo schermato, quindi la privacy è sempre disponibile.
+
+Si tratta di un cambiamento fondamentale che sta già aiutando più ZEC a spostarsi nella pool schermata.
+
+---
+
+## Transazioni e Action di Orchard
+
+Orchard ha introdotto un nuovo concetto chiamato **Action**:
+
+- Riducono la fuoriuscita di metadati usando un **singolo anchor** per tutte le Action di una transazione.  
+- Fondono i campi di Spend + Output (V4) in un unico value commitment.  
+- Questo abilita ottimizzazioni delle prestazioni del sistema di prove Halo2.
+
+Daira spiega le posizioni degli anchor (zcon3):
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/f6UToqiIdeY"
+    title="Zcon3"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+---
+
+## Bilancio del valore e privacy
+
+In alcuni casi (ad esempio le transazioni tra pool diverse) gli importi possono essere visibili a un osservatore esterno. Tuttavia, `valueBalanceSapling` e `valueBalanceOrchard` usano **commitment omomorfici** per provare il totale di ZEC nelle pool schermate e impedire la contraffazione.
+
+Approfondisci: [Defense Against Counterfeiting in Shielded Pools](https://electriccoin.co/blog/defense-against-counterfeiting-in-shielded-pools/)
+
+---
+
+## Miglioramenti futuri
+
+Il team ECC sta lavorando a nuovi metodi RPC in `zcashd` (che sostituiranno `z_sendmany`) che permetteranno agli utenti di visualizzare in anteprima e accettare/rifiutare una transazione proposta in base alle sue caratteristiche di privacy.
+
+---
+
+## Raccomandazione
+
+Prova l'ultima versione di **YWallet**!  
+Mostra già un "Transaction Plan" sullo schermo prima di premere invio, aiutandoti a fare scelte più private.
+
+Ottimo articolo sulla privacy delle transazioni: https://medium.com/@hanh.huynh/
+
+---
+
+**Thread originale di ZecHub (@ZecHub)**  
+https://x.com/ZecHub/status/1628498645627666432
+
+---
+
+*Questa pagina è stata compilata a partire dal thread originale Zero to Zero Knowledge per la wiki di ZecHub.*

--- a/translations/it/site/Zcash_Social_Media/Zero_to_Zero-knowledge.md
+++ b/translations/it/site/Zcash_Social_Media/Zero_to_Zero-knowledge.md
@@ -1,0 +1,33 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Social_Media/Zero_to_Zero-knowledge.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zero to Zero Knowledge | Serie educativa 
+
+
+## Funzioni di hash 
+
+https://twitter.com/ZecHub/status/1621240109663227906
+
+
+## Frasi di recupero (recovery seed) 
+
+https://twitter.com/ZecHub/status/1624125037945946145
+
+
+## Indirizzi Zcash 
+
+https://twitter.com/ZecHub/status/1628498645627666432
+
+
+## Trusted Execution Environment 
+
+https://twitter.com/ZecHub/status/1633579659282587651
+
+## Cryptonote
+
+https://twitter.com/ZecHub/status/1636473585781948416
+
+## Lelantus
+
+https://twitter.com/ZecHub/status/1641902859800150017

--- a/translations/it/site/contribute/Community_Infrastructure.md
+++ b/translations/it/site/contribute/Community_Infrastructure.md
@@ -1,0 +1,51 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/contribute/Build_on_Zcash.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecHub Community Infrastructure Framework
+
+
+### Infrastruttura della community 
+
+Tutti i nodi, le istanze di lightwalletd e le altre infrastrutture sono liberamente accessibili ed esistono per aumentare l'accesso degli sviluppatori alla rete Zcash. Questo permette al programma di bounty di ZecHub di servire gli sviluppatori in modo più libero e snello rispetto alle singole attività su [Dework](https://dework.zechub.org). 
+
+
+## Candidatura 
+
+- Tagga @ZecHubDAOMember nel canale #zechub nel Zcash Global Discord per richiedere l'accesso. 
+
+- Ti aggiungeremo a un canale dove potrai ricevere supporto e condividere aggiornamenti. 
+
+- https://discord.gg/zcash 
+
+
+
+## Guide utili 
+
+- [Zcash Readthedocs](https://zcash.readthedocs.io/en/latest/)
+
+- [The Zebra Book](https://zebra.zfnd.org)
+
+- [Akash Network Docs](https://akash.network/docs/)
+
+- [Configurare Zcashd sulla Akash Network](https://zechub.wiki/guides/how-to-run-zcashd-on-akash-network)
+
+- [Zcash Payment Requests Explained (video)](https://www.youtube.com/watch?v=l5auYQIzYsQ)
+
+- [Specifica ZIP-321](https://zips.z.cash/zip-0321)
+
+Se hai bisogno di consigli approfonditi da parte degli sviluppatori Zcash puoi pubblicare un post sul [Community Forum](https://forum.zcashcommunity.com).
+
+
+
+## Progetti 
+
+- Ci interessa quello che crei! ZecHub emetterà bounty tra 5 e 15 ZEC per la documentazione della tua nuova app. 
+
+- Alcune idee: 
+
+Un sito web per un player video condiviso con input di un URL che richiede il pagamento in ZEC.
+
+Inoltrare memo cifrati tra un nodo Zcashd e un account Farcaster.
+
+Un servizio di exchange schermato che registra gli ZEC depositati per asset con indirizzo di risposta, acquisto coperto di altri asset effettuato su una L2 Ethereum. 

--- a/translations/it/site/contribute/Contributing_Guide.md
+++ b/translations/it/site/contribute/Contributing_Guide.md
@@ -1,0 +1,113 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/contribute/Contributing_Guide.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Contribuire a ZecHub
+
+ZecHub aiuta le persone a imparare a conoscere Zcash. Se stai leggendo questa pagina, siamo davvero entusiasti che tu stia valutando di contribuire! Qualsiasi contributo tu dia verrà riportato su [zechub.wiki](https://www.zechub.wiki/) e sugli altri social media di ZecHub.
+
+### Nuovi contributori
+
+Per avere una panoramica di ZecHub, leggi il [README](https://github.com/ZecHub/zechub/blob/main/README.md).
+
+
+### Per iniziare
+
+ZecHub usa GitHub per gestire i contributi della community. Se sei nuovo su GitHub, niente paura! Ti spiegheremo come puoi partecipare come contributore della community a ZecHub. Riconosciamo mance in ZEC per i contributi accettati. In questa guida avrai una panoramica del flusso di lavoro dei contributi, dall'apertura di una issue, alla creazione di una pull request (PR), alla review e al merge della PR.
+
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/8eYDTyV39a4"
+    title="How to Contribute to ZecHub!"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+### Unisciti alla conversazione
+
+Per prima cosa, unisciti alla conversazione nei nostri [link della community](https://zechub.wiki/zcash-community/community-links).
+
+### Guide di stile
+
+Qualsiasi contributo a ZecHub dovrebbe seguire le [guide di stile di ZecHub](https://github.com/ZecHub/zechub/blob/main/styles/guide.md). Questo include wiki, documentazione e contenuti per i social media.
+
+### Modi in cui puoi contribuire
+
+ZecHub è un progetto guidato dalla community che mira a fornire supporto e risorse agli utenti e agli sviluppatori di Zcash. Ci sono molti modi per partecipare a ZecHub, tra cui scrivere per la nostra newsletter settimanale, contribuire alla nostra knowledge base o dare una mano con i progetti di sviluppo.
+
+Questi sono i tipi di contributo che ZecHub attualmente accetta:
+
+#### Lavoro di sviluppo - da 0,12 fino a 0,5 ZEC per PR approvata
+
+Qualsiasi lavoro di sviluppo approvato che aiuti a costruire l'ecosistema Zcash. Può includere la nostra wiki, nuovi wallet o qualsiasi applicazione tu possa immaginare.
+
+#### Tutorial su Zcash (video) - fino a 0,15 ZEC per tutorial
+
+Ecco un esempio di tutorial qui sotto:
+
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/qz4KzDjkqu8"
+    title="WSL Install + Zcashd Compile/Transaction Tutorial"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+Crea e condividi tutorial sulle app di Zcash e ricevi una ricompensa. Invia una PR a zechub/tutorials o invia il video al canale #video-content su Discord. Se il video soddisfa i nostri criteri, lo pubblicheremo e ti daremo una mancia.
+
+#### Wiki di ZecHub - fino a 0,08 ZEC per ogni nuova pagina wiki pubblicata
+
+Il nostro sito wiki fornisce materiali didattici su Zcash in un formato facile e digeribile. Zcash è una tecnologia molto avanzata con una community vivace, quindi c'è ancora molta documentazione da costruire. Il nostro obiettivo è costruire documentazione su:
+
+```
+- Zcash e le sue tecnologie correlate
+- Casi d'uso di ZEC (la valuta Zcash)
+- Guide per i nuovi utenti
+- Community ed ecosistema Zcash
+- Ecosistema e strumenti per la privacy
+```
+
+Si tratta di aree piuttosto ampie, quindi c'è molto su cui lavorare. Se vuoi qualche ispirazione, dai un'occhiata al nostro attuale [sito wiki-docs](https://zechub.wiki/) e guarda cosa manca. Una volta stabilito cosa vuoi scrivere, inizia a fare le tue modifiche e impara come inviare una PR al repo di ZecHub. Tutta la nostra documentazione è creata e mantenuta in questo repo. Usa il [template dei docs](https://github.com/ZecHub/zechub/blob/main/template.md) e segui lo [stile di ZecHub](https://zechub.wiki/contribute/style-guide) quando scrivi una pagina wiki. Dopo aver inviato una PR, manda un messaggio a @dismad, @squirrel o @vito nella sezione #zechub del Discord, e loro esamineranno la tua PR e faranno il merge se è pronta per essere aggiunta al sito. Se viene mergiata, aggiungeranno il documento al sito web di ZecHub. Se il documento non è pronto, ti suggeriranno modifiche nella PR.
+
+#### Wiki di ZecHub - 0,015 ZEC per ogni modifica accettata ai docs
+
+A volte le informazioni nei nostri docs non sono perfette. Va bene. È per questo che li rendiamo open-source! Se trovi qualcosa che necessita di una modifica in un wiki-doc, vai al footer del documento (che rimanda alla sua pagina Github) e proponi una modifica tramite una PR.
+
+#### Wiki di ZecHub - 0,005 ZEC per ogni link rotto corretto
+
+Se trovi un link rotto, o qualcosa di importante scritto male, vai al footer del documento (che rimanda alla sua pagina Github) e proponi la modifica tramite una PR.
+
+#### Newsletter - 0,05 ZEC per edizione
+
+Produciamo la newsletter settimanale dell'ecosistema. È un modo super semplice e a basso impegno per partecipare! La newsletter esce ogni venerdì o sabato. Se vuoi scrivere una newsletter, manda un messaggio a @squirrel nella sezione #zecweekly del Discord per farglielo sapere.
+
+Dopodiché puoi andare alla [sezione newsletter di questo repository](/newsletter/newsletterbasics.md) e inviare una pull request per creare una nuova edizione della newsletter. Segui il formato usato in questo [template](/newsletter/newslettertemplate.md).
+
+Dopo aver fatto questo, @squirrel (su Discord) vedrà che la tua nuova edizione della newsletter è disponibile, la esaminerà e poi la mergerà nel repository. Una volta mergiata, prenderà il contenuto e lo pubblicherà tramite Substack.
+
+
+#### Podcast - 0,25 ZEC per episodio pubblicato sui social di ZecHub
+
+Hai un'idea per un programma di notizie, un podcast, un talk su Twitter o qualche altra cosa video/audio? Diccelo su Discord #video-content e ne parleremo.
+
+Le ricompense per questo tipo di contenuti sono un po' più alte, quindi sarebbe necessario presentare una proposta alla DAO di ZecHub prima di approvare la spesa.
+
+
+#### Altre idee? Faccelo sapere!
+
+Hai un altro suggerimento? Diccelo su #general su Discord. Possiamo discuterne e vedere se la DAO di ZecHub lo supporterà.
+
+### Per concludere
+
+Non esitare a iniziare a contribuire a uno dei protocolli più rispettati del settore. Questo è un ottimo modo per partecipare a Zcash. Se hai domande sul contribuire, faccelo sapere su [Discord](#join-the-conversation).
+
+Grazie!

--- a/translations/it/site/contribute/Help_build_ZecHub.md
+++ b/translations/it/site/contribute/Help_build_ZecHub.md
@@ -1,0 +1,61 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/contribute/Help_build_ZecHub.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Aiuta a costruire ZecHub 
+
+Se sei un membro della comunità Zcash e vuoi contribuire a costruire ZecHub, ci sono alcune cose che sono molto utili.
+
+Cura i link per la newsletter e aggiungili alla pagina GitHub della newsletter: -> [Clicca qui per le istruzioni](https://github.com/ZecHub/zechub/blob/main/site/contribute/ZecWeekly_Newsletter.md)
+
+Verifica i fatti dei documenti della wiki, suggerisci modifiche e proponi nuove pagine su Github
+
+Crea contenuti video nelle seguenti categorie:
+```
+* Zcash explainer videos
+* Zcash wallet guide/tutorials
+* Third-party application demos
+```
+
+Produci design come poster/grafiche/animazioni per l'ecosistema Zcash & Privacy 
+
+Traduci una qualsiasi delle pagine esistenti della wiki.
+
+Segnala bug
+
+#### Per i dettagli sugli importi delle taglie, leggi la nostra pagina dei contributi -> [qui](https://zechub.wiki/contribute/contributing-guide#content).
+
+Pubblichiamo issue per i task per i quali abbiamo attualmente delle taglie aperte. Principalmente si trovano come
+
+<img width="2768" height="838" alt="Screenshot_2025-11-01_11-13-39" src="https://github.com/user-attachments/assets/dd7dc989-3449-4a12-a919-9333a31cbb5a" />
+
+
+[Dework](https://app.dework.xyz/zechub-2424)
+
+[Issue GitHub di ZecHub](https://github.com/ZecHub/zechub/issues)
+
+[Issue GitHub di ZecHub-Wiki](https://github.com/ZecHub/zechub-wiki/issues)
+
+[Issue GitHub di ZecHub-Namada](https://app.dework.xyz/zechub-2424)
+
+
+
+Se ci sono altri modi in cui vorresti contribuire, scrivi a ZecHub ([@ZecHub](https://twitter.com/zechub)) su Twitter oppure unisciti al nostro [Discord](https://discord.gg/zcash).
+
+____
+
+**Per poter effettuare i pagamenti, ZecHub richiede a tutti i contributori di compilare un modulo di dichiarazione con il proprio nome e indirizzo schermato:**
+
+**( Zcash | Namada | Penumbra | Ycash )**
+
+
+
+____
+
+<div>
+    <iframe
+      style={{ border: 'none', width: '100%' }}
+      height="540px"
+      src="https://noteforms.com/forms/zechub-contributor-form-yomcwt"
+    />
+  </div>

--- a/translations/it/site/contribute/Style_Guide.md
+++ b/translations/it/site/contribute/Style_Guide.md
@@ -1,0 +1,50 @@
+# Guida di Stile di ZecHub
+
+Lo stile di ZecHub è semplice e accessibile. Accogliamo tutti e ci concentriamo sulla comunità Zcash.
+
+## Principi
+
+1. **Pronti ad aiutare** - Dimostra agli utenti di Zcash che siamo dalla loro parte.
+
+2. **Brevi e diretti:**  Trasmetti il messaggio più semplice possibile. Inizia dal punto più importante.
+
+3. **Centrati sull'utente:** Scriviamo prima per gli utenti, secondariamente per gli sviluppatori e poi per tutti gli altri.
+
+## Fondamenti
+
+- **Vai al punto**. Inizia dal punto più importante. Anticipa le parole chiave per la lettura veloce. Rendi chiare le opzioni dell'utente e i passi successivi.
+
+- **Scrivi come parli**. I nostri utenti sono persone reali. Parla loro per iscritto.
+
+- **Sii breve**. Dai agli utenti informazioni sufficienti per risolvere un problema o fare una scelta.
+
+- **Niente punti nei titoli**. Rimuovi la punteggiatura finale nei titoli, nelle intestazioni, nei sottotitoli, nei titoli dell'interfaccia e negli elementi di elenco con tre parole o meno. I punti si usano nei paragrafi e nel corpo del testo.
+
+  - Esempi: Premi il pulsante Invia.->Premi il pulsante Invia
+
+- **Nel dubbio, evita le maiuscole**. Usa le maiuscole solo per nomi propri o nomi come Zcash, oltre che per la prima parola di un'intestazione o di una frase.
+
+  - Esempi: Come Inviare ZEC con Unified Address. → Come inviare ZEC con unified address
+
+- **Riscrivi la scrittura debole**. Nella maggior parte dei casi, inizia ogni affermazione con un verbo. "Puoi" e "ci sono" andrebbero rivisti.
+
+  - Esempi: Puoi inviare e ricevere ZEC dal tuo cellulare->Invia e ricevi ZEC con il tuo telefono
+
+- **Non essere prolisso**. Usa un solo spazio dopo punti e due punti.
+
+- **Evita le parole non inglesi** come de facto o ad hoc. Evita le abbreviazioni latine di espressioni inglesi comuni.
+
+    | Usa questo  | Invece di questo |
+    |-------------|-----------------|
+    | per esempio | e.g.            |
+    | cioè        | i.e.            |
+
+## Tweet
+
+> Questa guida di stile generale serve per scrivere articoli o guide utente per ZecHub. Per i tweet o le affermazioni brevi, usa la [guida di stile per i tweet](./tweets.md).
+
+---
+
+<small>
+La guida di stile di ZecHub è adattata dalla <a href="https://learn.microsoft.com/en-us/style-guide/">Microsoft Writing Style Guide</a> con modifiche. Consulta la guida Microsoft quando ne hai bisogno.
+</small>

--- a/translations/it/site/contribute/ZecHub_DAO.md
+++ b/translations/it/site/contribute/ZecHub_DAO.md
@@ -1,0 +1,9 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/contribute/ZecHub_DAO.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecHub DAO
+
+![Governance](https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F2f9c810c-61ae-47c1-b5e4-bd4265e60d7c_5259x1667.png)
+
+=> [La ZecHub DAO](https://zechub.wiki/dao)

--- a/translations/it/site/contribute/ZecWeekly_Newsletter.md
+++ b/translations/it/site/contribute/ZecWeekly_Newsletter.md
@@ -1,0 +1,129 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/contribute/ZecWeekly_Newsletter.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Newsletter ZecWeekly
+
+ZecWeekly è una newsletter che esce ogni venerdì mattina. Include tutte le notizie accadute durante la settimana nell'ecosistema Zcash.
+
+Le notizie sono curate settimanalmente dai membri della community e tutti i link rilevanti vengono aggiunti alla newsletter.
+
+Per favore iscriviti alla newsletter [qui](https://zechub.substack.com/).
+
+## Contribuire
+
+I contributi alla newsletter funzionano meglio quando un collaboratore prepara l'edizione della settimana corretta, segue l'attuale thread di bounty o coordinamento e invia la pull request dopo che i link settimanali sono pronti. Per favore non inviare un'edizione futura prima che ZecHub abbia pubblicato o confermato la data per quell'edizione. Le pull request anticipate spesso perdono gli aggiornamenti di fine settimana, vanno in conflitto con un curatore assegnato o usano la scadenza sbagliata.
+
+### 1. Conferma l'edizione corrente
+
+Prima di iniziare a scrivere:
+
+- Controlla le [issue GitHub di ZecHub](https://github.com/ZecHub/zechub/issues) e [Dework](https://app.dework.xyz/zechub-2424) per l'attuale task della newsletter.
+- Usa la data nel titolo della issue o nella descrizione del task come fonte di verità.
+- Apri la issue e controlla se un altro collaboratore ha già commentato, è stato assegnato o ha aperto una pull request collegata.
+- Cerca tra le pull request aperte il numero della issue e la data dell'edizione prima di iniziare. Per esempio, cerca `is:pr is:open "May 30th" repo:ZecHub/zechub`.
+- Se il task non è chiaro, chiedi nella issue, sul Discord di ZecHub o scrivendo a [ZecHub su Twitter](https://twitter.com/ZecHub) prima di preparare l'edizione completa.
+
+![Open GitHub issues filtered for current ZecWeekly newsletter tasks](assets/zecweekly-current-task-search.png)
+
+### 2. Fai il fork del repository
+
+Se sei nuovo su GitHub, usa questo flusso di lavoro:
+
+1. Apri il [repository di ZecHub](https://github.com/ZecHub/zechub).
+2. Clicca su **Fork** e crea un fork sotto il tuo account GitHub.
+3. Nel tuo fork, crea un nuovo branch per l'edizione. Un nome di branch chiaro è utile, come `digest-may-30-2026`.
+4. Assicurati che la tua pull request abbia come repository di base `ZecHub/zechub` e come branch di base `main`.
+
+Se usi la riga di comando, lo stesso flusso di lavoro è il seguente:
+
+```bash
+git clone https://github.com/YOUR-USERNAME/zechub.git
+cd zechub
+git checkout -b digest-month-day-year
+```
+
+### 3. Crea il file della newsletter
+
+Usa il [template della newsletter](https://github.com/ZecHub/zechub/blob/main/newsletter/newslettertemplate.md) come punto di partenza. Le edizioni della newsletter vanno nella cartella [`newsletter`](https://github.com/ZecHub/zechub/tree/main/newsletter).
+
+Quando crei il file:
+
+- Rispetta il formato del nome file richiesto dalla issue o usato dalle recenti edizioni accettate.
+- Mantieni lo stesso ordine delle sezioni del template, a meno che il task non richieda un formato diverso.
+- Aggiungi solo i link della settimana rilevante.
+- Scrivi una descrizione breve e chiara per ogni link in modo che i lettori capiscano perché è importante.
+- Traduci o riassumi in inglese le fonti non in inglese quando necessario.
+- Controlla ogni link prima di aprire la pull request.
+
+### 4. Raccogli i link al momento giusto
+
+ZecWeekly normalmente copre l'attività dell'ecosistema Zcash della settimana corrente ed è pubblicata verso la fine della settimana. La tempistica più sicura è:
+
+- Inizia a raccogliere i link dopo che la issue o il task della newsletter corrente è stato pubblicato.
+- Mantieni una bozza mentre la settimana è ancora in corso.
+- Invia la pull request a ridosso della data di consegna richiesta, dopo aver verificato gli aggiornamenti di fine settimana.
+- Non inviare la newsletter di una settimana futura prima che esista il task per quella data o prima che ZecHub confermi che dovresti prepararla.
+
+Se una issue dice di inviare entro una data specifica, segui quella data. Se c'è un conflitto tra questa pagina e una issue corrente, segui la issue corrente.
+
+### 5. Apri la pull request
+
+Quando il file della tua newsletter è pronto:
+
+1. Fai il commit delle tue modifiche sul tuo fork.
+2. Apri una pull request verso `ZecHub/zechub` sul branch `main`.
+3. Usa un titolo che corrisponda all'edizione, come `Zcash Ecosystem Digest | May 30th`.
+4. Collega la issue nel corpo della pull request in modo che i revisori possano collegare il lavoro al task.
+
+Esempio di corpo della pull request:
+
+```md
+Closes #ISSUE_NUMBER
+
+Summary:
+- Adds the Zcash Ecosystem Digest for Month Day.
+- Uses the newsletter template and the current issue deadline.
+- Checks links and descriptions for the requested week.
+```
+
+Dopo che la pull request è aperta, fai attenzione ai commenti di revisione. Se ZecHub chiede delle modifiche, aggiorna lo stesso branch invece di aprire una seconda pull request per la stessa edizione.
+
+### Esempi reali
+
+Usa queste pull request di newsletter già unite come esempi di invii accettati:
+
+- [Zcash Ecosystem Digest | April 11th](https://github.com/ZecHub/zechub/pull/1551)
+- [Zcash Ecosystem Digest | March 28th](https://github.com/ZecHub/zechub/pull/1544)
+- [Zcash Ecosystem Digest | February 14th](https://github.com/ZecHub/zechub/pull/1474)
+
+![Merged ZecWeekly newsletter pull request example](assets/zecweekly-example-pr.png)
+
+Quando confronti il tuo lavoro con un esempio, concentrati sulla posizione del file, il formato del titolo, l'ordine delle sezioni, le descrizioni dei link e se la pull request si ricollega al task corretto.
+
+### Errori comuni da evitare
+
+- Aprire una pull request prima che la data dell'edizione o il task siano confermati.
+- Lavorare su una issue che ha già una pull request collegata.
+- Inviare la pull request al proprio fork invece che a `ZecHub/zechub`.
+- Usare il nome di file sbagliato o mettere il file fuori dalla cartella `newsletter`.
+- Copiare una vecchia edizione senza aggiornare ogni data, link e descrizione.
+- Aggiungere link della settimana sbagliata.
+- Lasciare link interrotti, link duplicati o testo segnaposto dal template.
+- Aprire una nuova pull request dopo i commenti di revisione invece di aggiornare il branch originale.
+
+### Lista di controllo finale
+
+Prima di richiedere la revisione, conferma che:
+
+- La data della issue o del task corrisponda al file della tua newsletter.
+- Nessun'altra pull request aperta copra già la stessa issue o edizione.
+- Il file sia nella cartella `newsletter`.
+- Le sezioni del template siano complete.
+- Ogni link funzioni e abbia una descrizione utile.
+- Il corpo della pull request colleghi la issue corretta.
+- Tu sia disponibile a fare modifiche se i revisori le richiedono.
+
+## Edizioni passate
+
+[Archivio ZecWeekly](https://zechub.substack.com/p/archive)

--- a/translations/it/site/footer.md
+++ b/translations/it/site/footer.md
@@ -1,0 +1,5 @@
+Aggiungi questo testo a ogni pagina del sito notion. 1) è per le pagine completate, 2) è per le pagine incomplete.
+
+*Se desideri aggiungere o suggerire modifiche a questa pagina della wiki, vai al repo github di ZecHub (aggiungi link) e invia una pull request.*
+
+*Se desideri completare questa pagina, vai al repo github (aggiungi link), crea una pull request e completa la pagina con la documentazione pertinente.*

--- a/translations/it/site/guides/Akash_Network_Zcashd.md
+++ b/translations/it/site/guides/Akash_Network_Zcashd.md
@@ -1,0 +1,516 @@
+# Distribuire zcashd su Akash tramite Console
+
+Guida per distribuire un nodo completo Zcash zcashd (implementazione di Electric Coin Co) usando [Akash Console](https://console.akash.network). Di seguito trovi un video tutorial. Più in basso è disponibile una guida più approfondita.
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/SVekeNU6_-g"
+    title="Zcash Full Node setup on Akash Network"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+## Cosa stai distribuendo
+
+Un nodo completo zcashd che farà quanto segue:
+
+-> Sincronizzare l'intera blockchain Zcash (350GB+ per la mainnet, ~ 40GB per la testnet)
+
+-> Costare all'incirca 15 $/mese a seconda dei prezzi del token AKT
+
+-> Richiedere da diverse ore a diversi giorni per sincronizzarsi completamente
+
+-> Usare 4 vCPU, 16GB di RAM, 350GB di storage (mainnet) oppure 2 vCPU, 8GB di RAM, 50GB (testnet)
+
+-> Scaricare i parametri crittografici alla prima esecuzione (~ 2GB, una sola volta)
+
+**zcashd vs Zebra:**
+
+-> zcashd è l'implementazione originale del nodo Zcash realizzata da Electric Coin Co
+
+-> Zebra è l'implementazione alternativa della Zcash Foundation
+
+-> Entrambe sono compatibili con la rete Zcash
+
+-> zcashd ha più funzionalità (mining, wallet, API Insight Explorer)
+
+-> Usa zcashd se hai bisogno di funzionalità wallet o di specifiche API RPC
+
+
+### **Importante: mappatura delle porte su Akash**
+
+Quando esponi una porta su Akash (ad esempio la porta 8233 per il P2P di zcashd), questa **NON viene associata a quella porta esatta** sull'IP pubblico del provider. Il provider assegna invece una porta alta casuale (come 31234 o 42567) e la inoltra tramite reverse proxy alla porta 8233 del tuo container.
+
+Questo è voluto: i provider eseguono più distribuzioni e avrebbero conflitti se tutti cercassero di usare direttamente la porta 8233.
+
+**Cosa significa per te:**
+
+-> Configuri la porta 8233 nel SDL (la porta P2P standard di zcashd)
+
+-> Akash ti fornisce un URI come *provider.com:31234*
+
+-> Gli altri nodi Zcash si connettono a te su *provider.com:31234*
+
+-> All'interno del tuo container, zcashd resta in ascolto sulla porta 8233
+
+
+Tutto questo viene gestito automaticamente. Usa semplicemente l'URI che Akash ti fornisce.
+
+## Prerequisiti
+
+-> Estensione del browser **Keplr Wallet** installata (Chrome/Brave/Firefox)
+
+-> **Token AKT** - Procurati 50-100 AKT da un exchange (Coinbase, Kraken, Osmosis)
+
+-> **5 minuti** per cliccare attraverso l'interfaccia della Console
+
+
+## Passo 1: connetti il tuo wallet
+
+-> Vai su [https://console.akash.network](https://console.akash.network)
+
+-> Clicca su **"Connect Wallet"** in alto a destra
+
+-> Scegli **Keplr** (o il tuo wallet Cosmos preferito)
+
+-> Approva la connessione quando compare Keplr
+
+
+Il tuo saldo AKT dovrebbe comparire in alto a destra. Se è zero, vai prima a finanziare il tuo wallet.
+
+## Passo 2: crea la distribuzione
+
+-> Clicca sul pulsante **"Deploy"** (il grande pulsante blu al centro della pagina)
+
+-> Scegli **"Build your template"** (oppure passa direttamente al caricamento del SDL)
+
+### Opzione A: carica il file SDL (consigliata)
+
+[![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-zcash-zcashd)
+
+### Opzione B: usa l'editor SDL
+
+Se vuoi incollare manualmente il SDL:
+
+-> Copia il contenuto di *zcashd-akash.yml*
+
+-> Incollalo nell'editor SDL
+
+-> Modificalo secondo necessità (vedi la sezione di configurazione più in basso)
+
+-> Clicca su **"Create Deployment"**
+
+
+## Passo 3: rivedi e approva il deposito
+
+La Console ti mostrerà:
+
+-> **Deposito di distribuzione**: ~ 5 AKT (lo riavrai quando chiudi la distribuzione)
+
+-> **Costo stimato**: in base ai prezzi del tuo SDL
+
+
+Clicca su **"Approve"** e firma la transazione in Keplr.
+
+## Passo 4: scegli un provider
+
+Dopo ~ 30 secondi vedrai le offerte dei provider. Ogni offerta mostra:
+
+-> **Prezzo per blocco** (in AKT o USDC)
+
+-> **Costo mensile stimato**
+
+-> **Dettagli del provider** (uptime, regione, ecc.)
+
+
+**Non scegliere solo il più economico.** Controlla:
+
+-> Percentuale di uptime (punta a > 95%)
+
+-> Regione (più vicino a te = latenza migliore, ma per i nodi blockchain conta poco)
+
+-> Stato di verifica (segno di spunta verde = più affidabile)
+
+
+Clicca su **"Accept Bid"** sul provider scelto e firma in Keplr.
+
+## Passo 5: attendi la distribuzione
+
+La Console farà quanto segue:
+
+-> Creare il lease con il provider scelto
+
+-> Inviare il manifest (che indica al provider cosa eseguire)
+
+-> Avviare il tuo container
+
+
+Questo richiede 1-2 minuti. Vedrai gli aggiornamenti di stato nell'interfaccia.
+
+## Passo 6: verifica che sia in esecuzione
+
+Una volta distribuito, vedrai:
+
+-> Scheda **Services**: mostra il tuo servizio *zcashd* con lo stato
+
+-> Scheda **Logs**: log in tempo reale dal tuo nodo zcashd
+
+-> Scheda **Leases**: dettagli sulla tua distribuzione (DSEQ, provider, costo)
+
+
+### Controlla i log
+
+Clicca su **Logs** e dovresti vedere zcashd in fase di avvio:
+
+```bash
+[zcashd]: ZCASHD_NETWORK=mainnet
+[zcashd]: Starting: zcashd -printtoconsole -showmetrics=1
+...
+```
+
+**La prima esecuzione scaricherà zcash-params (~2GB).** È un'operazione che si effettua una sola volta e richiede 5-10 minuti a seconda della banda del provider. I riavvii successivi la salteranno.
+
+La sincronizzazione richiederà **da ore a giorni** a seconda della rete. Tieni d'occhio:
+
+-> L'aumento delle altezze dei blocchi
+
+-> Le connessioni con i peer (dovrebbero essere 10-30 peer)
+
+-> L'assenza di errori ripetuti
+
+
+## Passo 7: ottieni l'indirizzo del tuo nodo
+
+Clicca sulla scheda **Leases**, poi su **URIs**.
+
+Vedrai qualcosa come:
+
+```
+zcashd-8233: provider-hostname.com:31234
+```
+
+Questo è l'**endpoint P2P pubblico** del tuo nodo. Gli altri nodi Zcash si connetteranno a te a questo indirizzo.
+
+**Nota la mappatura delle porte:** hai configurato la porta 8233 nel SDL, ma Akash l'ha assegnata a una porta pubblica diversa (31234 in questo esempio). È normale - vedi la sezione "Mappatura delle porte su Akash" in cima se questo ti confonde. Il tuo nodo è accessibile a qualsiasi porta Akash mostri qui, non necessariamente la 8233.
+
+Se hai abilitato RPC (commentato per impostazione predefinita nel SDL), vedrai qui anche l'endpoint RPC con la sua porta mappata.
+
+## Opzioni di configurazione
+
+### Passare alla testnet
+
+Il SDL usa per impostazione predefinita la mainnet. Per usare invece la testnet:
+
+-> **Cambia la rete nella sezione *env*:**
+
+   ```yaml
+   # - "ZCASHD_NETWORK=mainnet"
+   - "ZCASHD_NETWORK=testnet"
+   ```
+
+-> **Aggiorna la porta esposta** nella sezione *expose*:
+
+   ```yaml
+   # Comment out Mainnet port:
+   # - port: 8233
+   #   as: 8233
+   #   to:
+   #     - global: true
+   #   proto: tcp
+
+   # Uncomment Testnet port:
+   - port: 18233
+     as: 18233
+     to:
+       - global: true
+     proto: tcp
+   ```
+
+-> **Opzionale: riduci le risorse** per la testnet in *profiles.compute.zcashd.resources*:
+
+   ```yaml
+   cpu:
+     units: 2  # Down from 4
+   memory:
+     size: 8Gi  # Down from 16Gi
+   storage:
+     - size: 50Gi  # Down from 150Gi
+   ```
+
+-> **Opzionale: abbassa i prezzi** in *profiles.placement.akash.pricing*:
+
+   ```yaml
+   amount: 5000  # Down from 10000
+   ```
+
+> nota: abbassare i prezzi potrebbe escludere dei provider dal fare offerte. sperimenta con questo valore, oppure usa l'endpoint del provider per verificare se farebbe un'offerta. (consulta la documentazione delle API del provider)
+
+### Abilitare l'accesso RPC
+
+RPC è disabilitato per impostazione predefinita per motivi di sicurezza. Per abilitarlo:
+
+**CRITICO: imposta credenziali robuste.** L'RPC di zcashd trasmette nome utente/password su HTTP (non HTTPS). Esponi RPC solo se comprendi le implicazioni di sicurezza.
+
+-> Decommenta nella sezione *env*:
+
+   ```yaml
+   - "ZCASHD_RPCUSER=yourusername"
+   - "ZCASHD_RPCPASSWORD=your_very_strong_password_here"  # Use a real password
+   - "ZCASHD_RPCBIND=0.0.0.0"
+   - "ZCASHD_RPCPORT=8232"  # Mainnet
+   # - "ZCASHD_RPCPORT=18232"  # Testnet
+   - "ZCASHD_ALLOWIP=0.0.0.0/0"  # Allow from anywhere (use with caution)
+   ```
+
+-> Decommenta la porta RPC in *expose*:
+
+   **Per la mainnet:**
+
+   ```yaml
+   - port: 8232
+     as: 8232
+     to:
+       - global: false  # Keep internal for security
+     proto: tcp
+   ```
+
+   **Per la testnet:**
+
+   ```yaml
+   - port: 18232
+     as: 18232
+     to:
+       - global: false
+     proto: tcp
+   ```
+
+**Attenzione**: se imposti *global: true* per RPC, lo stai esponendo a internet con autenticazione di base. È una pessima idea. Usa *global: false* e accedi a RPC attraverso la rete interna di Akash oppure imposta un tunnel sicuro.
+
+**Promemoria sulla mappatura delle porte**: anche se esponi RPC globalmente, Akash lo mapperà su una porta alta casuale (non 8232/18232). Controlla gli URI nella tua distribuzione per vedere l'endpoint pubblico effettivo. Per *global: false* (consigliato), l'endpoint RPC è accessibile solo all'interno della rete della distribuzione Akash, non da internet pubblico.
+
+### Abilitare l'indice delle transazioni
+
+L'indice delle transazioni ti permette di interrogare qualsiasi transazione tramite il suo ID via RPC. Usa più storage (~ 20% in più).
+
+Decommenta in *env*:
+
+```yaml
+- "ZCASHD_TXINDEX=1"
+```
+
+**Attenzione**: abilitare txindex su un nodo già sincronizzato richiede di reindicizzare l'intera blockchain, operazione che richiede ore.
+
+### Abilitare Insight Explorer
+
+Insight Explorer fornisce endpoint API REST aggiuntivi per i dati della blockchain (utili per i block explorer).
+
+Decommenta in *env*:
+
+```yaml
+- "ZCASHD_INSIGHTEXPLORER=1"
+```
+
+Questo abilita automaticamente txindex e aggiunge metodi RPC supplementari.
+
+### Abilitare le metriche Prometheus
+
+Per raccogliere le metriche per il monitoraggio:
+
+-> Decommenta in *env*:
+
+   ```bash
+   - "ZCASHD_PROMETHEUSPORT=9969"
+   - "ZCASHD_METRICSIP=0.0.0.0/0"
+   ```
+
+-> Decommenta la porta delle metriche in *expose*:
+
+   ```bash
+   - port: 9969
+     as: 9969
+     to:
+       - global: false
+     proto: tcp
+   ```
+   
+Le metriche saranno disponibili su http://yourendpoint:9969/metrics in formato Prometheus.
+
+### Regolare risorse/prezzi
+
+Se non ricevi offerte o vuoi ottimizzare i costi:
+
+**Per provider con specifiche più basse**, riduci nella sezione *profiles.compute.zcashd.resources*:
+
+-> CPU: *units: 2* (minimo per una velocità di sincronizzazione ragionevole)
+
+-> Memoria: *size: 12Gi* (minimo per la stabilità)
+
+-> Storage: *size: 120Gi* (minimo per la mainnet)
+
+
+**Per attirare più offerte**, aumenta in *profiles.placement.akash.pricing*:
+
+-> Mainnet: prova *amount: 15000* uakt/block
+
+-> Testnet: prova *amount: 7500* uakt/block
+
+
+I valori del SDL sono impostati prudenzialmente alti. La maggior parte dei provider farà offerte più basse.
+
+## Aggiornare la tua distribuzione
+
+Devi cambiare la configurazione dopo la distribuzione?
+
+-> Vai su **My Deployments** nella Console
+
+-> Trova la tua distribuzione zcashd
+
+-> Clicca su **"Update Deployment"**
+
+-> Modifica il SDL
+
+-> Clicca su **"Update"** e approva in Keplr
+
+
+**Nota**: l'aggiornamento riavvierà il tuo container. Il nodo riprenderà dal suo stato salvato (storage persistente), ma aspettati 1-2 minuti di inattività.
+
+## Monitoraggio
+
+### Tramite la Console
+
+-> **Scheda Logs**: log del container in tempo reale
+
+-> **Scheda Shell**: ottieni una shell all'interno del container (utile per il debug)
+
+-> **Scheda Events**: eventi Kubernetes (per lo più inutili a meno che qualcosa non si sia rotto)
+
+
+### Tramite RPC (se abilitato)
+
+Se hai abilitato RPC, puoi interrogare il tuo nodo come un normale nodo completo zcashd (perché lo è!)
+
+### Alternativa con zcash-cli
+
+Se hai accesso shell tramite la Console, puoi usare *zcash-cli* direttamente:
+
+```bash
+# From the Shell tab in Console
+zcash-cli getblockchaininfo
+zcash-cli getpeerinfo
+zcash-cli getinfo
+```
+
+## Chiudere la tua distribuzione
+
+Quando hai finito o vuoi smettere di pagare:
+
+-> Vai su **My Deployments**
+
+-> Trova la tua distribuzione zcashd
+
+-> Clicca su **"Close Deployment"**
+
+-> Conferma e firma in Keplr
+
+
+Il tuo deposito di 5 AKT verrà rimborsato. Lo **storage persistente** dovrebbe essere preservato dal provider, ma non farci affidamento - trattalo come qualsiasi altro provider cloud.
+
+## Risoluzione dei problemi
+
+### Errore "Insufficient funds"
+
+Ti servono più AKT. Finanzia il tuo wallet Keplr.
+
+### Nessuna offerta visualizzata
+
+Una di queste:
+
+-> Il tuo prezzo è troppo basso (aumenta *amount* nel SDL)
+
+-> I tuoi requisiti di risorse sono troppo alti per i provider disponibili (riduci CPU/memoria/storage)
+
+-> Attendi più a lungo (a volte servono 60-90 secondi perché compaiano le offerte)
+
+
+### Distribuzione bloccata su "pending"
+
+Il provider potrebbe avere dei problemi. Chiudi la distribuzione e prova un provider diverso.
+
+### I log di zcashd mostrano "No peers connected"
+
+È normale nei primi minuti. zcashd scoprirà i peer automaticamente. Se persiste dopo più di 10 minuti, potresti avere un problema di rete (improbabile su Akash).
+
+### Errori "Out of memory" nei log
+
+Hai risparmiato troppo sulla RAM. Chiudi la distribuzione e ridistribuisci con almeno 12Gi di memoria (16Gi consigliati).
+
+### La sincronizzazione non finisce mai
+
+Definisci "mai":
+
+-> **Ore**: normale
+
+-> **Giorni**: anch'esso normale per la mainnet da zero
+
+-> **Settimane**: qualcosa non va, controlla i log per gli errori
+
+
+### "Error fetching zcash-params"
+
+Il provider potrebbe avere problemi di rete o banda lenta. Di solito si risolve da solo. Se persiste per più di 30 minuti, prova a ridistribuire su un provider diverso.
+
+### Errori di autenticazione RPC
+
+-> Controlla che *ZCASHD_RPCUSER* e *ZCASHD_RPCPASSWORD* siano impostati correttamente
+
+-> Verifica di usare la porta corretta (8232 per la mainnet, 18232 per la testnet)
+
+-> Ricorda che le porte sono mappate da Akash - usa l'URI della tua distribuzione, non direttamente la 8232
+
+
+## Gestione dei costi
+
+Monitora la tua spesa nella Console:
+
+-> **My Deployments** -> La tua distribuzione -> Mostra la stima "Cost per month"
+
+-> Il saldo del tuo wallet Keplr diminuirà nel tempo
+
+
+Quando il tuo saldo si abbassa, Akash chiuderà automaticamente la tua distribuzione. **Ricarica periodicamente il tuo wallet** o imposta degli avvisi.
+
+### Ridurre i costi
+
+-> **Usa la testnet** per i test non di produzione (50% più economica)
+
+-> **Abbassa CPU/memoria** se non ti serve una sincronizzazione veloce
+
+-> **Scegli provider più economici** (non sempre saggio - l'uptime conta)
+
+-> **Usa USDC invece di AKT** se il prezzo di AKT è volatile (richiede una modifica dei prezzi nel SDL)
+
+-> **Disabilita txindex** se non ti serve (risparmia ~ 20% di storage)
+
+
+### Risorse aggiuntive
+
+**Akash Console**: [https://console.akash.network](https://console.akash.network)
+
+**Akash Docs**: [https://akash.network/docs/](https://akash.network/docs/)
+
+**Zcash Explorers**: [https://zechub.wiki/using-zcash/blockchain-explorers](https://zechub.wiki/using-zcash/blockchain-explorers)
+
+**Akash Discord**: [https://discord.akash.network](https://discord.akash.network) (per problemi con i provider)
+
+## Note finali
+
+- **Lo storage persistente conta.** Non saltare *persistent: true* né usare la classe *beta2*. Usa *beta3*.
+- **La sincronizzazione iniziale è lenta.** Sii paziente. È normale per i nodi blockchain.
+- **Tieni finanziato il tuo wallet.** Le distribuzioni si chiudono automaticamente quando finisci gli AKT.
+- **I backup non sono automatici.** Se tieni ai dati, parti dal presupposto che possano sparire e pianifica di conseguenza.
+- **La sicurezza RPC è cruciale.** Non esporre RPC a internet senza adeguate misure di sicurezza.
+- **I zcash-params sono in cache.** La prima esecuzione scarica ~2GB di parametri crittografici. È normale e accade una sola volta.

--- a/translations/it/site/guides/Akash_Network_Zebra.md
+++ b/translations/it/site/guides/Akash_Network_Zebra.md
@@ -1,0 +1,444 @@
+# Come eseguire Zebra su Akash Network
+
+Guida passo passo per il deploy di un nodo completo Zebra Zcash usando la [Akash Console](https://console.akash.network).
+
+### Cosa stai distribuendo
+
+Un nodo Zebra completo che:
+
+-> Sincronizzerà l'intera blockchain Zcash (oltre 100GB per la mainnet, ~40GB per la testnet)
+
+-> Costerà all'incirca $15 al mese a seconda del prezzo del token AKT
+
+-> Impiegherà da diverse ore a giorni per sincronizzarsi completamente
+
+-> Userà 4 vCPU, 16GB di RAM, 350GB di storage (mainnet) oppure 2 vCPU, 8GB di RAM, 50GB (testnet)
+
+
+### Importante: mappatura delle porte su Akash
+
+Quando esponi una porta su Akash (ad esempio la porta 8233 per il P2P di Zebra), questa **NON viene associata a quella porta esatta** sull'IP pubblico del provider. Il provider assegna invece una porta alta casuale (come 31234 o 42567) e la inoltra tramite reverse proxy alla porta 8233 del tuo container.
+
+Questo è voluto: i provider eseguono più deployment e avrebbero conflitti se tutti cercassero di usare direttamente la porta 8233.
+
+**Cosa significa per te:**
+
+-> Configuri la porta 8233 nell'SDL (la porta P2P standard di Zebra)
+
+-> Akash ti fornisce un URI come *provider.com:31234*
+
+-> Gli altri nodi Zcash si connettono a te su *provider.com:31234*
+
+-> All'interno del tuo container, Zebra continua ad ascoltare sulla 8233
+
+
+Questo viene gestito automaticamente. Usa semplicemente l'URI che Akash ti fornisce.
+
+### Prerequisiti
+
+1. Estensione del browser **Keplr Wallet** installata (Chrome/Brave/Firefox)
+2. **Token AKT** - Procurati 50-100 AKT da un exchange (Coinbase, Kraken, Osmosis)
+3. **5 minuti** per cliccare attraverso l'interfaccia della Console
+
+#### Passo 1: connetti il tuo wallet
+
+-> Vai su [https://console.akash.network](https://console.akash.network)
+
+-> Clicca su **"Connect Wallet"** in alto a destra
+
+-> Scegli **Keplr** (o il tuo wallet Cosmos preferito)
+
+-> Approva la connessione quando compare Keplr
+
+
+Il tuo saldo AKT dovrebbe apparire in alto a destra. Se è zero, finanzia prima il tuo wallet.
+
+#### Passo 2: crea il deployment
+
+-> Clicca sul pulsante **"Deploy"** (il grande pulsante blu, al centro della pagina)
+
+-> Scegli **"Build your template"** (oppure passa direttamente al caricamento dell'SDL)
+
+
+##### Opzione A: carica il file SDL (consigliato)
+
+[![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-zcash-zebra)
+
+##### Opzione B: usa l'editor SDL
+
+Se vuoi incollare manualmente [l'SDL](https://github.com/akash-network/awesome-akash/blob/master/zcash-zebra/deploy.yaml):
+
+-> Copia il contenuto di *zebra-akash.yml*
+
+-> Incollalo nell'editor SDL
+
+-> Modificalo secondo necessità (vedi la sezione configurazione più sotto)
+
+-> Clicca su **"Create Deployment"**
+
+
+#### Passo 3: esamina e approva il deposito
+
+La Console ti mostrerà:
+
+-> **Deposito del deployment**: ~5 AKT (lo riavrai indietro quando chiuderai il deployment)
+
+-> **Costo stimato**: basato sul prezzo del tuo SDL
+
+Clicca su **"Approve"** e firma la transazione in Keplr.
+
+#### Passo 4: scegli un provider
+
+Dopo circa 30 secondi vedrai le offerte dei provider. Ogni offerta mostra:
+
+-> **Prezzo per blocco** (in AKT o USDC)
+
+-> **Costo mensile stimato**
+
+-> **Dettagli del provider** (uptime, regione, ecc.)
+
+
+**Non scegliere solo il più economico.** Controlla:
+
+-> Percentuale di uptime (punta a > 95%)
+
+-> Regione (più vicina a te = latenza migliore, ma per i nodi blockchain conta poco)
+
+-> Stato di audit (segno di spunta verde = più affidabile)
+
+
+Clicca su **"Accept Bid"** sul provider scelto e firma in Keplr.
+
+#### Passo 5: attendi il deployment
+
+La Console:
+
+-> Creerà il lease con il provider scelto
+
+-> Invierà il manifest (indica al provider cosa eseguire)
+
+-> Avvierà il tuo container
+
+Questo richiede 1-2 minuti. Vedrai gli aggiornamenti di stato nell'interfaccia.
+
+#### Passo 6: verifica che sia in esecuzione
+
+Una volta distribuito, vedrai:
+
+-> Scheda **Services**: mostra il tuo servizio *zebra* con il relativo stato
+
+-> Scheda **Logs**: log del container in tempo reale
+
+-> Scheda **Leases**: dettagli sul tuo deployment (DSEQ, provider, costo)
+
+
+##### Controlla i log
+
+Clicca su **Logs** e dovresti vedere Zebra che si avvia:
+
+```bash
+Loading config from environment variables
+Mainnet network selected
+Listening for peer connections on [::]:8233
+Starting initial sync...
+```
+
+La sincronizzazione richiederà **da ore a giorni** a seconda della rete. Tieni d'occhio:
+
+-> Altezze di blocco in aumento
+
+-> Connessioni ai peer (dovrebbero essere 10-30 peer)
+
+-> Assenza di errori ripetuti
+
+
+#### Passo 7: ottieni l'indirizzo del tuo nodo
+
+Clicca sulla scheda **Leases**, poi su **URIs**.
+
+Vedrai qualcosa come:
+
+```bash
+zebra-8233: provider-hostname.com:31234
+```
+
+Questo è l'**endpoint P2P pubblico** del tuo nodo. Gli altri nodi Zcash si connetteranno a te a questo indirizzo.
+
+**Nota la mappatura delle porte:** hai configurato la porta 8233 nell'SDL, ma Akash l'ha assegnata a una porta pubblica diversa (31234 in questo esempio). È normale - vedi la sezione "Mappatura delle porte su Akash" all'inizio se questo ti confonde. Il tuo nodo è accessibile sulla porta che Akash mostra qui, non necessariamente la 8233.
+
+Se hai abilitato l'RPC (commentato per impostazione predefinita nell'SDL), vedrai qui anche l'endpoint RPC con la sua porta mappata.
+
+### Opzioni di configurazione
+
+#### Passare alla testnet
+
+L'SDL usa la Mainnet per impostazione predefinita. Per usare invece la Testnet:
+
+-> **Commenta la configurazione Mainnet** nella sezione *env*:
+
+   ```yaml
+   # - "ZEBRA_NETWORK__NETWORK=Mainnet"
+   # - "ZEBRA_NETWORK__LISTEN_ADDR=[::]:8233"
+   ```
+
+-> **Decommenta la configurazione Testnet**:
+
+   ```yaml
+   - "ZEBRA_NETWORK__NETWORK=Testnet"
+   - "ZEBRA_NETWORK__LISTEN_ADDR=[::]:18233"
+   ```
+
+-> **Aggiorna la porta esposta** nella sezione *expose*:
+
+   ```yaml
+   # Comment out Mainnet port:
+   # - port: 8233
+   #   as: 8233
+   #   to:
+   #     - global: true
+   #   proto: tcp
+
+   # Uncomment Testnet port:
+   - port: 18233
+     as: 18233
+     to:
+       - global: true
+     proto: tcp
+   ```
+
+-> **Opzionale: riduci le risorse** per la Testnet in *profiles.compute.zebra.resources*:
+
+   ```yaml
+   cpu:
+     units: 2  # Down from 4
+   memory:
+     size: 8Gi  # Down from 16Gi
+   storage:
+     - size: 50Gi  # Down from 150Gi
+   ```
+
+-> **Opzionale: abbassa il prezzo** in *profiles.placement.akash.pricing*:
+
+   ```yaml
+   amount: 5000  # Down from 10000
+   ```
+
+#### Abilitare l'accesso RPC
+
+L'RPC è disabilitato per impostazione predefinita per motivi di sicurezza. Per abilitarlo:
+
+**Per la Mainnet:**
+
+-> Decommenta nella sezione *env*:
+
+   ```yaml
+   - "ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:8232"
+   - "ZEBRA_RPC__COOKIE_DIR=/home/zebra/.cache/zebra"
+   ```
+
+-> Decommenta la porta RPC della Mainnet in *expose*:
+
+   ```yaml
+   - port: 8232
+     as: 8232
+     to:
+       - global: false  # Keep internal for security
+     proto: tcp
+   ```
+
+**Per la Testnet:**
+
+-> Decommenta nella sezione *env*:
+
+   ```yaml
+   - "ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:18232"
+   - "ZEBRA_RPC__COOKIE_DIR=/home/zebra/.cache/zebra"
+   ```
+
+-> Decommenta la porta RPC della Testnet in *expose*:
+
+   ```yaml
+   - port: 18232
+     as: 18232
+     to:
+       - global: false
+     proto: tcp
+   ```
+
+**Attenzione**: se imposti *global: true* per l'RPC, lo stai esponendo a internet. Zebra usa l'autenticazione tramite cookie per impostazione predefinita, ma comunque - non farlo a meno che tu non sappia cosa stai facendo.
+
+**Promemoria sulla mappatura delle porte**: anche se esponi l'RPC globalmente, Akash lo mapperà su una porta alta casuale (non 8232/18232). Controlla gli URI nel tuo deployment per vedere l'endpoint pubblico effettivo. Con *global: false* (consigliato), l'endpoint RPC è accessibile solo all'interno della rete del deployment Akash, non da internet.
+
+#### Abilitare le metriche (Prometheus)
+
+Per raccogliere le metriche per il monitoraggio:
+
+-> Decommenta in *env*:
+
+   ```yaml
+   - "ZEBRA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999"
+   ```
+
+-> Decommenta la porta delle metriche in *expose*:
+
+   ```yaml
+   - port: 9999
+     as: 9999
+     to:
+       - global: false
+     proto: tcp
+   ```
+
+#### Regolare risorse/prezzi
+
+Se non stai ricevendo offerte o vuoi ottimizzare i costi:
+
+**Per provider con specifiche più basse**, riduci nella sezione *profiles.compute.zebra.resources*:
+
+-> CPU: *units: 2* (minimo per una velocità di sincronizzazione ragionevole)
+
+-> Memoria: *size: 12Gi* (minimo per la stabilità)
+
+-> Storage: *size: 120Gi* (minimo per la mainnet)
+
+**Per attrarre più offerte**, aumenta in *profiles.placement.akash.pricing*:
+
+-> Mainnet: prova *amount: 1000000* uakt/blocco
+
+-> Testnet: prova *amount: 1000000* uakt/blocco
+
+### Aggiornare il tuo deployment
+
+Devi modificare la configurazione dopo il deploy?
+
+-> Vai su **My Deployments** nella Console
+
+-> Trova il tuo deployment Zebra
+
+-> Clicca su **"Update Deployment"**
+
+-> Modifica l'SDL
+
+-> Clicca su **"Update"** e approva in Keplr
+
+**Nota**: l'aggiornamento riavvierà il tuo container. Il nodo riprenderà dal suo stato salvato (storage persistente), ma aspettati 1-2 minuti di downtime.
+
+### Monitoraggio
+
+#### Tramite la Console
+
+-> **Scheda Logs**: log del container in tempo reale
+
+-> **Scheda Shell**: ottieni una shell all'interno del container (utile per il debug)
+
+-> **Scheda Events**: eventi Kubernetes (per lo più inutili a meno che qualcosa non sia rotto)
+
+
+#### Tramite RPC (se abilitato)
+
+Se hai abilitato l'RPC, puoi interrogare il tuo nodo come un normale nodo completo zebrad (perché lo è!)
+
+### Chiudere il tuo deployment
+
+Quando hai finito o vuoi smettere di pagare:
+
+-> Vai su **My Deployments**
+
+-> Trova il tuo deployment Zebra
+
+-> Clicca su **"Close Deployment"**
+
+-> Conferma e firma in Keplr
+
+Il tuo deposito di 5 AKT verrà rimborsato. Lo **storage persistente** dovrebbe essere preservato dal provider, ma non farci affidamento - trattalo come qualsiasi altro provider cloud.
+
+### Risoluzione dei problemi
+
+#### Errore "Insufficient funds"
+
+Ti servono più AKT. Finanzia il tuo wallet Keplr.
+
+#### Nessuna offerta visualizzata
+
+Possibili cause:
+
+-> Il tuo prezzo è troppo basso (aumenta *amount* nell'SDL)
+
+-> I tuoi requisiti di risorse sono troppo elevati per i provider disponibili (riduci CPU/memoria/storage)
+
+-> Aspetta di più (a volte servono 60-90 secondi perché compaiano le offerte)
+
+
+#### Deployment bloccato in "pending"
+
+Il provider potrebbe avere dei problemi. Chiudi il deployment e prova un provider diverso.
+
+#### I log di Zebra mostrano "No peers connected"
+
+È normale per i primi minuti. Zebra scoprirà i peer automaticamente. Se persiste dopo più di 10 minuti, potresti avere un problema di rete (improbabile su Akash).
+
+#### Errori "Out of memory" nei log
+
+Hai risparmiato troppo sulla RAM. Chiudi il deployment e riesegui il deploy con almeno 12Gi di memoria (16Gi consigliati).
+
+#### La sincronizzazione richiede un'eternità
+
+Definisci "un'eternità":
+
+-> **Ore**: normale
+
+-> **Giorni**: normale anche per la mainnet da zero
+
+-> **Settimane**: qualcosa non va, controlla i log per gli errori
+
+
+### Gestione dei costi
+
+Monitora la tua spesa nella Console:
+
+-> **My Deployments** -> Il tuo deployment -> Mostra la stima "Cost per month"
+
+-> Il saldo del tuo wallet Keplr diminuirà nel tempo
+
+
+Quando il tuo saldo si esaurisce, Akash chiuderà automaticamente il tuo deployment. **Ricarica periodicamente il tuo wallet** o imposta degli avvisi.
+
+#### Ridurre i costi
+
+-> **Usa la Testnet** per i test non in produzione (50% più economica)
+
+-> **Riduci CPU/memoria** se non ti serve una sincronizzazione veloce
+
+-> **Scegli provider più economici** (non sempre saggio - l'uptime conta)
+
+
+### Mainnet vs Testnet
+
+```markdown
+----------------------------------------------------------------------------------
+|            | Mainnet (default)               | Testnet                         |
+---------------------------------------------------------------------------------|
+| Purpose   | Production Zcash blockchain      | Testing and development         |
+| Network   | ZEBRA_NETWORK__NETWORK=Mainnet   | ZEBRA_NETWORK__NETWORK=Testnet  |
+| P2P Port  | 8233                             | 18233                           |
+| RPC Port  | 8232                             | 18232                           |
+| Sync time | Days                             | Hours                           |
+| Storage   | 350GB+                           | 50GB                            |
+| Resources | 4 CPU / 16GB RAM                 | 2 CPU / 8GB RAM                 |
+| Cost      | ~$15/month                       | ~$5/month                       |
+----------------------------------------------------------------------------------
+```
+
+Inizia con la Testnet se stai solo testando il processo di deployment. Vedi la sezione "Passare alla testnet" più sopra per la configurazione.
+
+### Risorse aggiuntive
+
+**Akash Console**: [https://console.akash.network](https://console.akash.network)
+
+**Documentazione Akash**: [https://akash.network/docs/](https://akash.network/docs/)
+
+**Documentazione Zebra**: [https://zebra.zfnd.org/](https://zebra.zfnd.org/)
+
+**Explorer Zcash**: [https://zechub.wiki/using-zcash/blockchain-explorers](https://zechub.wiki/using-zcash/blockchain-explorers)
+
+**Discord Akash**: [https://discord.akash.network](https://discord.akash.network) (per problemi con i provider)

--- a/translations/it/site/guides/Avalanche_RedBridge.md
+++ b/translations/it/site/guides/Avalanche_RedBridge.md
@@ -1,0 +1,73 @@
+# Zcash Avalanche RedBridge
+
+Lo Zcash Avalanche RedBridge è un bridge decentralizzato che consente l'interoperabilità tra le blockchain Zcash (ZEC) e Avalanche (AVAX). Questo bridge è progettato per facilitare il trasferimento senza soluzione di continuità di ZEC sulla blockchain Avalanche, sfruttando l'elevato throughput, le basse commissioni e i meccanismi di consenso ecosostenibili di Avalanche, preservando al contempo le funzionalità orientate alla privacy di Zcash.
+
+Il RedBridge supporta un'ampia gamma di casi d'uso, tra cui la finanza decentralizzata (DeFi) cross-chain, le transazioni private e la condivisione della liquidità, dando ai detentori di Zcash una maggiore accessibilità all'ecosistema Avalanche. Questo bridge è operato attraverso un insieme di nodi decentralizzati e un oracolo, noto come **ZavaX**, che garantisce un trasferimento dati affidabile e la verifica dei prezzi tra Zcash e Avalanche.
+
+### Funzionalità chiave
+
+Interoperabilità che preserva la privacy: consente agli utenti Zcash di mantenere la privacy mentre utilizzano applicazioni DeFi su Avalanche.
+Oracolo decentralizzato ZavaX: integra un sistema di oracolo per garantire dati di prezzo ZEC/AVAX accurati, consentendo operazioni cross-chain trustless.
+Scalabile ed ecosostenibile: utilizza il modello di consenso di Avalanche, fornendo transazioni ad alta velocità con un impatto ambientale minimo.
+Supporto per DeFi e DApp: i detentori di Zcash possono ora partecipare a varie piattaforme DeFi su Avalanche senza compromettere la privacy.
+
+### Componenti tecnici
+
+**Oracolo decentralizzato ZavaX**
+Descrizione: l'oracolo ZavaX è cruciale per il bridge, fornendo feed di prezzo cross-chain e abilitando conversioni trustless da ZEC ad AVAX.
+[Link all'oracolo](https://zavax-oracle.red.dev)
+
+**Contratto del bridge cross-chain**
+Descrizione: l'architettura degli smart contract che supporta il bridge Zcash Avalanche, gestendo depositi, conversioni e prelievi di ZEC.
+
+**Integrazione del livello di privacy**
+Descrizione: garantisce che le funzionalità di privacy di Zcash siano preservate durante l'intero processo di bridging, consentendo transazioni cross-chain private.
+
+## Deliverable e documentazione
+
+**Zcash Elastic Subnet Bridge su Avalanche**: [Proposta di grant](https://zcashgrants.org/gallery/25215916-53ea-4041-a3b2-6d00c487917d/36243580/)
+Di seguito i deliverable chiave e le risorse tecniche completati per il progetto Zcash Avalanche RedBridge:
+
+Deliverable 1.1: PoC preliminare che supporta l'interrogazione di transazioni Zcash testnet da una subnet Avalanche testnet tramite una CLI, pubblicato su Github e con una subnet a singolo nodo sulla testnet di Avalanche. https://github.com/red-dev-inc/zavax-oracle
+
+Deliverable 2.1: [Architettura](https://github.com/red-dev-inc/zavax-bridge/tree/main/Architecture)
+
+
+### Milestone 3 - 31 marzo 2024
+
+Il Deliverable 3.1 è completo e presenta la nostra analisi sull'adozione di FROST al posto di BLS per le firme a soglia nel bridge ZavaX. Questo cambiamento sfrutta librerie sottoposte ad audit dalla Zcash Foundation e facilita una migliore integrazione e sicurezza. https://github.com/ZcashFoundation/frost
+
+Deliverable 3.2 - Design UX e UI per la GUI completato, con dettagli sui nostri miglioramenti di sicurezza per la subnet dell'oracolo ZavaX, supportati dai risultati dei penetration test. Per maggiori dettagli, inclusi la configurazione del server e gli esiti dei test [Security Assesment](https://github.com/red-dev-inc/zavax-oracle/blob/main/security/deployment-notes.md)
+[Audit Report](https://github.com/red-dev-inc/zavax-oracle/blob/main/security/pen-testing-report-2024-09.md)
+Inoltre, il team ha effettuato un rebranding da ZavaX a redbridge e ha cambiato il token di staking da ZAX a RBR.
+
+### Milestone 4 - 30 aprile 2024
+Deliverable 4.1 - Deployment completamente funzionante sulle testnet di Zcash e Avalanche, con una Subnet a 3 validatori e supporto CLI
+
+### Milestone 5 - 31 maggio 2024
+Deliverable 5.1 - GUI: integrazione del bridge in Core o Webapp
+
+Milestone 6 - 30 giugno 2024
+Deliverable 6.1 - Superamento con successo dell'audit del software
+Deliverable 6.2 - Pubblicazione del codice sorgente sottoposto ad audit in un repository Github pubblico
+
+Dai un'occhiata al [repository Github](https://github.com/red-dev-inc/zavax-bridge/tree/main/Architecture)
+  
+Per maggiori dettagli tecnici, gli utenti sono invitati a esaminare il repository e la documentazione del progetto RedBridge per [esplorare](https://zcashgrants.org/gallery/25215916-53ea-4041-a3b2-6d00c487917d/36243580/) le specifiche dell'integrazione, i framework di test e i protocolli di sicurezza.
+
+
+![img1](https://github.com/user-attachments/assets/b8c5d267-1711-458a-8a32-1df9d56fae8a)
+
+
+* Deliverable: 
+Nel Q1 2025, il team ha annunciato il lancio del [sito demo di red·bridge](https://redbridge-demo.red.dev/index.html), dove chiunque può provare l'esperienza utente, dare feedback e suggerire miglioramenti. Serve anche come modo semplice per presentare il progetto a persone non tecniche.
+
+* Il team ha usato Zebra per la versione finale di red·bridge. Per testarla, hanno aggiornato due dei tre nodi nella loro blockchain di test, ZavaX Oracle, che gira sulla testnet Fuji di Avalanche. L'ultimo nodo è stato aggiornato con successo, e ora [Zavax Oracle](https://zavax-oracle.red.dev/) gira su ZEBRA!
+
+* Nel Q1 2025, il sito web red.bridge è stato programmato per offrire quattro temi: red, Dark, Light e Zebra, a differenza della versione iniziale, che era red.
+
+* Un altro punto è che il team attiverà la red·bridge L1 live sulla mainnet di Avalanche a dicembre 2025. Inizialmente, fungerà da oracolo per la blockchain Zcash e poi, poco dopo, anche per Bitcoin. In tal caso, ogni richiesta costerà 0,001 AVAX in token di gas. Questa build consentirà a qualsiasi L1 o smart contract su Avalanche di interrogare a basso costo i dati da Zcash e Bitcoin in modo decentralizzato.
+
+* Nel Q2, il team ha presentato alla Avalanche Foundation una milestone ACP-77 (nota come Avalanche9000) per rendere l'esecuzione di un guardian red.bridge più anticipata e accessibile a tutti. Inizialmente, i validatori dovevano mettere in staking circa 2000 AVAX; tuttavia, con i costi di Avalanche9000, ai validatori bastava 1 AVAX (al mese). Inoltre, questa milestone finalizza anche il piano di utilizzo dell'implementazione FROST della ZF, che assegna a ogni Guardian una quota di firma per un controllo sicuro e distribuito del wallet del bridge.
+
+* Tra il Q1 e il Q2 del 2026, red.bridge ospiterà l'airdrop del suo token RBR (precedentemente ZAX) per i membri delle community Zcash e Avalanche. Secondo il fondatore di red.dev, ospiteranno una testnet incentivata in cui gli utenti avranno la possibilità di guadagnare RBR aiutando a testare il bridge.

--- a/translations/it/site/guides/BTCPayServer_Zcash_Plugin.md
+++ b/translations/it/site/guides/BTCPayServer_Zcash_Plugin.md
@@ -1,0 +1,897 @@
+# BTCPay Server con supporto Zcash: guida completa all'installazione e all'integrazione
+
+BTCPay Server consente alle attività online di accettare pagamenti in criptovaluta direttamente, senza intermediari o custodi. Questa guida ti accompagna attraverso l'intero processo di configurazione di BTCPay Server con supporto nativo per i pagamenti schermati in Zcash.
+
+> Questa documentazione si concentra sull'integrazione di Zcash nella tua istanza di BTCPay Server.  
+> Supporta sia le configurazioni con **full node (Zebra)** sia quelle basate su **lightwalletd**.
+
+---
+
+## Indice
+
+- [Perché usare BTCPay Server con Zcash](#Why-Use-BTCPay-Server-with-Zcash)
+- [Come funziona BTCPay Server](#How-BTCPay-Server-Works)
+- [Dove sono conservati i fondi? Chi controlla le chiavi private?](#Where-Are-Funds-Stored-Who-Controls-the-Private-Keys)
+- [Come configurare BTCPay Server per accettare Zcash](#How-to-Set-Up-BTCPay-Server-for-Accepting-Zcash)
+  - [Distribuire BTCPay Server con supporto Zcash](#Deploying-BTCPay-Server-with-Zcash-Support)
+  - [Eseguire il tuo full node Zcash (Zebra + Lightwalletd)](#Running-Your-Own-Zcash-Full-Node)
+  - [Connettersi a un nodo lightwalletd esterno (configurazione personalizzata)](#Connecting-to-an-External-Lightwalletd-Node)
+  - [Ospitare BTCPay Server a casa con Cloudflare Tunnel](#Hosting-BTCPay-Server-at-Home-with-Cloudflare-Tunnel)
+- [Configurare il plugin Zcash nell'interfaccia web di BTCPay Server](#Configuring-the-Zcash-Plugin-in-the-BTCPay-Server-Web-Interface)
+- [Integrare BTCPay Server con il tuo sito web](#Integrating-BTCPay-Server-with-Your-Website)
+  - [Integrazione tramite API](#API-Integration)
+    - [Generare una chiave API](#Generating-an-API-Key)
+    - [Esempio: creare una fattura tramite API](#Example-Creating-an-Invoice-via-API)
+    - [Configurare un webhook](#Setting-Up-a-Webhook-Optional)
+  - [Integrazione CMS](#CMS-Integration)
+  - [Pulsante di pagamento o iframe](#Payment-Button-or-Iframe-No-CMS-or-API-Needed)
+- [Conclusione](#Conclusion)
+- [Risorse](#Resources)
+
+
+---
+
+## Perché usare BTCPay Server con Zcash
+
+Il commercio online accetta sempre più spesso criptovalute. È veloce, globale e funziona senza banche. Questo avvantaggia sia i commercianti che i clienti. Ma c'è un dettaglio importante che molti trascurano.
+
+Quando effettua un ordine, il cliente fornisce in genere informazioni personali: nome, indirizzo di spedizione e numero di telefono. Se il pagamento viene effettuato utilizzando una blockchain pubblica - come Bitcoin, Ethereum o le stablecoin su Ethereum o Tron - la transazione diventa permanentemente visibile per essere analizzata.
+
+Chiunque, anche senza sapere cosa è stato ordinato, può:
+
+- vedere quando e quanto è stato pagato  
+- tracciare da dove provengono i fondi e dove sono andati  
+- collegare un indirizzo di criptovaluta a una persona reale se esiste un qualsiasi punto di correlazione (ad esempio, un'email trapelata o il nome di spedizione)
+
+Questo significa che un singolo acquisto può rivelare l'intera storia finanziaria di un cliente.
+
+E funziona anche al contrario. Se l'indirizzo di un commerciante è mai apparso on-chain, diventa esposto. Concorrenti e osservatori terzi possono tracciare i volumi di pagamento, l'attività dei fornitori e la struttura dei flussi commerciali.
+
+### La combinazione di BTCPay Server e Zcash può risolvere questo problema.
+
+
+BTCPay Server è un sistema gratuito e decentralizzato per ricevere pagamenti in criptovaluta.  
+Non è un intermediario di pagamento e non detiene alcun fondo. Tutti i pagamenti vanno direttamente al wallet del commerciante.  
+Può trattarsi di un wallet personale o di una configurazione multisig all'interno di un'organizzazione.
+
+Il server si occupa dei compiti di coordinamento:
+
+- genera un indirizzo univoco per ogni ordine  
+- monitora quando il pagamento viene ricevuto e lo collega all'ordine  
+- emette ricevute e notifiche  
+- fornisce un'interfaccia di pagamento per il cliente  
+
+Tutto funziona sotto il controllo del proprietario del negozio, senza dipendere da servizi di terze parti.
+
+Zcash è una criptovaluta costruita su prove a conoscenza zero. Supporta un modello di transazione completamente privato.  
+Quando si utilizzano indirizzi schermati (d'ora in poi semplicemente chiamati "indirizzi"), il mittente, il destinatario e l'importo della transazione non vengono rivelati sulla blockchain.
+
+Per i negozi online, questo significa:
+
+- L'acquirente può completare il pagamento senza rivelare la propria storia finanziaria  
+- Il venditore riceve il pagamento senza esporre il proprio indirizzo, il volume delle vendite o la struttura delle transazioni  
+- Nessun osservatore esterno può collegare il pagamento all'ordine o ai dati del cliente
+
+### Esempio pratico
+
+Un utente effettua un ordine e seleziona Bitcoin o USDT come metodo di pagamento.  
+Il sito web genera un indirizzo di pagamento e mostra l'importo.  
+Dopo che il pagamento è stato effettuato, questo indirizzo viene memorizzato sulla blockchain e diventa pubblico.  
+A un malintenzionato basta collegare un solo ordine all'indirizzo per ottenere una visibilità a lungo termine sull'intera storia delle sue transazioni.
+
+Ora immagina la stessa situazione con Zcash.  
+BTCPay Server genera un indirizzo schermato. L'acquirente invia il pagamento.  
+Dal punto di vista della blockchain, non accade nulla. Non ci sono dati pubblici da analizzare.  
+Il server riceve la conferma, la collega all'ordine e completa il processo.
+
+Per chiunque dall'esterno, sembra che non sia successo nulla.  
+Tutta la logica rimane tra il negozio e il cliente - come dovrebbe essere.
+
+Questa soluzione non compromette l'automazione o l'usabilità.  
+Tutto funziona allo stesso modo delle altre criptovalute, semplicemente senza il rischio di fughe di dati.
+
+
+
+## Come funziona BTCPay Server
+
+BTCPay Server agisce come un ponte di elaborazione dei pagamenti tra la tua piattaforma di e-commerce e la blockchain. Ecco come funziona il flusso:
+
+1. **Il cliente effettua un ordine** sul tuo sito web (ad esempio WooCommerce, Magento o qualsiasi piattaforma con integrazione BTCPay).
+
+2. **Il negozio richiede una fattura di pagamento** a BTCPay Server. Il server genera una fattura univoca con:
+   - L'importo dell'ordine
+   - Un conto alla rovescia
+   - Un Zcash Unified Address (UA) - ad esempio `u1...` - che include un ricevente Orchard (schermato) per impostazione predefinita.
+
+3. **Il cliente vede la pagina di pagamento** e invia ZEC all'indirizzo fornito.
+
+4. **BTCPay Server monitora la blockchain**, verificando il pagamento rispetto a:
+   - L'importo previsto
+   - L'indirizzo di ricezione
+   - Il timestamp della fattura
+
+5. **Una volta che la transazione viene rilevata e confermata**, BTCPay notifica il negozio.
+
+6. **Il cliente riceve una conferma di pagamento.** Facoltativamente, il server può inviare una ricevuta via email.
+
+Tutto questo processo avviene **automaticamente**, senza intermediari o custodi.  
+BTCPay Server **non detiene alcun fondo** - collega semplicemente il sistema di ordini alla blockchain in modo sicuro e privato.
+## Dove sono conservati i fondi? Chi controlla le chiavi private?
+
+BTCPay Server **non** è un wallet e **non richiede chiavi private**.  
+Tutti i fondi vanno **direttamente** al wallet del commerciante. La sicurezza è garantita dall'uso di un'**architettura basata su viewing key**.
+
+### Come funziona
+
+- **Il wallet viene creato in anticipo.**  
+  Il commerciante utilizza un wallet Zcash che supporta le viewing key - come [YWallet](https://ywallet.app/installation) o [Zingo! Wallet](https://zingolabs.org/).  
+  Un elenco completo è disponibile su [ZecHub.wiki](https://zechub.wiki/wallets).
+
+- **BTCPay Server si connette tramite una viewing key.**  
+  Una viewing key è una **chiave di sola lettura**: può rilevare i pagamenti in entrata e generare nuovi indirizzi di ricezione,  
+  ma non può spendere i fondi. Il server non memorizza frasi seed o chiavi private.
+
+- **I dati della blockchain sono accessibili tramite un server `lightwalletd`.**  
+  Puoi usare un nodo pubblico come `https://zec.rocks`, oppure eseguire il tuo stack `Zebra + lightwalletd` per la piena sovranità.
+
+- **Ogni ordine riceve un indirizzo univoco.**  
+  Le viewing key consentono al server di derivare nuovi indirizzi schermati Zcash per ogni fattura,  
+  permettendo un tracciamento sicuro dei pagamenti e prevenendo il riutilizzo degli indirizzi.
+
+- **Mantieni il pieno controllo sui fondi.**  
+  Anche se il server venisse compromesso, nessuno potrebbe rubare il tuo denaro - potrebbero essere esposti solo i metadati dei pagamenti.
+
+Questo design separa l'**infrastruttura** dal **controllo degli asset**.  
+Puoi aggiornare, migrare o reinstallare BTCPay Server senza mettere a rischio alcun fondo.
+
+## Come configurare BTCPay Server per accettare Zcash
+
+Nelle sezioni precedenti abbiamo spiegato come funziona BTCPay Server con Zcash e perché è importante per i pagamenti che preservano la privacy. Ora è il momento di mettere le mani in pasta.
+
+La tua configurazione esatta dipenderà da diversi fattori:
+
+- Hai già un'istanza di BTCPay Server?
+- Vuoi usare un lightwalletd pubblico o eseguire il tuo full node?
+- Il server verrà eseguito su un VPS o a casa?
+
+Questo capitolo copre tutti gli scenari di configurazione attuali - dalle configurazioni minime alle distribuzioni completamente sovrane.
+
+Vedremo i seguenti aspetti:
+
+- Come distribuire tutto da zero su un VPS, incluso il full node (Zebra)
+- Come eseguire BTCPay Server a casa mantenendo nascosto il tuo IP usando **Cloudflare Tunnel**
+- Come abilitare e configurare il supporto Zcash all'interno dell'interfaccia web di BTCPay Server
+- Come integrare BTCPay con il tuo sito web o negozio online
+
+
+## Distribuire BTCPay Server con supporto Zcash
+
+Passiamo alla configurazione vera e propria. In questa sezione installeremo BTCPay Server con supporto Zcash - sia su un VPS nuovo sia aggiungendo il supporto ZEC a un'istanza esistente.
+
+Se hai già BTCPay Server in esecuzione (ad esempio per BTC o Lightning), non è necessario reinstallare tutto - basta abilitare il plugin ZEC.
+
+Vedremo varie configurazioni, dalle configurazioni minime che usano un nodo `lightwalletd` pubblico alle installazioni completamente sovrane con il tuo full node.  
+L'opzione migliore dipende dalla posizione del tuo server e da quanta indipendenza desideri dall'infrastruttura esterna.
+
+> Documentazione ufficiale del plugin:  
+> [https://github.com/btcpay-zcash/btcpayserver-zcash-plugin](https://github.com/btcpay-zcash/btcpayserver-zcash-plugin)
+>
+> **Attenzione - un solo wallet per istanza:**  
+> Il plugin Zcash utilizza **un unico wallet condiviso** tra **tutti i negozi** dell'istanza BTCPay.  
+> Se ospiti più negozi indipendenti su un'unica istanza, condivideranno lo stesso wallet Zcash.  
+> Usa istanze separate se hai bisogno di un isolamento rigoroso dei wallet.
+
+---
+
+### Configurazione VPS consigliata
+
+Prima di installare, assicurati di avere:
+
+- Un VPS con **Ubuntu 22.04+**
+- Un nome di dominio che punti all'indirizzo IP del tuo server (tramite DNS)
+- `git`, `docker` e `docker-compose` installati
+- Accesso SSH al server
+
+---
+
+## Preparare il server (parte nascosta)
+
+<details>
+  <summary>Clicca per espandere</summary>
+
+Per distribuire BTCPay Server con supporto Zcash, avrai bisogno di quanto segue:
+
+### 1. VPS con Ubuntu 22.04 o più recente
+
+Consigliamo di usare un'installazione minima di **Ubuntu Server 22.04 LTS**.  
+Qualsiasi provider VPS che offra un indirizzo IP dedicato andrà bene.  
+
+**Requisiti minimi**:  
+- 2 core CPU  
+- 4 GB di RAM  
+- 40 GB di spazio su disco  
+
+Questa configurazione è sufficiente se usi lightwalletd per Zcash.  
+Se prevedi di eseguire un **full node Zcash**, avrai bisogno di **almeno 300 GB** di spazio libero su disco.
+
+---
+
+### 2. Nome di dominio che punta al tuo server
+
+Nel pannello di controllo del tuo provider DNS, crea un record `A` per un sottodominio  
+(ad esempio `btcpay.example.com`) che punti all'IP del tuo VPS.  
+
+Questo dominio verrà usato per accedere a BTCPay Server dal browser  
+e per generare automaticamente un **certificato SSL gratuito** tramite Let's Encrypt.
+
+---
+
+### 3. Accesso SSH al server
+
+Per installare BTCPay Server, devi connetterti al tuo VPS via SSH.  
+Dal tuo terminale, esegui:
+
+`ssh root@YOUR_SERVER_IP`
+
+Se usi macOS, Linux o WSL su Windows, SSH è già disponibile nel terminale.
+Su Windows nativo, usa un client SSH come **PuTTY**.
+
+---
+
+### 4. Installa Git, Docker e Docker Compose
+
+Una volta connesso via SSH, aggiorna i pacchetti di sistema e installa i componenti richiesti:
+
+```
+sudo apt update && sudo apt upgrade -y
+sudo apt install git curl docker.io docker-compose-plugin -y
+sudo systemctl enable docker
+```
+
+> Su Ubuntu 22.04 e versioni più recenti, `docker-compose` da APT è deprecato.
+> Il pacchetto consigliato è `docker-compose-plugin`, che fornisce il comando `docker compose` (nota lo spazio invece del trattino).
+
+L'ambiente del tuo server è ora pronto per l'installazione di BTCPay Server.
+
+</details>
+
+---
+
+### Passo 1: clona il repository
+
+Crea una directory di lavoro e scarica il deployment Docker di BTCPay Server:
+
+```
+mkdir BTCPayServer
+cd BTCPayServer
+git clone https://github.com/btcpayserver/btcpayserver-docker
+cd btcpayserver-docker
+```
+
+---
+
+### Passo 2: esporta le variabili d'ambiente
+
+Sostituisci `btcpay.example.com` con il tuo dominio effettivo:
+
+```
+export BTCPAY_HOST="btcpay.example.com"
+export NBITCOIN_NETWORK="mainnet"
+export BTCPAYGEN_CRYPTO1="btc"
+export BTCPAYGEN_CRYPTO2="zec"
+export BTCPAYGEN_REVERSEPROXY="nginx"
+export BTCPAYGEN_LIGHTNING="none"
+```
+
+> Se prevedi di aggiungere Monero o Litecoin in seguito, puoi includerli già ora:
+
+```
+export BTCPAYGEN_CRYPTO3="ltc"
+export BTCPAYGEN_CRYPTO4="xmr"
+```
+
+Puoi aggiungere nuove monete in qualsiasi momento esportando le variabili appropriate e rieseguendo lo script di configurazione:
+
+`. ./btcpay-setup.sh -i`
+
+Per questa guida, ci concentreremo **solo su Zcash**.
+
+---
+
+### Passo 3: esegui l'installer
+
+Esegui lo script di configurazione per compilare e avviare il server:
+
+`. ./btcpay-setup.sh -i`
+
+Lo script installerà le dipendenze, genererà il file `docker-compose.yml`, avvierà i servizi e configurerà `systemd`.
+Questo richiede circa 5 minuti.
+
+Una volta completato, la tua istanza di BTCPay Server sarà disponibile all'indirizzo:
+
+`https://btcpay.example.com`
+
+> Se stai modificando un'installazione esistente (ad esempio aggiungendo ZEC), assicurati di arrestare e riavviare il server con le nuove impostazioni:
+
+```
+cd ~/BTCPayServer/btcpayserver-docker
+btcpay-down.sh
+. ./btcpay-setup.sh -i
+```
+
+Poi prosegui alla sezione successiva per configurare Zcash nell'interfaccia web di BTCPay Server.
+
+
+
+## Eseguire il tuo full node Zcash
+
+Se preferisci **non** affidarti a nodi `lightwalletd` pubblici, puoi distribuire il tuo full node Zcash insieme a Lightwalletd sullo stesso server.  
+Questo ti garantisce la **piena autonomia** - nessuna dipendenza esterna, nessuna fiducia richiesta.
+
+---
+
+### Passo 1: assicurati di avere spazio su disco sufficiente
+
+Un full node Zcash (Zebra + Lightwalletd) richiede attualmente **300+ GB** di spazio su disco, e continua a crescere.
+
+Suddivisione:
+
+- Il database della blockchain Zebra: ~260-270 GB
+- L'indicizzazione di Lightwalletd: ~15-20 GB
+
+#### Spazio di archiviazione consigliato:
+
+- **400 GB+** se il server è usato **solo** per i pagamenti Zcash
+- **800 GB+** se il server esegue anche BTCPay Server, PostgreSQL, Nginx, ecc.
+
+> Idealmente usa un disco SSD/NVMe con **capacità di 1 TB**, soprattutto se non prevedi di effettuare il pruning dei dati con regolarità.
+
+---
+
+### Passo 2: imposta le variabili d'ambiente
+
+Aggiungi quanto segue alla configurazione del tuo ambiente per attivare la configurazione full node:
+
+```
+export BTCPAYGEN_EXCLUDE_FRAGMENTS="zcash"
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS="zcash-fullnode"
+```
+
+Questo includerà il fragment `zcash-fullnode`, che avvia sia `zebrad` che `lightwalletd` all'interno di BTCPay Server.
+
+---
+
+### Passo 3: riesegui l'installer
+
+`. ./btcpay-setup.sh -i`
+
+Lo script:
+
+* Scaricherà le immagini Docker per Zebra e Lightwalletd
+* Configurerà i servizi all'interno dello stack BTCPay
+* Collegherà il plugin Zcash all'istanza **locale** di `lightwalletd`
+
+> **La sincronizzazione completa della blockchain può richiedere diversi giorni**, specialmente su server VPS con poche risorse.
+> Finché la sincronizzazione non è completa, i pagamenti schermati non saranno disponibili.
+
+
+## Connettersi a un nodo Lightwalletd esterno
+
+Nella maggior parte dei casi, la piena autonomia non è necessaria - e i commercianti potrebbero non voler dedicare tempo e spazio su disco all'esecuzione di un full node Zcash.  
+Per impostazione predefinita, BTCPay Server si connette a un nodo `lightwalletd` pubblico per gestire i pagamenti schermati senza scaricare l'intera blockchain.
+
+L'endpoint predefinito è:
+
+`https://zec.rocks:443`
+
+Tuttavia, puoi configurare BTCPay Server per connettersi a **qualsiasi nodo `lightwalletd` esterno**, come:
+
+`https://lightwalletd.example:443`
+
+Questa sezione mostra come farlo usando un **fragment Docker personalizzato**.
+
+> Un esempio di configurazione completo con tutte le variabili d'ambiente è disponibile nel [repository del plugin](https://github.com/btcpay-zcash/btcpayserver-zcash-plugin/blob/master/docs/zcash-lightwalletd.custom.yml).  
+> I passaggi seguenti mostrano una configurazione minima funzionante.
+
+---
+
+### Passo 1: crea un fragment Docker personalizzato
+
+Nella directory del tuo progetto BTCPayServer, crea un file fragment personalizzato:
+
+```
+cd ~/BTCPayServer/btcpayserver-docker
+mkdir -p docker-compose-generator/docker-fragments
+nano docker-compose-generator/docker-fragments/zcash-lightwalletd.custom.yml
+```
+
+Aggiungi il seguente contenuto:
+
+```
+exclusive:
+- zcash
+```
+
+La direttiva `exclusive` garantisce che solo un fragment con la stessa etichetta (`zcash` in questo caso) possa essere attivo alla volta.
+Questo previene conflitti di configurazione - ad esempio, non puoi eseguire contemporaneamente il fragment `zcash-fullnode` e questo fragment personalizzato per il `lightwalletd` esterno.
+Marcandolo come `exclusive: zcash`, BTCPay Server disabiliterà automaticamente il fragment predefinito `zcash-fullnode` e i container `lightwalletd` interni, consentendoti di connetterti invece al tuo nodo esterno.
+
+---
+
+### Passo 2: imposta le variabili d'ambiente
+
+Nel terminale:
+
+```
+export BTCPAYGEN_EXCLUDE_FRAGMENTS="$BTCPAYGEN_EXCLUDE_FRAGMENTS;zcash"
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;zcash-lightwalletd.custom"
+```
+
+---
+
+### Passo 3: definisci l'indirizzo del nodo esterno
+
+Apri il tuo file `.env`:
+
+`nano .env`
+
+Aggiungi la seguente riga, sostituendo l'URL con l'endpoint che hai scelto:
+
+`ZCASH_LIGHTWALLETD=https://lightwalletd.example:443`
+
+Puoi usare:
+
+* Un **nodo pubblico**, come `https://lightwalletd.zcash-infra.com`
+* Il tuo nodo self-hosted, distribuito separatamente da BTCPay Server
+
+> Se il `lightwalletd` esterno diventa non disponibile o sovraccarico, i pagamenti schermati falliranno.
+> Per servizi critici, scegli un **endpoint stabile e collaudato** (come il predefinito `zec.rocks`).
+
+> Vuoi ospitare tu stesso `lightwalletd`?
+> Puoi usare il file `docker-compose.lwd.yml` dal [repository di Zebra](https://github.com/ZcashFoundation/zebra/blob/main/docker/docker-compose.lwd.yml).
+> **Attenzione:** questa configurazione non è documentata ufficialmente e richiede una configurazione manuale di TLS, port forwarding e firewall - consigliata solo per utenti esperti.
+
+---
+
+### Passo 4: riesegui l'installer
+
+`. ./btcpay-setup.sh -i`
+
+BTCPay Server applicherà la tua configurazione personalizzata e si connetterà al nodo `lightwalletd` specificato.
+
+D'ora in poi, il plugin Zcash utilizzerà quell'endpoint esterno per gestire le transazioni schermate.
+
+
+## Ospitare BTCPay Server a casa con Cloudflare Tunnel
+
+Vuoi accettare pagamenti Zcash ospitando BTCPay Server su un dispositivo domestico - come un Raspberry Pi 5 o qualsiasi server locale **senza un IP statico**?  
+Puoi esporre in modo sicuro la tua istanza a Internet usando **Cloudflare Tunnel**.
+
+Questo metodo evita il port forwarding e nasconde il tuo vero indirizzo IP al pubblico - mantenendo al contempo il server accessibile via HTTPS.
+
+Ti aiuta anche a **evitare il costo del noleggio di un VPS**, il che è ideale se i pagamenti in criptovaluta sono una funzionalità opzionale piuttosto che il cuore della tua attività.
+
+---
+
+### Passo 1: installa Cloudflare Tunnel
+
+1. Crea un account su [cloudflare.com](https://www.cloudflare.com) e aggiungi il tuo dominio.
+2. Sul tuo **server domestico**, installa Cloudflare Tunnel:
+
+```
+sudo apt update
+sudo apt install cloudflared --legacy
+```
+
+3. Autenticati con Cloudflare:
+
+`cloudflared tunnel login`
+
+Questo comando aprirà una finestra del browser. Accedi e autorizza l'accesso al tuo dominio.
+Cloudflare creerà automaticamente un file `credentials` con un token sul tuo server.
+
+4. Crea un nuovo tunnel (puoi chiamarlo `btcpay` o come preferisci):
+
+`cloudflared tunnel create btcpay`
+
+Questo genera un file `btcpay.json` contenente l'ID del tunnel e le credenziali - ti servirà nel passaggio successivo.
+
+---
+
+### Passo 2: crea il file di configurazione del tunnel
+
+Crea la directory di configurazione (se non esiste) e apri il file di configurazione:
+
+```
+sudo mkdir -p /etc/cloudflared
+sudo nano /etc/cloudflared/config.yml
+```
+
+Incolla la seguente configurazione:
+
+```
+tunnel: btcpay    # il nome del tuo tunnel
+credentials-file: /root/.cloudflared/btcpay.json
+
+ingress:
+  - hostname: btcpay.example.com      # il tuo dominio
+    service: http://127.0.0.1:80
+  - service: http_status:404
+```
+
+#### Spiegazione:
+
+* `tunnel` - nome del tunnel che hai creato in precedenza
+* `credentials-file` - percorso del file token generato durante `cloudflared tunnel login`
+* `hostname` - il tuo dominio registrato con Cloudflare (ad esempio `btcpay.example.com`)
+* `service` - indirizzo locale del tuo BTCPay Server (di solito `http://127.0.0.1:80` per Nginx)
+
+> Cloudflare farà da proxy al traffico verso il tuo server locale in modo sicuro, senza esporre il tuo IP domestico.
+
+
+### Passo 3: aggiungi un record DNS per il tuo tunnel
+
+Dopo aver creato il tunnel, Cloudflare di solito **aggiunge automaticamente un record DNS CNAME** per il tuo dominio. Dovrebbe avere questo aspetto:
+
+`btcpay.example.com -> <UUID>.cfargotunnel.com`
+
+Se non appare automaticamente, aggiungilo manualmente:
+
+1. Vai alla tua [Dashboard di Cloudflare](https://dash.cloudflare.com/)
+2. Vai alla sezione **DNS**
+3. Aggiungi un nuovo record CNAME:
+   - **Name**: `btcpay`
+   - **Target**: `<UUID>.cfargotunnel.com`  
+     Puoi trovare il valore esatto nel tuo file `btcpay.json` o eseguendo:
+     
+     `cloudflared tunnel list`
+     
+   - **Proxy status**: abilitato (nuvola arancione)
+
+> Questo record garantisce che tutte le richieste a `btcpay.example.com` vengano instradate attraverso Cloudflare Tunnel, nascondendo al pubblico il tuo vero IP.
+
+---
+
+### Passo 4: abilita il tunnel all'avvio del sistema
+
+Per far sì che il tunnel venga eseguito automaticamente all'avvio, installalo come servizio di sistema:
+
+`sudo cloudflared service install`
+
+Quindi abilita e avvia il servizio:
+
+```
+sudo systemctl enable cloudflared
+sudo systemctl start cloudflared
+```
+
+Controlla lo stato:
+
+`sudo systemctl status cloudflared`
+
+Dovresti vedere un messaggio come `Active: active (running)` e la conferma che `btcpay.example.com` è online.
+
+> D'ora in poi, il tunnel si avvierà automaticamente a ogni riavvio, e il tuo BTCPay Server sarà accessibile pubblicamente - senza port forwarding e senza esporre il tuo vero IP.
+
+---
+
+### Passo 5: finalizza la configurazione di BTCPay Server
+
+Se stai per installare BTCPay Server per la prima volta, imposta il tuo dominio prima di eseguire lo script di configurazione:
+
+`export BTCPAY_HOST="btcpay.example.com"`
+
+Questo garantisce che venga usato il dominio corretto quando si generano la **configurazione di Nginx** e i **certificati SSL**.
+
+Se BTCPay Server è già installato e stai solo aggiungendo il tunnel:
+
+```
+cd ~/BTCPayServer/btcpayserver-docker
+. ./btcpay-setup.sh -i
+```
+
+La configurazione rigenererà i file di configurazione e applicherà il nuovo dominio.
+Dovresti ora essere in grado di accedere al tuo server all'indirizzo:
+
+`https://btcpay.example.com`
+
+> Che tu stia usando un `lightwalletd` pubblico o il tuo full node, questo non influisce sul tunnel.
+> Tutto ciò che conta è che BTCPay Server sia in ascolto localmente su `127.0.0.1:80`.
+
+
+## Configurare il plugin Zcash nell'interfaccia web di BTCPay Server
+
+> **Importante per le configurazioni multi-negozio:**  
+> Il wallet Zcash configurato qui è **globale** per l'istanza. Tutti i negozi useranno questo wallet a meno che tu non esegua istanze BTCPay separate.
+
+Dopo aver distribuito con successo la tua istanza di BTCPay Server, dovrai eseguire alcune configurazioni di base tramite l'interfaccia web di amministrazione.  
+La documentazione ufficiale fornisce istruzioni complete in inglese - qui vedremo i passaggi essenziali e ci concentreremo specificamente sulla configurazione del plugin Zcash.
+
+---
+
+### Passo 1: accedi all'interfaccia web
+
+Visita la tua istanza all'indirizzo:
+
+`[https://btcpay.example.com](https://btcpay.example.com)`
+
+- Inserisci il tuo login e la tua password di amministratore.
+- Se è la prima volta che accedi, ti verrà chiesto di creare un account.
+- Il primo account che registri otterrà automaticamente i privilegi di amministratore.
+
+---
+
+### Passo 2: installa il plugin Zcash
+
+1. Nel menu principale, vai a:
+
+`Plugins -> Browse Plugins`
+
+2. Individua il plugin **Zcash (ZEC)**. Usa la barra di ricerca se necessario.
+3. Clicca **Install** e conferma.
+
+> Ripeti questo processo per qualsiasi altra altcoin che hai abilitato durante la configurazione del server.
+
+Dopo l'installazione, clicca **Restart Server** per ricaricare l'interfaccia con i plugin attivi.
+
+
+### Passo 3: collega il tuo wallet tramite Viewing Key
+
+Dopo aver installato il plugin, apparirà una nuova sezione **Zcash** nel menu delle impostazioni.
+
+1. Vai a:
+
+`Zcash -> Settings`
+
+2. Incolla la tua **Unified Full Viewing Key (UFVK)** - BTCPay deriverà un Unified Address per ogni fattura e rileverà i pagamenti schermati in entrata.
+
+> **Nota:** le Viewing Key Sapling legacy sono supportate, ma per usare gli indirizzi Orchard/Unified dovresti fornire una **UFVK**.
+
+
+   Formato di esempio:
+
+`uview184syv9wftwngkay8d...`
+
+3. Inserisci un valore nel campo Block height
+
+* **Prima configurazione con un nuovo wallet (nuova frase seed):** inserisci l'attuale block height di Zcash (puoi verificarlo su 3xpl.com/zcash) - questo velocizza la scansione iniziale.
+* **Migrazione sullo stesso server da una configurazione legacy solo Sapling agli Unified Address / Orchard:** lascia questo campo vuoto.
+* **Spostamento del tuo negozio su un nuovo server con lo stesso wallet/UFVK:** facoltativamente inserisci la birth height - un'altezza approssimativa del primo ordine pagato del tuo negozio (fai corrispondere la data dell'ordine su 3xpl per restringere la scansione). Se non sei sicuro, lascialo vuoto.
+
+> Non tutti i wallet supportano ancora l'esportazione della **Unified Full Viewing Key (UFVK)**.  
+> Opzioni consigliate:  
+> – [**YWallet**](https://ywallet.app/installation)  
+> – [**Zingo! Wallet (versione per PC)**](https://zingolabs.org/)  
+> In entrambe le app, cerca l'esportazione UFVK nella sezione di backup/esportazione.
+
+Queste chiavi supportano la **rotazione automatica degli indirizzi**, il che significa:
+- Ogni cliente ottiene un indirizzo di pagamento **univoco**
+- Tu vedi un **unico saldo unificato**
+
+Puoi trovare un elenco di compatibilità più ampio su [ZecHub -> Wallets](https://zechub.wiki/wallets).
+
+Una volta compilati tutti i campi, clicca **Save**.
+
+---
+
+### Testa il tuo flusso di pagamento ZEC
+
+Congratulazioni - il tuo wallet Zcash è ora collegato a BTCPay Server.
+
+Eseguiamo un test:
+
+1. Vai a:
+
+`Invoices -> Create New`
+
+2. Genera una fattura di prova per un piccolo importo in ZEC.
+3. Invia i fondi da **un wallet diverso** (non quello collegato a BTCPay).
+4. Una volta rilevata la transazione, la pagina della fattura mostrerà un'animazione di celebrazione.
+5. Verifica che lo stato della fattura cambi in **Paid**.
+
+Se tutto funziona - sei pronto a integrare i pagamenti ZEC nel tuo sito web usando l'API o i plugin CMS.
+
+
+
+## Integrare BTCPay Server con il tuo sito web
+
+Una volta collegato il tuo wallet Zcash a BTCPay Server, puoi integrare il sistema di pagamento nel tuo sito web.  
+Ci sono diversi modi per farlo - dall'accesso diretto all'API ai plugin pronti all'uso per le piattaforme CMS più popolari.
+
+---
+
+### Opzioni di integrazione
+
+- **Integrazione tramite API**  
+  Ideale per siti web personalizzati o sistemi senza CMS.  
+  Ti dà il pieno controllo sulla creazione delle fatture, sul tracciamento dei pagamenti e sulle notifiche - tutto all'interno della tua interfaccia e della tua logica.  
+  Richiede conoscenze di programmazione di base, quindi questo compito è meglio affidato al tuo sviluppatore.
+
+- **Plugin CMS**  
+  Disponibili per piattaforme come **WooCommerce**, **PrestaShop** e altre.  
+  Questi plugin ti permettono di accettare pagamenti in pochi minuti - senza scrivere codice.
+
+- **Pulsante di pagamento o iframe**  
+  Il metodo più semplice.  
+  Perfetto per landing page, siti web personali o qualsiasi sito in cui vuoi semplicemente incorporare un link per donazioni o un widget di checkout.
+
+---
+
+### Integrazione tramite API
+
+Se usi una piattaforma personalizzata (o nessun CMS), l'API è l'opzione migliore.  
+Ti offre completa flessibilità: puoi creare fatture, tracciarne lo stato, ricevere notifiche e controllare completamente l'esperienza utente.
+
+> Nota: anche alcuni plugin CMS usano l'API internamente, quindi creare una chiave API è spesso il **primo passo necessario**, indipendentemente dal tuo metodo di integrazione.
+
+Passo successivo: genera una chiave API per il tuo negozio e inizia a usare la [Greenfield API](https://docs.btcpayserver.org/API/Greenfield/v1/) per costruire la tua integrazione.
+
+
+### Generare una chiave API
+
+Per integrare BTCPay Server con il tuo sito web o app, dovrai generare una chiave API.
+
+1. Accedi a BTCPay Server e apri il **menu utente** (angolo in alto a destra)
+2. Vai su **API Keys**
+3. Clicca **Create a new API key**
+4. Inserisci un nome per la tua chiave
+5. Nella sezione **Permissions**, abilita:
+   - `Can create invoice`
+   - `Can view invoice`
+   - *(Facoltativo)* `Can modify store settings` - solo se hai bisogno della gestione a livello di negozio
+
+6. Clicca **Generate**. La tua chiave API personale verrà visualizzata - copiala e conservala in modo sicuro.
+
+> Questa chiave concede l'accesso alle fatture del tuo negozio.  
+> Non condividerla pubblicamente e non esporla nel codice lato client.
+
+---
+
+### Esempio: creare una fattura tramite API
+
+**Endpoint:**
+
+```
+POST /api/v1/stores/{storeId}/invoices
+Authorization: token {apiKey}
+Content-Type: application/json
+```
+
+**Corpo della richiesta:**
+
+```
+{
+  "amount": 5,
+  "currency": "ZEC",
+  "checkout": {
+    "speedPolicy": "HighSpeed",
+    "paymentMethods": ["Zcash"]
+  }
+}
+```
+
+**Risposta:**
+
+Riceverai un oggetto JSON con:
+
+* `invoiceId`
+* Un URL di pagamento che puoi incorporare nel tuo sito web o inviare al cliente
+
+Vedi la documentazione completa:
+[Greenfield API – Create Invoice](https://docs.btcpayserver.org/API/Greenfield/v1/#operation/CreateInvoice)
+
+---
+
+### Configurare un webhook (facoltativo)
+
+Per ricevere notifiche in tempo reale quando lo stato delle fatture cambia (ad esempio quando viene ricevuto un pagamento):
+
+1. Vai alle impostazioni del tuo negozio -> **Webhooks**
+2. Aggiungi l'URL dell'endpoint del tuo backend che gestirà le richieste `POST` da BTCPay Server
+3. BTCPay invierà automaticamente notifiche quando una fattura viene pagata o scade
+
+I payload dei webhook e la logica di retry sono descritti nella [documentazione ufficiale dei webhook](https://docs.btcpayserver.org/FAQ/General/#how-to-create-a-webhook-).
+
+> Esempi di integrazione sono disponibili per vari linguaggi di programmazione nei documenti BTCPay e nei repository GitHub.
+
+
+
+### Integrazione CMS
+
+BTCPay Server supporta plugin per i più popolari sistemi di gestione dei contenuti (CMS).  
+L'integrazione più matura e diffusa è quella con **WordPress + WooCommerce**, che rende facile accettare pagamenti ZEC **senza scrivere codice**.
+
+---
+
+#### WooCommerce (WordPress)
+
+BTCPay Server supporta ufficialmente un plugin per WooCommerce.
+
+Passaggi per l'integrazione:
+
+1. Installa il plugin **BTCPay for WooCommerce** dalla directory dei plugin di WordPress o da GitHub.
+2. Nel pannello di amministrazione di WordPress, vai a:
+
+`WooCommerce -> Settings -> Payments`
+
+3. Trova **BTCPay** nell'elenco e clicca **Set up**
+4. Inserisci l'URL del tuo BTCPay Server e segui le istruzioni di autorizzazione  
+   (è consigliata la generazione automatica della chiave API)
+5. Abilita il metodo di pagamento e salva le impostazioni
+
+> Istruzioni dettagliate, video tutorial e guide alla risoluzione dei problemi sono disponibili nella documentazione del plugin.
+
+Troverai anche altre opzioni di integrazione CMS in quella stessa sezione dei documenti BTCPay.
+
+---
+
+### Pulsante di pagamento o iframe (senza CMS o API)
+
+Se non usi un CMS e non vuoi lavorare con le API, il modo più semplice per accettare pagamenti ZEC è **incorporare un link o un widget di pagamento** direttamente nel tuo sito web.
+
+Questo metodo è ideale per:
+
+- Landing page
+- Siti portfolio
+- Blog o pagine statiche
+- Progetti senza un server backend
+
+---
+
+#### Opzione 1: pulsante di pagamento (link)
+
+1. In BTCPay Server, crea manualmente una fattura nella sezione **Invoices**
+2. Copia il link di pagamento, ad esempio:
+
+`[https://btcpay.example.com/i/abc123](https://btcpay.example.com/i/abc123)`
+
+3. Aggiungi il link al tuo HTML:
+
+```
+<a href="https://btcpay.example.com/i/abc123" target="_blank">
+  Pay with ZEC
+</a>
+```
+
+---
+
+#### Opzione 2: fattura incorporata (iframe)
+
+Per visualizzare la fattura direttamente sul tuo sito, usa un iframe:
+
+`<iframe src="https://btcpay.example.com/i/abc123" width="600" height="350" frameborder="0"></iframe>`
+
+> Puoi personalizzare lo stile del pulsante o del contenitore iframe per adattarlo al design del tuo sito - BTCPay Server consente una personalizzazione flessibile della pagina della fattura.
+
+## Conclusione
+
+Questa guida è stata lunga - ma copre solo gli aspetti fondamentali dell'integrazione dei pagamenti Zcash con BTCPay Server.
+
+L'interfaccia di BTCPay Server offre molte più funzionalità di quelle mostrate qui. Fortunatamente, l'interfaccia è disponibile in più lingue (incluso il russo), il che rende facile esplorare e sperimentare ulteriormente.
+
+BTCPay è uno strumento estremamente flessibile. Puoi:
+
+* Ospitare più negozi indipendenti su un'unica istanza
+* Definire ruoli e permessi personalizzati per i membri del team - dalla sola visualizzazione degli ordini all'amministrazione completa
+* Usare i tuoi domini e il tuo branding
+* Configurare webhook, wallet di riserva e persino l'accesso tramite Tor
+* Configurare impostazioni avanzate come regole fiscali, codici sconto, personalizzazione della pagina di checkout, restrizioni sui metodi di pagamento e altro ancora
+
+BTCPay è stato costruito come alternativa open-source ai fornitori di pagamenti centralizzati. Se stai cercando di accettare pagamenti privati in ZEC senza intermediari, questa piattaforma merita assolutamente la tua attenzione.
+
+Ti auguriamo buona fortuna nell'esplorare l'ecosistema BTCPay e nel rendere i tuoi pagamenti veramente tuoi.
+
+## Risorse
+
+* [Sito web ufficiale di BTCPay Server](https://btcpayserver.org/)
+* [FAQ di BTCPay](https://docs.btcpayserver.org/FAQ/)
+* [Repository GitHub di BTCPay Server](https://github.com/btcpayserver/btcpayserver)
+* [Demo Mainnet di BTCPay Server](https://mainnet.demo.btcpayserver.org/login?ReturnUrl=%2F)
+* [Plugin Zcash per BTCPay (GitHub)](https://github.com/btcpay-zcash/btcpayserver-zcash-plugin)
+* [Guida all'installazione del plugin Zcash](https://github.com/btcpay-zcash/btcpayserver-zcash-plugin/blob/master/docs/installation.md)
+* [Esempio di zcash-lightwalletd.custom.yml personalizzato](https://github.com/btcpay-zcash/btcpayserver-zcash-plugin/blob/master/docs/zcash-lightwalletd.custom.yml)
+* [File Docker Compose di Lightwalletd (Zebra)](https://github.com/ZcashFoundation/zebra/blob/main/docker/docker-compose.lwd.yml)
+* [Documentazione delle chiavi API di BTCPay (Greenfield API)](https://docs.btcpayserver.org/API/Greenfield/v1/#tag/API-Keys)
+* [Creare un Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-remote-tunnel/)
+* [Elenco di compatibilità dei wallet Zcash (ZecHub)](https://zechub.wiki/wallets)
+* [Zebra + Lightwalletd su Raspberry Pi 5 (ZecHub)](https://free2z.com/ZecHub/zpage/zcash-101-zebra-lightwalletd-sync-journal-on-raspberry-pi-5)

--- a/translations/it/site/guides/Blockchain_Explorers.md
+++ b/translations/it/site/guides/Blockchain_Explorers.md
@@ -1,0 +1,94 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Blockchain_Explorers.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Block explorer
+
+## Introduzione
+
+Nel mondo degli affari tradizionale ogni transazione include una ricevuta come prova d'acquisto. Allo stesso modo, nel mondo della blockchain un utente riceve una ricevuta digitale sotto forma di id della transazione per ogni transazione completata. La maggior parte dei wallet te la fornisce. I block explorer sono semplicemente strumenti che permettono di visualizzare ciò che è già accaduto su una blockchain. Prendono in input: id delle transazioni, indirizzi o hash dei blocchi, e mostrano visivamente ciò che è avvenuto.
+
+## Esempi
+<div>
+
+- Bitcoin: [c839b44a7052393f4672cdc4ec79f8f15d3036565e13bede0fab91f674506a7c](https://mempool.space/tx/c839b44a7052393f4672cdc4ec79f8f15d3036565e13bede0fab91f674506a7c)
+
+- Ethereum: [0x43117fc201f8d3c09a72d42ab4a048003f348917771b9ace64b8944a91807320](https://etherscan.io/tx/0x43117fc201f8d3c09a72d42ab4a048003f348917771b9ace64b8944a91807320)
+
+- Cosmos: [D0587C76E7689A9EFBDDA587DDB450F6C6E972FCEEA37DD8DA9AF95C23CF8170](https://www.mintscan.io/cosmos/txs/D0587C76E7689A9EFBDDA587DDB450F6C6E972FCEEA37DD8DA9AF95C23CF8170)
+
+- Zcash (pubblica): [8dd212847a97c5eb9cee5e7e58c4d9e739f4156273ae3b2da1a4ff79ad95ff82](https://explorer.zec.rocks/transactions/8dd212847a97c5eb9cee5e7e58c4d9e739f4156273ae3b2da1a4ff79ad95ff82)
+
+- Zcash (privata): [19a4be270089490ece2e5fe7a6c9b9804af3c7ed43e1fb1b744b0fb29070fa5d](https://explorer.zec.rocks/transactions/19a4be270089490ece2e5fe7a6c9b9804af3c7ed43e1fb1b744b0fb29070fa5d)
+
+</div>
+
+
+#### Nota come, con Zcash, la seconda transazione abbia tutti i dettagli importanti nascosti; questo è importante e ha grandi implicazioni in un mondo digitale.
+
+
+## Mappe della blockchain
+
+Quindi abbiamo questa lunga stringa di caratteri come ricevuta digitale, e adesso? È qui che usiamo un [block explorer](https://nym.com/blog/using-blockchain-privately), o mappa, per aiutarci a digerire ciò che è accaduto sulla blockchain. Nota come ciascuna chain abbia sopra la propria versione di [block explorer](https://nym.com/blog/using-blockchain-privately). È importante capire che tutti questi progetti blockchain sono esempi di software open source. Cioè, chiunque può contribuire e/o forkare il codice a proprio piacimento. Con questa comprensione, ciascun progetto si specializza in aree diverse e personalizza il block explorer per adattarlo alle esigenze di quel progetto.
+
+### Blocchi
+Le transazioni vengono inserite nei *blocchi*. Quando un blocco viene minato/validato, ogni transazione al suo interno viene confermata e viene creato un hash del blocco. Qualsiasi hash creato può essere inserito in un block explorer. Potresti aver visto i CEX richiedere un certo numero di *conferme* prima di rilasciare i tuoi fondi: questa è la metrica che usano per assicurarsi che la tua transazione sia 
+sufficientemente finalizzata. Come fa la blockchain a determinare quali transazioni entrano nel prossimo blocco? È un argomento di ricerca complesso, ma la maggior parte delle chain moderne usa l'idea delle *commissioni* per determinare chi finisce in cima alla coda. Più alta è la commissione, più alta è la probabilità di avanzare verso la testa della coda.
+
+### Indirizzi
+
+Un modo divertente per imparare visivamente i [block explorer](https://nym.com/blog/using-blockchain-privately) è inserire l'indirizzo di una qualsiasi transazione casuale. Poi puoi muoverti indietro nel tempo e vedere da dove provenivano i fondi! Ogni transazione ha sia un indirizzo di input che uno di output.  Armati di queste informazioni, si può facilmente muoversi sia in avanti che indietro a partire da qualsiasi transazione che sia stata spesa. Per chi ama gli enigmi, questo è l'equivalente digitale di un enorme puzzle finanziario e potrebbe essere usato a fini di trasparenza. Usare un block explorer non solo rende tutto questo molto più facile da visualizzare, ma *mette anche in evidenza* la necessità della privacy nelle transazioni. A meno che tu non stia usando Zcash schermato, puoi farlo con *qualsiasi* blockchain trasparente: BTC, ETH, ATOM, DOGE, VTC, ecc. ... . Questo punto è critico per chiunque usi la blockchain in modo sicuro avviandosi verso un futuro solo digitale.
+
+### Importi
+
+Analogamente agli indirizzi di cui sopra, qualsiasi transazione su una blockchain pubblica ha gli importi disponibili pubblicamente, in bella vista. Questo include gli importi sia sugli indirizzi di input che su quelli di output di qualsiasi transazione. Un'eccezione a questo è quando scegli di usare Zcash schermato: allora tutti gli importi sono nascosti. Per i piccoli imprenditori che hanno necessariamente bisogno di privacy per un *commercio equo*, questo è un enorme vantaggio!
+
+![amounts](https://user-images.githubusercontent.com/81990132/206312357-e9504151-830f-4fa1-81cb-f23619fd7226.png)
+
+
+### Cosa un explorer può e non può vedere su Zcash
+
+#### TL;DR
+- Gli indirizzi trasparenti (`t`) sono completamente visibili su un explorer, proprio come Bitcoin
+- Le transazioni completamente schermate (da z a z) nascondono l'importo, gli indirizzi e il memo
+- La commissione è comunque visibile, anche su una transazione completamente schermata
+- Lo shielding (spostare `t` verso schermato) e il deshielding (da schermato di nuovo a `t`) sono parzialmente visibili, perché un lato è trasparente
+- La privacy si mantiene solo finché i fondi restano dentro i pool schermati
+
+Zcash ha più di un tipo di indirizzo, e un explorer li tratta in modo molto diverso.
+
+Gli indirizzi trasparenti, che iniziano con `t`, funzionano come Bitcoin. Un explorer mostra il mittente, il destinatario, l'importo e la scia che riconduce a dove provenivano i fondi.
+
+Gli indirizzi schermati sono il lato privato. I fondi nei [pool schermati](https://zechub.wiki/using-zcash/shielded-pools#content) Sapling o Orchard sono protetti da prove a conoscenza zero. Cerca una transazione completamente schermata e l'explorer non può mostrare l'importo, gli indirizzi o il memo. Può confermare solo che è avvenuta una transazione valida ed è stata registrata in un blocco. Questo è l'esempio privato nascosto mostrato in cima a questa pagina.
+
+Un dettaglio resta comunque visibile anche per le transazioni completamente schermate: la commissione. Le regole di consenso di Zcash richiedono che la commissione trasparente sia dichiarata esplicitamente, quindi un explorer può sempre mostrarla, anche quando gli importi sono mascherati. Per questo motivo è buona pratica usare la commissione standard del wallet, così che la tua transazione non si distingua per il pagamento di un importo insolito.
+
+L'explorer può anche vedere quando i fondi attraversano tra il lato trasparente e quello schermato. Spostare fondi `t` in un pool è lo shielding, riportarli fuori è il deshielding. Questi attraversamenti sono parzialmente visibili perché un lato è trasparente. Solo l'attività completamente privata da z a z, che non tocca mai un indirizzo `t`, mantiene nascosto tutto tranne la commissione.
+
+La conclusione: la privacy dipende dal restare dentro i pool schermati. Una volta che i fondi toccano un indirizzo `t`, quella parte della loro storia è pubblica quanto Bitcoin. Per dimostrare la tua attività schermata a qualcuno che scegli tu, come un commercialista, condividi una viewing key invece di renderla pubblica. Vedi la pagina [Viewing Key](https://zechub.wiki/zcash-tech/viewing-keys#content).
+
+
+### Guida visiva
+
+Ecco quattro buoni esempi di diversi block explorer:
+
+* [Mempool.space](https://mempool.space)
+* [Ethscan](https://etherscan.io/)
+* [Zcash Block Explorer](https://mainnet.zcashexplorer.com)
+* [Mintscan](https://hub.mintscan.io/chains/ibc-network)
+
+
+![bitcoinExlporer](https://user-images.githubusercontent.com/81990132/206279968-a06eb0a1-b3a6-49af-a30f-7d871b906eeb.png)
+
+
+![ethExplorer](https://user-images.githubusercontent.com/81990132/206280208-2ce5eddd-157e-4eed-90a0-680c1520ec57.png)
+
+
+![zcashExplorer](https://user-images.githubusercontent.com/81990132/206280454-a2c7563f-e82d-47b9-9b58-02eece1c89ee.png)
+
+
+![cosmos](https://user-images.githubusercontent.com/81990132/206316791-2debfd28-923a-44f4-b7d3-701182112c30.png)
+
+
+
+

--- a/translations/it/site/guides/Brave_Wallet_Guide.md
+++ b/translations/it/site/guides/Brave_Wallet_Guide.md
@@ -1,0 +1,135 @@
+# Come inviare e ricevere Zcash (ZEC) schermato con Brave Wallet: una guida passo passo alla privacy
+
+Brave Wallet è un wallet crypto sicuro e nativo, integrato direttamente nel browser Brave, senza bisogno di estensioni.
+
+
+## Perché il supporto a ZEC schermato è importante
+
+
+Zcash è una delle uniche criptovalute a offrire la privacy di default con le transazioni schermate.
+
+Brave Wallet ora supporta ZEC schermato con Orchard, abilitando transazioni private senza software di terze parti.
+
+Gli utenti possono ora inviare/ricevere ZEC senza rivelare saldi o metadati, il tutto all'interno del browser Brave.
+
+
+## Tutorial
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/TNcHY-GXFVo"
+    title="How to use ZEC on Brave"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+## Parte 1: configurare Brave Wallet
+
+**Passaggi trattati:**
+
+1. Apri il browser Brave (per ora solo desktop)
+
+2. Clicca sull'icona del Wallet o vai su brave://wallet
+
+3. Configura il tuo wallet (crealo o importalo)
+
+4. Accedi alla dashboard crypto
+
+
+![img1](https://github.com/user-attachments/assets/f54cd1a1-8569-4925-ba1c-7597d030593e)
+
+
+## Parte 2: aggiungere Zcash (ZEC) a Brave Wallet
+
+**Passaggi trattati:**
+
+1. Nella dashboard del Wallet, clicca su "Manage Assets"
+
+2. Cerca ZEC e abilitalo
+
+3. ZEC ora appare nel tuo wallet
+
+
+![img2](https://github.com/user-attachments/assets/6f2b2190-cf55-4394-9d5f-29ff9b5bb525)
+
+
+## Parte 3: ricevere ZEC schermato (Unified Address)
+
+**Passaggi trattati:**
+
+1. Clicca su ZEC nei tuoi asset
+
+2. Seleziona "Receive"
+
+3. Brave genera un Unified Address (UA): un unico indirizzo che supporta sia transazioni schermate che trasparenti
+
+4. Copia o scansiona il codice QR
+
+5. Condividi il tuo UA con il mittente
+
+
+
+![img3](https://github.com/user-attachments/assets/53c940b6-1a03-4fa7-aefa-d3478f678a88)
+
+
+
+## Parte 4: inviare ZEC schermato in modo privato
+
+**Passaggi trattati:**
+
+1. Seleziona ZEC -> Send
+
+2. Incolla l'Unified Address o l'indirizzo schermato del destinatario
+
+3. Inserisci l'importo
+
+4. Conferma i dettagli della transazione
+
+5. Clicca su Send: i fondi vengono ora trasferiti in modo privato, usando il pool Orchard
+
+
+![img4](https://raw.githubusercontent.com/Kellyjoe8/zechub/refs/heads/main/Internet_20250808_172118_4.webp)
+
+
+
+
+## Tipi di indirizzo
+
+Ecco una spiegazione per ciascun tipo di indirizzo Zcash:
+
+**indirizzo-t (t1...)** - Gli indirizzi trasparenti funzionano come gli indirizzi Bitcoin, il che significa che le transazioni sono pubbliche sulla blockchain. Sono più facili da usare con wallet non-Zcash, ma non offrono privacy.
+
+**indirizzo-z (zs...)** - Gli indirizzi schermati usano la tecnologia di privacy di Zcash (Sprout/Sapling) per nascondere mittente, destinatario e importo. Solo le view key o il proprietario possono rivelarne i dettagli.
+
+**UA (u... o QR)** - Gli Unified Address combinano più tipi di indirizzo (trasparente, schermato, Orchard) in uno solo. Questo consente la massima compatibilità privilegiando al contempo la privacy dove possibile.
+
+
+
+## Avanzato
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/AmTMa5HXa2w"
+    title="Brave Wallet Tutorial : Defi with Near Intents and Shielded Zcash"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+    
+
+## Conclusione: la privacy resa pratica
+
+Con Brave Wallet e ZEC schermato, la privacy è ora accessibile a tutti, senza software speciali o conoscenze avanzate.
+
+Ideale per giornalisti, attivisti o persone attente alla privacy.
+
+Prova oggi stesso la tua prima transazione schermata all'interno di Brave!
+
+
+**Resta privato. Resta libero. Invia ZEC in modo privato con Brave Wallet.**

--- a/translations/it/site/guides/Free2Z_Livestreaming.md
+++ b/translations/it/site/guides/Free2Z_Livestreaming.md
@@ -1,0 +1,63 @@
+# Livestreaming su Free2Z
+
+Ehi, come va? ZecHub mantiene davvero le promesse quando si tratta di wiki. Oggi siamo entusiasti di condividere con te alcune novità sulla piattaforma Free2Z. Se non ne hai ancora sentito parlare, questa guida ti darà un'idea della piattaforma e di come funziona.
+
+**Cos'è Free2Z?**
+
+Free2Z è nata come piattaforma incentrata sulla privacy, costruita per permettere ai creativi di mostrare i propri contenuti al mondo e guadagnare donazioni usando Zcash, la moneta digitale nota per le sue caratteristiche uniche di privacy.
+
+**Come faccio a unirmi alla Community?**
+
+* Per prima cosa, crea un account sul loro sito ufficiale [https://free2z.cash](https://free2z.cash).
+* Trova il pulsante di login nell'angolo in alto a destra della pagina. Inserisci le tue credenziali. Puoi anche creare un account con il tuo indirizzo email o il tuo account X.
+
+![](https://i.ibb.co/VWhmwy4s/IMG-9351.jpg)
+
+* Congratulazioni per essere entrato a far parte della community\! Ora è il momento di personalizzare il tuo profilo caricando un avatar, un banner e una descrizione di chi sei e di cosa fai.
+
+![](https://i.ibb.co/yBFPnr17/IMG-9360.jpg)
+
+* Assicurati di aggiungere anche il tuo indirizzo Zcash nel campo del wallet per ricevere donazioni e mance dai sostenitori.
+
+![](https://i.ibb.co/qLLKCr34/IMG-9361.jpg)
+
+**FUNZIONALITÀ**
+
+**ZPages:** Le ZPages permettono ai creatori di condividere i propri lavori scritti con una comunità più ampia. Un aspetto particolarmente interessante dello scrivere su questa piattaforma è che il tuo pubblico può sostenere il tuo lavoro tramite donazioni, un ottimo modo per mostrare apprezzamento.
+
+![](https://i.ibb.co/BKyx1xc0/IMG-9365.jpg)
+
+**Conoscere i 2Zs**
+
+Sono punti che valgono $0,01 sulla piattaforma. Con i 2Zs, le persone possono sostenere i loro creativi preferiti tramite donazioni e abbonamenti. Possono anche partecipare ad attività della community come votazioni, commenti sulle ZPages, content boosting e funzionalità di livestream.
+
+![](https://i.ibb.co/1G9YyMz7/IMG-9370.jpg)
+
+Tramite donazioni, abbonamenti e livestream a pagamento (pay-per-view), puoi guadagnare 2Zs. Puoi anche acquistare punti con ZEC semplicemente scansionando il tuo codice QR.
+
+![](https://i.ibb.co/JjpCHK9N/IMG-9381.jpg)
+![](https://i.ibb.co/HLJDbFwX/IMG-9379.jpg)
+
+**Come Avviare un Livestream**
+
+Clicca sull'icona del tuo profilo e apparirà un elenco a discesa. Seleziona "Stream" e dovresti vedere quattro opzioni di livestream. Seleziona semplicemente quella più adatta alle tue esigenze e premi il pulsante per avviare lo stream. Permetti a Free2Z di usare la tua videocamera e il tuo microfono. Free2Z ti chiederà di inserire un nickname che vorresti usare durante la diretta. Dopodiché, premi il pulsante Join per dare il via alla diretta. I tuoi iscritti possono unirsi alla diretta. Puoi anche copiare l'URL della diretta dal tuo browser e condividerlo con gli amici perché si uniscano.
+
+[https://free2z.cash/Cjfrankie/broadcast](https://free2z.cash/Cjfrankie/broadcast)
+
+
+**Private Beta**
+
+Questa opzione promette di offrire crittografia end-to-end, riunioni private e un link di riunione univoco che può essere inviato ai partecipanti.
+
+![](https://i.ibb.co/zTnTHXLz/IMG-9374.jpg)
+
+**Cos'altro puoi ottenere dal livestream?**
+
+Il livestream di Free2Z offre alcuni vantaggi unici, come sondaggi per prendere decisioni e plugin come la condivisione di documenti e la lavagna, perfetti per presentazioni, condivisione dello schermo, chat e molto altro!
+
+![](https://i.ibb.co/2m17ttc/IMG-9375.jpg)
+![](https://i.ibb.co/HfnTFFxs/IMG-9377.jpg) 
+
+Ecco come appare una sessione di livestream su Free2Z
+
+![](https://i.ibb.co/SwzQ6wPw/Screenshot-2025-05-25-053026.png)

--- a/translations/it/site/guides/Free2z_Live.md
+++ b/translations/it/site/guides/Free2z_Live.md
@@ -1,0 +1,195 @@
+[![Edit Page](https://img.shields.io/badge/Edit-blue)](https://github.com/zechub/zechub/edit/main/site/guides/Free2z_Live.md)
+
+# Free2z: configurazione dell'account + tutorial sul Livestream
+
+## Introduzione
+
+Free2Z è una piattaforma che permette a creatori e sostenitori di connettersi e raggiungere i propri obiettivi. Free2Z offre ai creatori strumenti per mettere in mostra i propri talenti e raccogliere fondi per i propri progetti senza compromettere la privacy. I sostenitori possono trovare e supportare le cause in cui credono.
+
+## Crea il tuo account
+
+Attualmente esistono due modi per creare il tuo account su Free2Z:  
+1. Scegli un nome utente e una password.  
+2. Collega il tuo account Twitter.  
+
+Per creare un account o accedere, visita https://free2z.cash/ e clicca sul pulsante 'CREATE'.
+
+![Modulo di login/registrazione](https://i.ibb.co/6rz0YPM/image-2023-11-19-133101013.png)
+
+Il modulo di login/registrazione comparirà nel tuo browser. Scegli il tuo nome utente e una password robusta: queste saranno le tue credenziali di accesso. Risolvi il captcha e clicca sul pulsante 'Enter' per creare il tuo account.
+
+![Modulo di inserimento nome utente e password](https://i.ibb.co/d47k50g/image-2023-11-19-133141052.png)
+
+In alternativa, puoi creare un account Free2Z collegando il tuo account Twitter. Per farlo, clicca sul logo di Twitter accanto a 'Login With' e ti verrà chiesto di collegare il tuo account Twitter.
+
+![Opzione di login con Twitter](https://i.ibb.co/kc6QN7Z/image-2023-11-19-133210103.png)
+
+Clicca su **Authorize app** per collegare il tuo account Twitter a Free2Z.
+
+## Personalizza il tuo profilo
+
+Dopo aver creato l'account, verrai reindirizzato alla pagina del tuo profilo Free2Z. Se hai creato l'account collegando Twitter, la maggior parte dei campi sarà compilata automaticamente. Se hai creato un account inserendo nome utente e password, dovresti inserire qui le tue informazioni. Puoi usare uno pseudonimo invece del tuo vero nome.
+
+![Header del profilo vuoto di default](https://i.ibb.co/GxyHz1D/default-header.png)
+
+Per ora è piuttosto spoglio, quindi rendiamolo più interessante impostando un avatar e un banner. L'interfaccia di Free2Z rende questo passaggio molto facile tramite il pulsante di caricamento (la freccia verso l'alto sulla destra).
+
+![Pulsanti di caricamento di avatar e banner](https://i.ibb.co/5jsjfZV/avatar-and-banner.png)
+
+Puoi vedere il risultato in cima alla pagina.
+
+![Pagina del profilo dopo la personalizzazione](https://i.ibb.co/7y542gp/resultatpage.png)
+
+Ah, molto meglio! Se hai qualche dote artistica, puoi rendere la pagina del tuo profilo Free2Z fantastica! Scrivi una bella descrizione per la tua pagina. Puoi parlare di te stesso o descrivere il tipo di contenuti che gli altri possono aspettarsi da te. (Suggerimento: usa la sintassi markdown per personalizzare la tua descrizione!)
+
+![Modifica del campo descrizione](https://i.ibb.co/cD1DFXw/edit-description.png)
+
+Non dimenticare di fornire il tuo indirizzo schermato Zcash, così i sostenitori possono donarti direttamente!
+
+![Campo dell'indirizzo schermato Zcash](https://i.ibb.co/8zRYgFS/p2p-address.png)
+
+L'ultimo passaggio per completare la configurazione della tua pagina è impostare un 'Member Price'. Si tratta del prezzo in 2Zs (Tuzies) che gli altri utenti pagheranno per abbonarsi alla tua pagina! (Maggiori dettagli sui 2Zs più avanti).
+
+![Impostazione del prezzo dell'abbonamento](https://i.ibb.co/VW9sYYz/member-price.png)
+
+Infine, clicca sul pulsante 'Update Profile' per finalizzare la configurazione del tuo profilo!
+
+## Abbonamenti e 2Zs
+
+Free2Z consente agli utenti di abbonarsi ai propri creatori preferiti e di accedere a funzionalità esclusive e contenuti riservati ai membri. Il creatore dovrebbe configurare un importo minimo di 2Zs per un abbonamento.  
+
+I 2Zs, o Tuzies, sono crediti digitali in-app utilizzati in Free2Z per molti scopi, tra cui:  
+1. Abbonarsi ai creatori  
+2. Aumentare la visibilità di una pagina Free2Z  
+3. Fare donazioni ai creatori  
+
+Puoi vedere i tuoi crediti 2Zs nell'header della pagina del tuo profilo.
+
+![Saldo 2Zs / Tuzies nell'header](https://i.ibb.co/2dBPyPb/tuzis-balance.png)
+
+Puoi acquistare altri 2Zs con Zcash cliccando sul tuo saldo di 2Zs. L'importo minimo per l'acquisto è 0,05 ZEC e l'attuale tasso di conversione è 0,05 ZEC = 10 2Zs.
+
+![Interfaccia per l'acquisto di 2Zs](https://i.ibb.co/MgZb9rg/buy-tuzies.png)
+
+## Donazioni e abbonamenti
+
+Una volta trovato un creatore che ti piace, puoi mostrare il tuo apprezzamento donando e abbonandoti a lui. Tutte le donazioni vanno direttamente al wallet del creatore. A titolo di esempio, abboniamoci alla [pagina ufficiale di Free2Z](https://free2z.cash/free2z).
+
+![Pagina ufficiale di Free2Z](https://i.ibb.co/C2T6txY/free2z-page.png)
+
+Per abbonarti a una pagina, tutto ciò che devi fare è cliccare sull'icona di abbonamento nell'header della pagina.
+
+![Pulsante di abbonamento sulla pagina del creatore](https://i.ibb.co/k5Hbdfr/subscribe-to-creator.png)
+
+Vedrai l'importo minimo per l'abbonamento. Verifica di avere abbastanza tuzis e clicca su subscribe.
+
+![Popup di conferma dell'abbonamento](https://i.ibb.co/8j4p73J/confirm-subscribe.png)
+
+### Dona usando 2Zs o Zcash
+
+Puoi donare direttamente sulla loro pagina cliccando sull'icona Fund creator.
+
+![Pulsante Fund creator](https://i.ibb.co/xCz5X92/fund-creator.png)
+
+Oppure, all'interno di un post, cerca il pulsante più fluttuante. Da qui puoi donare al creatore o promuovere il post su Free2Z.
+
+![Pulsanti di azione fluttuanti all'interno di un post](https://i.ibb.co/Rzs7ST1/post-floating-buttons.png)
+
+## Live Streaming
+
+La piattaforma Free2z offre una fantastica funzionalità chiamata Free2z Live. Con questo strumento, i creatori possono avviare dirette live per i membri abbonati. Alcune funzionalità chiave di Free2z Live includono:  
+- Audio e video  
+- Condivisione dello schermo  
+- Editing collaborativo del codice  
+- Chat  
+- Lavagna condivisa  
+- E molto altro!
+
+### Cosa puoi fare con Free2z Live
+
+Free2z Live è uno strumento potente che permette ai creatori di trasmettere qualsiasi tipo di contenuto. Ecco alcuni esempi del tipo di contenuti che puoi trasmettere con Free2z Live:  
+- Tutorial e dimostrazioni  
+- Spettacoli ed eventi  
+- Progetti collaborativi  
+- Reportage e giornalismo dal vivo  
+- La tua creatività è l'unico limite!
+
+### Come andare in diretta
+
+È molto facile avviare una diretta con Free2z Live. Ma ci sono alcuni requisiti prima di poter iniziare la tua diretta.  
+1. Il creatore **deve** avere un **member price** minimo di 10 2Zs.  
+2. Il creatore **deve** avere un saldo di almeno 150 2Zs nel proprio account.  
+
+Se il creatore soddisfa **entrambe** le condizioni di cui sopra, un'icona chiamata **Go Live** sarà disponibile sulla pagina del suo profilo.
+
+![Pulsante Go Live](https://i.ibb.co/7RFywwK/go-live.png)
+
+Per avviare una diretta, basta cliccare sul pulsante **Go Live** e l'app Free2z chiederà il permesso di usare il microfono e la webcam (se ne hai una). Dopo aver concesso le autorizzazioni necessarie, Free2z ti chiederà di inserire un nickname che vuoi usare durante la diretta. Una volta scelto un nickname, clicca su **Join** per avviare la tua diretta.
+
+![Scelta del nickname per la diretta](https://i.ibb.co/4VMbCrW/select-nickname.png)
+
+E fatto! Quando avvii una diretta, il tuo profilo mostrerà un'icona che indica che sei in diretta, così i tuoi abbonati possono unirsi alla diretta.
+
+![Partecipare a una diretta](https://i.ibb.co/qpBLcKr/join-livestream.png)
+
+Quando le persone si uniscono alla diretta, possono chattare, chiedere di salire sul palco, interagire votando nei sondaggi e altro ancora.
+
+![Esempio di una sessione di Free2z Live](https://i.ibb.co/r3XTY8M/free2z-live-example.png)
+
+_(Esempio di sessione di Free2z Live)_
+
+Free2z Live è versatile e potente. Nella prossima sezione fornirò una panoramica delle sue funzionalità e dei suoi strumenti.
+
+### Esplorare Free2z Live
+
+Questo wiki-doc non vuole essere una guida approfondita a Free2z o Free2z Live. Ma ecco una panoramica generale dei suoi strumenti.
+
+In basso a sinistra dello schermo vediamo alcuni pulsanti.
+
+![Controlli in basso a sinistra](https://i.ibb.co/XLQBDk1/free2z-live-left.png)
+
+Una bella funzione qui è la possibilità di condividere il tuo schermo così gli altri utenti possono vedere cosa stai facendo.
+
+In basso troviamo le opzioni della diretta.
+
+![Barra degli strumenti inferiore](https://i.ibb.co/7JbmDXc/free2z-live-bottom.png)
+
+Alcune delle opzioni chiave qui sono:  
+- Attiva / disattiva il microfono  
+- Abilita / disabilita la webcam  
+- Lascia il palco  
+- Silenzia tutti gli oratori  
+- Esci  
+
+Per terminare una diretta, clicca sul pulsante 'Leave', poi clicca su 'End meeting for all' per interrompere la riunione per tutti i partecipanti.
+
+![Pannello di interazione in basso a destra](https://raw.githubusercontent.com/ZecHub/zechub/main/site/guides/assets/free2z-live-right.png)
+
+I pulsanti in basso a destra contengono funzioni legate all'interazione durante la diretta, come:  
+- **Chat**: permette ai partecipanti di chattare tra loro e con l'host durante la diretta.  
+- **Polls**: permette all'host di creare sondaggi e raccogliere feedback dai partecipanti.  
+- **Lista dei partecipanti**: mostra l'elenco dei partecipanti alla diretta.  
+- **Plugins**: permette all'host di aggiungere plugin ed estensioni per arricchire l'esperienza della diretta.
+
+![Pannello dei plugin](https://raw.githubusercontent.com/ZecHub/zechub/main/site/guides/assets/free2z-live-plugins.png)
+
+Non è scopo di questo wiki-doc spiegare tutti i plugin, ma ti incoraggio davvero a provarli tutti, poiché offrono tutti un grande valore di interazione tra creatori e spettatori. Per lanciare un plugin, basta cliccare sul pulsante 'razzo' sulla destra.
+
+## Conclusione
+
+In conclusione, Free2z è una piattaforma versatile che permette ai creatori di mettere in mostra le proprie capacità, condividere conoscenze, raccogliere fondi per i propri progetti e coinvolgere i propri sostenitori attraverso il potente strumento di Free2z Live.
+
+----
+
+### Risorse
+
+[Free2z](https://free2z.cash/)  
+[Documentazione di Free2z](https://free2z.cash/docs/)  
+[Panoramica sui 2Z](https://free2z.cash/docs/2Zs/)  
+[Creare un profilo](https://free2z.cash/docs/creators/creating-a-profile)  
+[Cos'è Free2z Live?](https://free2z.cash/docs/creators/free2z-live)  
+[Free2z per i sostenitori](https://free2z.cash/docs/category/for-supporters)
+
+---
+
+_Scritto da James Katz per Zechub._

--- a/translations/it/site/guides/Hardened_Zebrad.md
+++ b/translations/it/site/guides/Hardened_Zebrad.md
@@ -1,0 +1,130 @@
+# Nodo completo Zebra rafforzato
+
+- Usa un utente dedicato senza privilegi + sandboxing systemd a livello di kernel (lo stesso isolamento di Docker).  
+- L'RPC è solo localhost con autenticazione sicura tramite cookie (predefinita e raccomandata).  
+
+
+---
+
+## Prerequisiti
+
+- qualsiasi distro basata su Ubuntu
+- toolchain Rust installata (`rustup` + `cargo`)
+- Almeno 300 GB di spazio su disco libero (partizione `/var`)
+
+
+---
+
+## Configurazione una tantum (eseguita come utente normale)
+
+### 1. Aggiorna il sistema e installa le dipendenze di build
+
+```
+sudo apt update && sudo apt install -y build-essential pkg-config libclang-dev clang libssl-dev protobuf-compiler
+```
+
+## Aggiorna Rust e installa l'ultimo zebrad (v4.3.0+)
+
+```
+rustup update
+cargo install --locked --force zebrad
+sudo cp ~/.cargo/bin/zebrad /usr/local/bin/zebrad
+sudo chown root:root /usr/local/bin/zebrad
+sudo chmod 755 /usr/local/bin/zebrad
+zebrad --version
+```
+
+## Crea un utente zebra dedicato senza privilegi
+
+```
+sudo adduser --system --group --no-create-home --shell /usr/sbin/nologin zebra
+```
+
+
+## Crea una directory dati sicura
+
+```
+sudo mkdir -p /var/lib/zebrad
+sudo chown zebra:zebra /var/lib/zebrad
+sudo chmod 700 /var/lib/zebrad
+```
+
+## Crea una configurazione sicura (/etc/zebrad/zebrad.toml)
+
+```
+sudo mkdir -p /etc/zebrad
+sudo tee /etc/zebrad/zebrad.toml > /dev/null <<EOF
+[network]
+network = "Mainnet"
+listen_addr = "0.0.0.0:8233"
+
+[state]
+cache_dir = "/var/lib/zebrad"
+
+[rpc]
+# Enable RPC on localhost only (never expose to the internet!)
+listen_addr = "127.0.0.1:8232"
+
+# Cookie authentication 
+enable_cookie_auth = true     # ← uncomment to be explicit
+EOF
+
+sudo chown zebra:zebra /etc/zebrad/zebrad.toml
+sudo chmod 600 /etc/zebrad/zebrad.toml
+```
+
+## Crea un servizio systemd rafforzato
+
+```
+sudo tee /etc/systemd/system/zebrad.service > /dev/null <<EOF
+[Unit]
+Description=Zebra Zcash Full Node (zebrad)
+After=network.target
+
+[Service]
+Type=simple
+User=zebra
+Group=zebra
+ExecStart=/usr/local/bin/zebrad --config /etc/zebrad/zebrad.toml start
+
+UMask=0027
+ExecStartPost=/bin/chmod 750 /var/lib/zebrad-rpc
+ExecStartPost=/bin/chmod 640 /var/lib/zebrad-rpc/.cookie
+
+# Kernel-level sandboxing (makes native zebrad as isolated as Docker)
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+NoNewPrivileges=yes
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+ReadWritePaths=/var/lib/zebrad /var/lib/zebrad-rpc
+
+LimitNOFILE=65535
+Restart=on-failure
+RestartSec=5s
+EOF
+
+sudo systemctl daemon-reload
+```
+
+## Uso quotidiano - Flusso di lavoro con un solo comando
+
+| Azione                  | Comando                                      | Note |
+|-------------------------|----------------------------------------------|-------|
+| **Avvia**               | `sudo systemctl start zebrad`                | Un comando |
+| **Ferma**               | `sudo systemctl stop zebrad`                 | Un comando |
+| **Stato**               | `sudo systemctl status zebrad`               | Mostra se è in esecuzione |
+| **Log in tempo reale**  | `journalctl -u zebrad -f -o short-precise`  | Sostituisce `screen -r` |
+| **Ottieni il cookie RPC** | `sudo cat /var/lib/zebrad/.cookie`         | Solo mentre è in esecuzione |
+
+**Alias di comodità** (aggiungi a `~/.bashrc` o `~/.zshrc`):
+```
+alias zebra-start='sudo systemctl start zebrad'
+alias zebra-stop='sudo systemctl stop zebrad'
+alias zebra-status='sudo systemctl status zebrad'
+alias zebra-logs='journalctl -u zebrad -f'
+alias zebra-cookie='sudo cat /var/lib/zebrad/.cookie'
+```

--- a/translations/it/site/guides/Keystone_Zashi.md
+++ b/translations/it/site/guides/Keystone_Zashi.md
@@ -1,0 +1,104 @@
+# Guida utente Keystone Zashi
+
+Guida su Twitter:  => [Guida Twitter all'integrazione del wallet hardware Zashi x Keystone](https://x.com/zashi_app/status/1869793574880973144) 
+
+Questa integrazione segna un'evoluzione significativa nell'usabilità di Zcash, abilitando la conservazione a freddo (cold storage) di ZEC schermati. La comunità Zcash ha affrontato battute d'arresto con altre piattaforme di wallet hardware in passato, ma Keystone è emerso come un partner collaborativo disposto a superare i limiti e a innovare al fianco della Electric Coin Company. Il team di Keystone ha ricevuto una sovvenzione ZCG per finanziare la propria parte del lavoro.
+
+## Tutorial Keystone X Zashi
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/ktYf7josJKM"
+    title="Keystone X Zashi Tutorial"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+    
+
+## Preparazione
+[Ordina e ricevi il tuo Keystone 3 Pro o Keystone 3](https://keyst.one) 
+
+Livello della batteria: assicurati che il tuo dispositivo Keystone abbia un livello di batteria superiore al 20%.
+
+Cavo USB o scheda SD:
+
+- Cavo USB per l'aggiornamento del firmware (incluso).
+- Scheda micro SD (sotto 1 TB) per gli aggiornamenti (da acquistare separatamente).
+
+Accesso al sito web ufficiale di Keystone per la verifica e l'aggiornamento del firmware.
+
+App Zashi configurata sul tuo dispositivo mobile.
+
+## [Guida passo passo (dispositivo Keystone)](https://keyst.one/get-started) 
+
+
+**Scegli la tua lingua**
+-Verifica del dispositivo (via QR): la verifica del dispositivo è cruciale per rilevare potenziali manomissioni durante il trasporto, prevenire attacchi alla catena di fornitura e garantire la sicurezza del firmware installato.
+  - Visita la pagina di verifica del dispositivo sul sito web di Keystone.
+  - Clicca su Scansiona codice QR sul sito web ufficiale.
+  - Usa la fotocamera del tuo Keystone per scansionare il codice QR mostrato sul sito web.
+  - Un codice di verifica apparirà sullo schermo del tuo Keystone.
+  - Inserisci questo codice sul sito web per completare il processo di verifica.
+
+- **Aggiornamento del firmware:**
+  - Aggiornamento tramite scheda MicroSD
+    - Assicurati che il tuo wallet Keystone abbia almeno il 20% di carica della batteria.
+    - Inserisci la scheda SD nel tuo computer e formattala come FAT32.
+    - Scarica l'ultima versione del firmware Cypherpunk dalla [pagina di aggiornamento del firmware di Keystone](https://keyst.one/firmware) e salva il file keystone3.bin nella radice della tua scheda MicroSD.
+    - Inserisci la scheda SD con il firmware nel tuo wallet Keystone.
+    - Accedi all'opzione "Upgrade" sul tuo wallet Keystone, poi segui le istruzioni a schermo per avviare il processo di aggiornamento.
+  - **Aggiornamento tramite cavo USB**
+    - Se la tua versione del firmware è inferiore alla 1.0.4, dovrai eseguire l'aggiornamento iniziale usando una scheda MicroSD prima di poter procedere con gli aggiornamenti via USB.
+    - Assicurati che il tuo wallet Keystone abbia almeno il 20% di carica della batteria.
+    - Tocca via USB e usa il cavo USB per collegare il tuo wallet Keystone al computer. Tocca [Approve] per concedere al tuo wallet Keystone l'accesso USB, poiché altrimenti potrebbe consentire solo la ricarica.
+    - Apri il browser web del tuo computer e vai alla [pagina di aggiornamento del firmware di Keystone](https://keyst.one/firmware)
+    - Nella pagina di aggiornamento, clicca il pulsante Install Update e segui le istruzioni fornite per installare l'ultimo firmware.
+- **Crea il wallet:**
+    - Password sicura: scegli un PIN o una password robusti per proteggere il tuo wallet.
+    - Dai un nome al tuo wallet (facoltativo): facoltativamente, dai un nome al tuo wallet per facilitarne l'identificazione, oppure salta questo passaggio.
+    - Seleziona Create New Wallet se stai configurando un wallet per la prima volta.
+    - Il tuo dispositivo genererà una seed phrase di 24 parole.
+    - Annota questa seed phrase e conservala in modo sicuro.
+    - Conferma la seed phrase verificando le parole nell'ordine corretto come mostrato sullo schermo.
+- **Collega Zashi + wallet Keystone:**
+    - Sul dispositivo Keystone: tocca … nella pagina principale
+    - Tocca Connect Software Wallet e scegli Zashi. Apparirà il codice QR per la connessione a Zashi.
+    - Nell'app Zashi: tocca il menu a tendina zashi (in alto a sinistra dello schermo)
+    - Tocca Connect Hardware Wallet
+    - Tocca Ready to Scan
+    - Scansiona il QR mostrato sul dispositivo Keystone
+    - Nell'app Zashi: conferma l'account del wallet Keystone toccando l'account visualizzato
+    - Tocca Connect in fondo allo schermo
+
+
+## Aiuto aggiuntivo
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/Jr6LqtD1W0s"
+    title="Connect Keystone Hardware Wallet to Zashi"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+    
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/t_OHb1KqrRg"
+    title="Sign an Outgoing Transaction with Keystone"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+
+

--- a/translations/it/site/guides/Maya_Protocol.md
+++ b/translations/it/site/guides/Maya_Protocol.md
@@ -1,0 +1,80 @@
+# Maya Decentralised Exchange
+
+---
+
+## Tutorial
+
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/f1k6xhNfTV8"
+    title="How to Swap Ethereum to Zcash on LeoDex"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+## Cos'è Maya Protocol?
+
+Maya è un sistema di [exchange decentralizzato](https://nym.com/blog/what-is-dex) (DEX) che abilita lo scambio di criptovalute tra diverse blockchain. Puoi, ad esempio, scambiare Bitcoin (BTC) sulla blockchain Bitcoin con Ethereum (ETH) sulla blockchain Ethereum in modo semplice, senza detenere gli asset né coinvolgere alcuna autorità centralizzata o procedure Know Your Customer (KYC).
+
+Maya Protocol è stato sviluppato usando il Cosmos Software Development Kit (Cosmos SDK) e opera su un meccanismo di consenso Proof of Bond (PoB). Il protocollo è sostenuto dai "Node Operator", che mettono in staking del capitale nel sistema e guadagnano rendimenti come ricompensa per il loro contributo e i loro sforzi. In sostanza, i nodi sono computer che eseguono software che valida gli swap degli utenti e supervisiona gli asset in indirizzi designati su diverse blockchain.
+
+Per completare uno swap, la criptovaluta supportata deve essere ricevuta in uno degli indirizzi di Maya, inviata da un utente, e poi un importo equivalente viene inviato da un altro degli indirizzi di Maya su una blockchain diversa. Questo processo è gestito e approvato da almeno due terzi dei nodi, assicurandosi in particolare che i fondi siano stati correttamente ricevuti.
+
+In questo modo, gli utenti possono inviare un tipo di token su una blockchain e riceverne uno diverso su un'altra blockchain, il tutto in modo nativo e senza usare token wrapped.
+
+## Cos'è Proof of Bond?
+
+Proof of Bond (PoB) è un meccanismo di consenso in cui gli operatori di nodo devono impegnare un bond (di solito sotto forma del token nativo della rete) per partecipare alla rete. Questo bond agisce come una forma di sicurezza economica, garantendo che i nodi agiscano onestamente e mantengano l'integrità della rete. Se un nodo cerca di agire in modo malevolo o non riesce a svolgere i propri compiti, il suo bond può essere tagliato (slashed), il che significa che una porzione di esso viene sottratta come penalità.
+
+In Maya Protocol, questo meccanismo aiuta a produrre valore economico dalle risorse messe in staking dagli operatori di nodo, aumentando l'efficienza del capitale. Allo stesso modo, in Thorchain, gli operatori di nodo vincolano (bond) RUNE (il token nativo) per mettere in sicurezza la rete e garantire la cooperazione tra i partecipanti.
+
+## Differenze tra Maya e THORChain
+
+Maya è un fork di THORChain, ma arricchito con alcune nuove caratteristiche e funzionalità che ne fanno un'ottima alternativa. Le più importanti sono
+
+### Liquidity Node
+
+Anziché seguire il modello Pure Bond, Maya sta valutando un passaggio a un modello a Liquidity Node. In questo sistema, i nodi sono abilitati a contribuire direttamente liquidità, vincolandola alla rete. Questo approccio comporta che gli operatori di nodo affrontino un rischio significativo: se usano impropriamente i fondi, subiscono perdite, fungendo da potente deterrente. Di conseguenza, gli operatori di nodo usano le Liquidity Unit delle Liquidity Pool, che forniscono simultaneamente liquidità e rafforzano la sicurezza della rete.
+
+### Protezione dall'Impermanent Loss
+
+Un sistema che protegge i fornitori di liquidità dalla perdita temporanea (LP) che possono subire quando forniscono liquidità, a causa delle costanti fluttuazioni nei prezzi degli asset crypto.
+L'ILP detiene il 10% della fornitura di $CACAO (10 milioni di $CACAO) ed è continuamente reintegrata dal 10% delle commissioni del protocollo. L'ILP diventa attiva 50 giorni dopo un deposito di liquidità, con una copertura limitata al 100%.
+
+La durata della copertura ILP dipende dalla performance dell'ASSET e di $CACAO. La copertura completa si raggiunge dopo 150 giorni se l'ASSET ha una performance migliore, e dopo 450 giorni se $CACAO ha una performance migliore. L'ILP viene sia pagata che azzerata in caso di prelievo completo, ma non è influenzata dai prelievi parziali. In caso di ricariche (top-up), l'ILP viene azzerata ma non pagata.
+
+### Un modello di allocazione diverso
+
+La Liquidity Auction è stato un evento di 21 giorni progettato per distribuire i token $CACAO tra i partecipanti. Durante l'evento, gli utenti depositavano asset supportati a un indirizzo specifico. Alla conclusione dell'asta, il 90% dei token $CACAO è stato allocato ai partecipanti in proporzione ai loro contributi di liquidità, mentre il restante 10% è stato allocato alla riserva ILP. I partecipanti sono diventati fornitori di liquidità, con i loro asset depositati e i token $CACAO inseriti nelle pool di Maya, consentendo loro di guadagnare una quota delle commissioni generate.
+
+### Un modo diverso di gestire le riserve
+
+Alla genesi di Maya Protocol, le riserve di CACAO disponibili erano solo il 10% della fornitura totale, rispetto al 44% di THORChain, ed erano principalmente destinate alla protezione dall'Impermanent Loss (ILP). Maya non ha emissioni di blocco; e se verranno implementate la Protocol Owned Liquidity e il Lending, avranno un design diverso, poiché in THORChain questi aspetti sono strettamente integrati con le Riserve.
+
+Ciononostante, nonostante le sue differenze, Maya funge anche da soluzione complementare a THORChain, offrendo ridondanza, estensione e validazione, e integrando nuove reti non presenti nell'attuale implementazione di THORChain.
+
+Inoltre, l'obiettivo di Maya è diventare un *backend* su cui altri servizi possano costruire, nella speranza di vedere numerosi nuovi *frontend*, ossia servizi DEX costruiti sull'infrastruttura di Maya.
+
+## Integrazione dei wallet con Maya Protocol
+
+Agendo come *backend*, Maya ha bisogno di essere supportata da diverse UI e wallet per essere usata. 
+Ecco un elenco con alcuni dei servizi che già supportano Maya:
+
+[Thorwallet DEX](https://www.thorwallet.org/): Ledger, XDEFI, Metamask, Keystore
+
+[El Dorado](https://www.eldorado.market/): XDEFI, Keystore
+
+[CacaoSwap](https://cacaoswap.app/): Keystore, MetaMask, XDEFI, Keplr, Leap
+
+[Asgardex](https://www.asgardex.com/): Keystore, Ledger
+
+[DefiSpot](https://www.defispot.com/t): XDEFI, Metamask, Keplr, Phantom, Walletconnect, Leap Wallet, Argeentx, Braavos, Trustwallet e Rabby.
+
+[XDEFI](https://www.xdefi.io/): un wallet self-custody multi-ecosistema con supporto per oltre 30 blockchain native e tutte le chain EVM e Cosmos, tra cui Bitcoin, Ethereum, Solana, THORChain, Maya Protocol, TRON e altre.
+
+[KeepKey ](https://keepkey.com/): un hardware wallet per conservare in modo sicuro gli asset digitali.

--- a/translations/it/site/guides/Migration_Guide_Zcashd_To_Zebrad_Zallet.md
+++ b/translations/it/site/guides/Migration_Guide_Zcashd_To_Zebrad_Zallet.md
@@ -1,0 +1,202 @@
+# Guida alla migrazione: da zcashd a Zebrad/Zallet
+
+L'ecosistema Zcash sta evolvendo. Il tradizionale nodo completo Zcashd, gestito da *Electric Coin Company (ECC)* / *Zodl*, viene gradualmente sostituito da Zebra e Zallet.
+
+- Zebra è una moderna implementazione in Rust del protocollo Zcash sviluppata dalla Zcash Foundation
+- Zallet è un wallet leggero costruito per interfacciarsi senza problemi con i nodi Zebra, sviluppato da Zodl
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![ChatGPTImageOct12202508_15_20A](https://hackmd.io/_uploads/SJNBsSYTel.jpg)
+</div>
+
+Questa guida ti accompagna nella migrazione da **Zcashd** a **Zebrad** e **Zallet**, inclusi configurazione, importazione del wallet e risoluzione dei problemi comuni di migrazione.
+
+---
+
+## Il progetto Zcash ha annunciato formalmente che zcashd verrà deprecato nel 2025.
+
+**Stato di deprecazione e cosa significa**
+
+- Il progetto Zcash ha annunciato formalmente che zcashd verrà deprecato nel 2025.
+- I nodi completi vengono migrati a Zebrad, un'implementazione in Rust, mentre Zallet è destinato a succedere alla componente wallet di zcashd.
+- In risposta, il progetto Zebra tiene traccia di una milestone "Zcashd Deprecation" per garantire compatibilità, migrazione RPC e supporto dell'ecosistema.
+- Per molti metodi RPC, Zebrad/Zallet mireranno a essere sostituzioni drop-in (emulando o riproducendo il comportamento). Altri cambieranno o potrebbero non essere supportati.
+
+**Perché migrare - oltre alla deprecazione**
+
+Anche lasciando da parte la deprecazione, ci sono ragioni convincenti per passare:
+- Sicurezza e robustezza: la memory-safety di Rust e gli strumenti moderni riducono i rischi di vulnerabilità.
+- Prestazioni ed efficienza: Zebrad è progettato per il parallelismo, un uso più efficiente delle risorse e una sincronizzazione più veloce.
+- Architettura modulare: separare la logica del nodo (Zebrad) dall'interfaccia del wallet (Zallet) offre confini più chiari e percorsi di aggiornamento migliori.
+- Compatibilità futura dell'ecosistema: gli strumenti, i miglioramenti e il resto dell'ecosistema Zcash punteranno sempre più su Zebrad/Zallet.
+- Tranquillità: evita di rimanere bloccato eseguendo una componente deprecata e non supportata.
+
+### Ora immergiamoci nella guida alla migrazione
+
+**1. Fai il backup di tutto**
+* Esegui il backup del tuo wallet.dat (o di qualsiasi altro file wallet / archivio chiavi) dal tuo nodo zcashd.
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![bash (1)](https://hackmd.io/_uploads/SJ_0mUtTxg.svg)
+</div>
+
+* Salva il tuo zcash.conf e tutte le impostazioni personalizzate.
+* Esporta una copia di tutti gli script RPC o le automazioni che usi.
+* Verifica che i tuoi backup siano validi (ad esempio, in un altro ambiente, prova ad aprirli o ispezionarli).
+* Esamina quali metodi JSON-RPC stai attualmente utilizzando.
+* Confrontali con la tabella di compatibilità pianificata mantenuta sul [sito di supporto Zcash](https://z.cash/support/zcashd-deprecation/?utm_source=chatgpt.com)
+* Preparati a cambiamenti o metodi mancanti (alcuni potrebbero richiedere workaround o adattamenti).
+
+**2. Requisiti di sistema e spazio su disco**
+* Assicurati di avere spazio su disco sufficiente (la chain di Zcash è grande). Almeno 10 GB di spazio libero su disco.
+* Assicurati che la tua macchina abbia una rete, CPU e RAM stabili.
+* Una connessione internet
+* Se prevedi di compilare dai sorgenti, assicurati di avere Rust e Cargo installati.
+
+**3. Installazione / configurazione di Zebrad**
+Puoi scaricare un binario precompilato oppure compilare dai sorgenti.
+* La Zcash Foundation pubblica release e binari per Zebra. Ad esempio, potresti usare uno script di installazione o scaricare il binario appropriato per il tuo OS.
+
+* Nota che nelle versioni recenti di Zebra, [l'endpoint RPC non è più abilitato per impostazione predefinita in Docker.](https://zfnd.org/zebra-2-3-0-release/?utm_source=chatgpt.com)
+
+**Opzione A: installazione tramite binario precompilato**  
+Su **Linux**/**macOS**:
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![bash (2)](https://hackmd.io/_uploads/HJhYu8Y6el.svg)
+</div>
+
+Questo installa l'ultima versione stabile di zebrad.
+
+**Opzione B: compilazione dai sorgenti**
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![bash (3)](https://hackmd.io/_uploads/Syg8FUK6eg.svg)
+</div>
+
+Dopo la compilazione, sposta il binario nel tuo path:
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![migration 11](https://hackmd.io/_uploads/BJ0zjLY6ll.png)
+</div>
+
+**4. Configurazione e avvio**  
+Genera una configurazione predefinita:
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![migration2](https://hackmd.io/_uploads/HJV1C8tTxx.png)
+</div>
+
+Modifica **zebrad.toml** secondo le tue preferenze (indirizzo di ascolto, porte, directory di stato, caching).
+
+**Avvia il nodo:**
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![image](https://hackmd.io/_uploads/H1KPkvt6gl.png)
+</div>
+
+Il nodo inizierà a sincronizzarsi dal genesis - aspettati diverse ore (o più) a seconda dell'hardware e della rete.
+
+**5. Installazione / configurazione di Zallet (Wallet)**
+
+Zallet è progettato per sostituire la parte wallet di zcashd.
+
+Controlla la pagina GitHub / delle release di Zallet per i binari.
+
+**Oppure compila dai sorgenti:**
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![image](https://hackmd.io/_uploads/SyUFxvFTex.png)
+</div>
+
+* Avvia la GUI o la CLI (a seconda di ciò che fornisce la tua installazione).
+* Configuralo per connettersi al tuo nodo Zebrad locale tramite l'endpoint RPC o API.
+
+**6. Importare il tuo wallet zcashd in Zallet**  
+Tramite dump della chiave privata
+
+Su zcashd, esporta le tue chiavi private:
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![bash (4)](https://hackmd.io/_uploads/rJzgzwFagx.svg)
+</div>
+
+* In Zallet, scegli Import Keys o un'opzione simile.
+* Indirizzalo a **zcashd_keys.txt**.
+* Zallet dovrebbe analizzare e importare gli indirizzi ZEC e le chiavi associate.
+
+**Tramite frase seed** (se applicabile)
+
+* Se il tuo wallet supporta un backup tramite seed, usa Restore from Seed Phrase in Zallet.
+* Funziona solo se il tuo wallet zcashd è stato derivato da un seed (o se disponi di una conversione del seed).
+
+**Rescan e sincronizzazione del wallet**
+
+* Una volta importate le chiavi, Zallet attiverà un rescan della chain tramite Zebrad.
+* Concedi del tempo a Zallet per ricostruire il tuo saldo e la cronologia delle transazioni.
+
+**7. Verifica saldi e sincronizzazione**
+
+Una volta importato, Zallet si connetterà al tuo nodo Zebrad e rieseguirà la scansione della blockchain.
+Al termine della sincronizzazione, i tuoi saldi e le tue transazioni dovrebbero apparire esattamente come prima.
+
+Puoi verificare lo stato di sincronizzazione del tuo nodo eseguendo:
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![image](https://hackmd.io/_uploads/SyIyVDY6xl.png)
+</div>
+
+Oppure controlla i log.
+
+<div className="my-8 w-full max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-xl">
+![image](https://hackmd.io/_uploads/r1HfVPF6gg.png)
+</div>
+
+**8. Risoluzione dei problemi**
+
+<div className="overflow-x-auto my-8 rounded-2xl border border-slate-200 dark:border-slate-700">
+  <table className="w-full min-w-full border-collapse text-sm">
+    <thead className="bg-slate-100 dark:bg-slate-800">
+      <tr>
+        <th className="px-6 py-4 text-left font-semibold text-slate-900 dark:text-white">Problema</th>
+        <th className="px-6 py-4 text-left font-semibold text-slate-900 dark:text-white">Possibile causa</th>
+        <th className="px-6 py-4 text-left font-semibold text-slate-900 dark:text-white">Soluzione</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr className="border-b border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-900/50">
+        <td className="px-6 py-4">Zebrad non si avvia</td>
+        <td className="px-6 py-4">Porta in uso o configurazione errata</td>
+        <td className="px-6 py-4">Controlla **zebrad.toml** e usa una porta libera</td>
+      </tr>
+      <tr className="border-b border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-900/50">
+        <td className="px-6 py-4">Sincronizzazione lenta</td>
+        <td className="px-6 py-4">Congestione della rete</td>
+        <td className="px-6 py-4">Assicura una connessione stabile, riavvia Zebrad</td>
+      </tr>
+      <tr className="border-b border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-900/50">
+        <td className="px-6 py-4">Transazioni mancanti nel wallet</td>
+        <td className="px-6 py-4">Importazione parziale delle chiavi</td>
+        <td className="px-6 py-4">Reimporta le chiavi o esegui un rescan in Zallet</td>
+      </tr>
+      <tr className="border-b border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-900/50">
+        <td className="px-6 py-4">Zallet non riesce a connettersi al nodo</td>
+        <td className="px-6 py-4">Nodo non in esecuzione o endpoint errato</td>
+        <td className="px-6 py-4">Avvia Zebrad e verifica la porta RPC corretta</td>
+      </tr>
+      <tr className="border-b border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-900/50">
+        <td className="px-6 py-4">Zallet va in crash</td>
+        <td className="px-6 py-4">Build obsoleta</td>
+        <td className="px-6 py-4">Aggiorna all'ultima release da GitHub</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+**9. Conclusione**
+
+Migrare da zcashd a Zebrad e Zallet ti offre un'esperienza Zcash più veloce, più sicura e più moderna.
+Con la sicurezza basata su Rust, il design modulare e strumenti migliori, questa configurazione garantisce che il tuo nodo e il tuo wallet restino pronti per il futuro mentre l'ecosistema Zcash continua a evolversi.
+
+Consiglio: tieni le chiavi del tuo wallet offline ed esegui regolarmente il backup dei dati di Zallet.
+Visita [zebra.zfnd.org](https://zebra.zfnd.org) e [zallet.zfnd.org](https://zallet.zfnd.org) per aggiornamenti e supporto della community.

--- a/translations/it/site/guides/My_First_Zcash_Workbook.md
+++ b/translations/it/site/guides/My_First_Zcash_Workbook.md
@@ -1,0 +1,167 @@
+# My First Zcash Workbook
+
+---
+
+## Introduzione
+
+*My First Zcash* è un quaderno didattico creato per aiutare i nuovi studenti, in particolare i giovani e i principianti nel mondo cripto, a comprendere i fondamenti di Zcash, della privacy finanziaria, del denaro digitale e dei sistemi che stanno dietro la tecnologia. È stato sviluppato da un gruppo eterogeneo e appassionato di contributori provenienti da tutta la comunità globale di Zcash, combinando sviluppo software, design, ricerca, didattica e advocacy della privacy.
+
+Questa guida fornisce una panoramica dell'arco di apprendimento centrale del quaderno, suddiviso in nove sezioni principali. Non sostituisce il libro stesso, ma è piuttosto una risorsa di accompagnamento che riassume il percorso didattico ed evidenzia informazioni importanti per istruttori, studenti ed educatori della comunità.
+
+Il quaderno è disponibile gratuitamente per il download in PDF o come flipbook interattivo:
+
+[Outline](https://drive.google.com/file/d/1eYWLgvAAHzCpr2b7bZ494FTZAtHqmtRk/view)
+
+[Flipbook](https://midd.me/nbp2)
+
+[GitHub Repo](https://github.com/massadoptionorg/My-First-Zcash) 
+
+
+
+---
+
+## 1. Cos'è Zcash?
+
+Questa prima sezione introduce i lettori all'idea del denaro digitale e al perché la privacy sia importante in una società digitale moderna.  Mette a confronto i sistemi finanziari tradizionali con le blockchain trasparenti, evidenziando come la maggior parte dei registri pubblici esponga l'attività degli utenti.  Zcash è descritto come un denaro digitale alternativo che preserva la privacy e permette agli utenti di scambiare in modo sicuro senza rivelare informazioni finanziarie personali.
+
+ Il quaderno sottolinea che la privacy non riguarda il nascondere illeciti, ma il proteggere le persone comuni da esposizione ingiustificata, sorveglianza e sfruttamento dei dati.  Gli studenti vengono guidati attraverso esempi diretti che mostrano come Zcash sia stato creato per dare alle persone un controllo genuino sulla propria vita finanziaria e come le normali transazioni finanziarie rivelino più informazioni personali di quanto ci rendiamo conto.
+
+
+---
+
+## 2. Chi ha costruito Zcash e perché esiste?
+
+Questa sezione spiega le origini di Zcash attraverso la lente della ricerca scientifica e della crittografia. Introduce le prove a conoscenza zero, in particolare gli "zk-SNARK", come la tecnologia rivoluzionaria che rende possibili le transazioni private schermate.
+
+Il quaderno tocca anche la storia del lancio di Zcash, i suoi principi fondanti e la comunità globale che oggi mantiene e supporta l'ecosistema. La missione è incentrata sul dare potere agli individui, fornire accesso al denaro digitale resistente alla censura e far progredire la tecnologia della privacy per tutti.
+
+
+---
+
+## 3. Come funziona Zcash
+
+Questa parte scompone le basi tecniche del protocollo Zcash in un linguaggio accessibile. I concetti chiave includono:
+
+- Indirizzi trasparenti vs. schermati  
+- Viewing key e divulgazione controllata  
+- Il ruolo dei miner/validatori  
+- Come le prove a conoscenza zero validano le transazioni  
+- Come la privacy viene preservata pur garantendo che la rete resti decentralizzata e sicura  
+
+I diagrammi e le metafore visive nel quaderno aiutano a semplificare questi concetti per i principianti.
+
+
+---
+
+## 4. Usare Zcash nella vita di tutti i giorni
+
+La quarta sezione si concentra su esempi d'uso concreti. Mostra come qualcuno potrebbe inviare e ricevere Zcash usando i wallet mobili, come i codici QR facilitino i pagamenti e come gli utenti impieghino le transazioni schermate per protezione personale, riservatezza aziendale o trasferimenti transfrontalieri.
+
+Gli esempi mostrano situazioni del mondo reale, tra cui dare mance agli artisti, trasferire denaro a parenti all'estero, sostenere ONG in modo anonimo o utilizzare Zcash come paghetta digitale privata di un adolescente.
+
+---
+
+## 5. Costruire con Zcash
+
+Questa sezione mette in evidenza come sviluppatori, designer, ricercatori ed educatori possano costruire su Zcash. Introduce concetti come:
+
+- Wallet Zcash  
+- SDK per sviluppatori  
+- Gruppi di lavoro della comunità  
+- Il ruolo dei contributori nello sviluppo open-source  
+- Come gli aggiornamenti della rete Zcash migliorano il protocollo  
+
+I lettori acquisiscono una percezione di come Zcash si evolva nel tempo e di come i contributori globali aiutino ad ampliare strumenti, infrastrutture, applicazioni e risorse didattiche.
+
+
+---
+
+## 6. Sicurezza, protezione e buone pratiche
+
+Questa sezione insegna le abitudini fondamentali di sicurezza digitale:
+
+- Proteggere le chiavi e le seed phrase  
+- Evitare le truffe  
+- Comprendere i wallet custodial vs. non-custodial  
+- Praticare una solida igiene delle password  
+- Evitare di condividere pubblicamente informazioni sensibili del wallet  
+
+Queste lezioni dotano i nuovi utenti di abitudini chiave che vanno oltre Zcash, estendendosi alla vita digitale in generale.
+
+
+---
+
+## 7. La comunità globale di Zcash
+
+L'ecosistema Zcash è globale, eterogeneo e guidato dalla comunità. Questa sezione spiega come i contributori collaborino tramite forum aperti, GitHub, Discord e gruppi di lavoro. Introduce la cultura dello sviluppo open-source, dell'advocacy della privacy e della didattica dal basso.
+
+Il quaderno descrive anche le organizzazioni coinvolte nell'ecosistema, tra cui no-profit, fondazioni e builder indipendenti che sostengono la rete e mantengono la decentralizzazione di Zcash e la sua missione di bene pubblico.
+
+
+---
+
+## 8. Conosci i creatori - "Le persone che l'hanno fatto!"
+
+Questa sezione mette in luce i talentuosi contributori che hanno reso possibile *My First Zcash*. Tra loro:
+
+**Ice (@frostbyte11211)**
+
+Uno studente di scuola superiore interessato a privacy, computer, crittografia e psicologia.
+
+**Pacu (@thecodebuffet)** 
+
+Un veterano sviluppatore di wallet Zcash, in precedenza presso ECC dove lavorava su SDK e tecnologia Light Client, ora contributore dell'ecosistema con una sovvenzione ZCG.
+
+**Marek** 
+
+Un ingegnere presso la Zcash Foundation.  
+
+**Alfredo Garcia** 
+
+Un ingegnere di sistemi Rust che lavora nel team Zebra presso la Zcash Foundation.
+
+**Pili (@mpguerra)** 
+
+Manager presso la Zcash Foundation con oltre 20 anni di esperienza, incluso il lavoro sul Tor Project.
+
+**Zksquirrel** 
+
+Zcash Arborist, redattore di appunti per la comunità e contributore alle iniziative didattiche di ZecHub.
+
+**Tripleyouww** 
+
+Coordinatore del supporto alla comunità presso la Zcash Foundation.  
+
+**Mass Adoption Alliance** 
+
+Un'iniziativa che dà potere ai giovani attraverso la didattica sulle criptovalute decentralizzate e sulla privacy finanziaria.
+
+---
+
+Questi profili mostrano ai lettori che Zcash è mantenuto da una comunità eterogenea di ingegneri, designer, sviluppatori, educatori e organizzatori provenienti da tutto il mondo.
+
+
+---
+
+## 9. Come partecipare
+
+La sezione finale invita i lettori a diventare parte dell'ecosistema Zcash. Le opportunità includono:
+
+- Unirsi al Zcash Global Discord  
+- Partecipare alle community call e ai gruppi di lavoro  
+- Contribuire alle future traduzioni del quaderno  
+- Sostenere la didattica open-source  
+- Creare contenuti, contributi di codice, opere artistiche o feedback  
+- Esplorare le sovvenzioni della comunità Zcash  
+
+Il messaggio è chiaro: chiunque può partecipare, e la comunità accoglie contributori di ogni provenienza e livello di competenza.
+
+[Zcash Global Discord](https://discord.gg/F6DCkCDK)
+
+---
+
+# Licenza
+
+*My First Zcash* è concesso in licenza secondo la **Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0).**
+
+[License](https://creativecommons.org/licenses/by-sa/4.0/)

--- a/translations/it/site/guides/Nym_VPN.md
+++ b/translations/it/site/guides/Nym_VPN.md
@@ -1,0 +1,71 @@
+# Nym VPN 
+
+Nym è una mix network (mixnet) in evoluzione, un tipo di infrastruttura di rete informatica per la privacy che maschera i metadati dell'utente, separando gli indirizzi IP di origine e di destinazione. Anonimizza vari tipi di comunicazione, tra cui la messaggistica, i trasferimenti di file, le transazioni di pagamento e la navigazione web sui siti di base. Il progetto è costruito su software libero e open-source ed è decentralizzato, mantenuto da un insieme distribuito di nodi indipendenti in tutto il mondo. Nym VPN e Mixnet accettano pagamenti in ZEC schermato! 
+
+[Articolo del blog di Nym](https://nym.com/blog/nymvpn-with-zcash) | [Scarica Nym VPN](https://nym.com)
+
+## Tutorial
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/gSeECj4ddYA"
+    title="How to Buy NymVPN with Zcash (ZEC)"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+   
+
+### Accedi a contenuti con restrizioni geografiche
+
+Aggira le restrizioni geografiche per accedere a servizi di streaming, siti web o contenuti non disponibili nella tua regione.
+
+### Migliora la tua sicurezza sul WiFi pubblico
+
+Proteggi i tuoi dati dagli hacker quando usi il Wi-Fi pubblico in bar, aeroporti o hotel.
+
+### Privacy avanzata in un'unica soluzione 
+
+Proteggi la tua privacy
+Cifra la tua connessione internet per nascondere le tue attività online a ISP, inserzionisti e tracker di dati.
+
+### Sii anonimo online
+
+Maschera il tuo indirizzo IP per restare anonimo durante la navigazione, evitando profilazione o pubblicità mirate.
+
+### Evita il throttling della banda
+
+Impedisci agli ISP di rallentare la tua connessione internet quando fai streaming o giochi.
+
+### Previeni sorveglianza e censura
+
+Aggira la censura e accedi a siti web o social media bloccati nei paesi restrittivi.
+
+### Servizi bancari online sicuri
+
+Proteggi le informazioni finanziarie sensibili quando accedi ai servizi bancari online o effettui pagamenti.
+
+### Evita i prezzi dinamici
+
+Nascondi la tua posizione per evitare la discriminazione di prezzo basata sulla località per voli, hotel o prodotti.
+
+### Proteggi le tue transazioni crypto
+
+Proteggi le tue attività in criptovaluta con i pagamenti non collegabili (unlinkable) e la protezione avanzata dei metadati di NymVPN.
+
+
+## Guide all'installazione di Nym VPN:
+
+[iOS](https://vimeo.com/1083490444/81e95709b0) 
+
+[MacOS](https://vimeo.com/1080779573/78844dc8db)
+
+[Windows](https://vimeo.com/1085710809/52876930a6)
+
+[Android](https://vimeo.com/1096218590?share=copy)
+
+
+Scopri di più sull'[integrazione tra Nym e Zcash](https://nym.com/blog/zcash-ltgt-nym)
+ 

--- a/translations/it/site/guides/Raspberry_Pi_4_Full_Node.md
+++ b/translations/it/site/guides/Raspberry_Pi_4_Full_Node.md
@@ -1,0 +1,402 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Raspberry_Pi_4_Full_Node.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# Raspberry Pi 4: guida a un nodo completo *zcashd*
+
+
+Lo scopo di questa guida è aiutare a istruire gli Zcasher interessati a far girare un nodo completo su un Raspberry Pi 4 a basso consumo.
+
+<img src="https://user-images.githubusercontent.com/81990132/197372541-dcd886ab-a3d0-4614-b490-0294ddf3ffae.png" alt="zcashd" width="700" height="700"/>
+
+
+## Video
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/SGYrzhs1l2k"
+    title="How to compile Zcash Node on Raspberry Pi!"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+## Supporto
+
+Se trovi utile questa guida, valuta di donare ZEC per sostenere ZecHub:
+
+`u1rl2zw85dmjc8m4dmqvtstcyvdjn23n0ad53u5533c97affg9jq208du0vf787vfx4vkd6cd0ma4pxkkuc6xe6ue4dlgjvn9dhzacgk9peejwxdn0ksw3v3yf0dy47znruqftfqgf6xpuelle29g2qxquudxsnnen3dvdx8az6w3tggalc4pla3n4jcs8vf4h29ach3zd8enxulush89`
+
+
+## Cosa imparerai
+
+```markdown
+* How to create a bootable Ubuntu Server microSD card
+* How to setup internet connectivity on the Raspberry Pi 4
+* How to access your Raspberry Pi 4 remotely
+* How to install zcashd
+* How to setup zcashd
+* How to use zcashd
+```
+
+
+## Prerequisiti
+
+> [Canakit Raspberry Pi 4 da 8GB](https://www.canakit.com/raspberry-pi-4-starter-max-kit.html) o equivalente
+
+> Un computer con un lettore di schede microSD
+
+> Una rete Wi-Fi o un cavo ethernet con connessione a internet
+
+> SSD/HHD esterno con supporto USB3
+
+
+##### nota: mantenere sicuro il tuo server *non* è affatto semplice. Per qualsiasi suggerimento/raccomandazione/buona pratica che vada oltre quanto trattato in questa guida, *per favore* crea una PR e aiuta a mantenere questa guida il più aggiornata possibile.
+
+
+
+### Preparare la scheda SD
+
+In questo passaggio creerai una scheda SD *avviabile* che permetterà al tuo Raspberry Pi 4 di avviarsi. Inserisci la scheda microSD nel computer. Potresti dover usare l'adattatore fornito con il Canakit o qualsiasi altro adattatore equivalente. Installa Raspberry Pi Imager per il tuo sistema operativo. Scarica la versione per il sistema operativo a cui hai accesso al momento.
+     
+     > [Ubuntu](https://downloads.raspberrypi.org/imager/imager_latest_amd64.deb)
+     
+     > [Windows](https://downloads.raspberrypi.org/imager/imager_latest.exe)
+     
+     > [macOS](https://downloads.raspberrypi.org/imager/imager_latest.dmg)
+
+Per esempio, su linux dopo aver scaricato digiteresti quanto segue:
+
+`sudo dpkg -i imager_latest_amd64.deb`
+
+Apri Raspberry Pi Imager
+
+`rpi-imager`
+
+<img src="https://user-images.githubusercontent.com/81990132/197372069-fb9f7417-d320-42cf-ad65-38d630512985.png" alt="rpi imager" width="400" height="400"/>
+
+Scegli il sistema operativo e il dispositivo di archiviazione. Poiché i Raspberry Pi 4 sono a 64 bit, consiglio di scegliere "Other general-purpose OS" => Ubuntu => Ubuntu Server 24.04.3 LTS (64 bit). Clicca su Storage e seleziona la tua scheda SD. Prima di scrivere sulla scheda SD, clicca su Advanced options cliccando sull'icona bianca a forma di ingranaggio vicino all'angolo in basso a destra.
+
+
+<img src="https://user-images.githubusercontent.com/81990132/197372159-1169c6f4-f6aa-4f44-9679-fe7aa542bbd3.png" alt="gear" width="200" height="200"/>
+
+
+
+Qui puoi aggiornare:
+
+```markdown
+* Hostname of your Raspberry Pi 4
+* Enable SSH
+* Create a username and pw
+* Enable and configure your wi-fi if needed
+```
+ 
+<img src="https://user-images.githubusercontent.com/81990132/197372149-8b85bfac-e473-4808-87cd-f27f15d05de8.png" alt="advanced" width="400" height="400"/>
+
+ 
+Una volta completato premi Write
+
+
+### Avviare Ubuntu Server
+
+Se hai un monitor e una tastiera in più collegali ora. Nota: sono opzionali. Inserisci la scheda SD appena formattata nel Raspberry Pi 4 e collega anche l'SSD/HHD esterno alla porta USB3. Collega anche il cavo di alimentazione e accendilo.
+
+### Connettersi da remoto al tuo Raspberry Pi 4
+
+Ora dobbiamo connetterci al tuo Raspberry Pi 4. Cose che ci servono:
+
+```markdown
+* Username and pw (from previous step)
+* IP address so we can use SSH
+* Monitor, and keyboard (optional)
+* If you have a monitor and keyboard connected directly to your pi, the rest of this section can be skipped.
+```
+
+Due modi per trovare il tuo indirizzo IP sono tramite la pagina di amministrazione del router, oppure con nmap. Se usi il router, dipende dal produttore e rimando questi dettagli a una rapida ricerca su google. Per nmap, prima assicurati che sia installato:
+
+     `sudo apt-get install nmap`
+     
+Trova l'indirizzo IP del tuo computer attuale e annota le prime tre sezioni. Tipicamente è 192.168.1.xxx o 192.168.50.xxx. Inserisci questi dettagli in nmap come segue:
+          
+`sudo nmap -sn 192.168.50.0/24`
+
+oppure
+
+`sudo nmap -sn 192.168.1.0/24`
+
+Questo mostrerà tutti i dispositivi connessi alla tua rete domestica, che dovrebbe rivelare l'indirizzo IP / indirizzo MAC del tuo Raspberry Pi 4. Usando il tuo username, la tua pw e il tuo indirizzo IP possiamo ora effettuare il login tramite SSH
+
+```markdown
+* ssh <username>@<ip address of your pi> note: you must plugin *your* username and *your* IP address, and *your* pw when prompted.
+* For example: `ssh ubuntu@192.168.1.25 where the username is *ubuntu* and IP address is 192.168.1.25.
+```
+
+
+  <img src="https://user-images.githubusercontent.com/81990132/197372846-e1279388-eaaa-4fbb-8d5d-f9928cb45195.png" alt="sshLogin" width="400" height="400"/>
+       
+
+Se sei curioso di sapere quale versione di Raspberry Pi stai usando, prova questo comando:
+
+     `cat /sys/firmware/devicetree/base/model ; echo`
+
+  <img src="https://user-images.githubusercontent.com/81990132/197689888-367c8eb3-2667-4c8c-85b3-44d46afe07a7.png" alt="which" width="700" height="400"/>
+
+         
+
+### Installare *zcashd*
+
+Due modi per installare zcashd includono il download di un binario precompilato oppure la compilazione di zcashd dal codice sorgente. Consiglio *vivamente* di compilare dal sorgente. Per compilare da soli è altamente raccomandato il cross-compile. Il cross-compile consiste nel costruire su una piattaforma un binario che girerà su un'altra piattaforma. Una delle ragioni è che i Raspberry Pi 4 sono a basso consumo e quindi non molto veloci! Sfrutta il tuo computer principale per aiutarti in questo. Puoi prendere l'ultima release [qui](https://github.com/zcash/zcash/releases). Per fare il cross-compile dobbiamo assicurarci di avere i pacchetti necessari. Installa quanto segue:
+
+```bash
+sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python3 python3-zmq zlib1g-dev curl bsdmainutils automake libtinfo5
+sudo apt-get install gcc-aarch64-linux-gnu
+```
+
+Poi spostati nella directory della release di zcashd appena scaricata ed esegui:
+
+`HOST=aarch64-linux-gnu ./zcutil/build.sh`
+          
+
+### Configurare *zcashd*
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/9t2LX3HFldw"
+    title="Zcashd Wallet Tool - Generate & Import Private Key"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+---
+
+Ora dobbiamo trasferire tutti i file binari di zcashd sul tuo Raspberry Pi 4. A partire da Zcashd v5.3 i file necessari includono:
+
+```markdown
+zcashd
+zcash-cli
+zcash-tx
+zcash-gtest
+zcash-inspect
+zcashd-wallet-tool
+fetch-params.sh
+```
+
+Questi file si trovano nella directory /src della tua ultima release scaricata se li hai compilati tu stesso. Altrimenti, i file precompilati sono dove li hai scaricati. Due modi per realizzare i trasferimenti sono usare SFTP, oppure usare il tuo drive esterno.
+
+#### SFTP
+
+```bash
+sftp username@<ip of RaspberryPi4>
+put zcash*
+```
+   
+#### Copia esterna
+     
+Copia semplicemente i file sul drive esterno prima di collegarlo al Raspberry Pi 4. Se hai già un nodo completo sincronizzato e vuoi risparmiare tempo, puoi anche copiare i dati di blocks e chainstate.
+   
+` cd ~/.zcash/`
+     
+Esegui semplicemente:
+
+```bash
+tar -zcvf blocks.tar.gz /blocks
+tar -zcvf chainstate.tar.gz /chainstate
+```
+     
+Copia i file .gz di blocks e chainstate sul tuo SSD/HHD esterno. Poi monta l'SSD/HDD esterno nella cartella Media così da poterlo vedere:
+
+```markdown
+lsblk will display all drives connected. Most will be of the format sda
+id will show your user and group id's.
+```
+          
+<img src="https://user-images.githubusercontent.com/81990132/197372643-abef88fd-9177-4bf9-abda-3c221188cd10.png" alt="lsblk" width="400" height="400"/>
+
+
+          
+          `sudo mount -o umask=0077,gid=<groupid>,uid=<userid> /dev/sda1 /media/portableHD/`
+          
+Tieni d'occhio sia chi possiede le cartelle/file sia i permessi.
+
+```bash
+sudo chown -R <username>: portableHD
+sudo chmod -R 600 portableHD/
+```
+     
+Se hai copiato i file .gz di blocks e chainstate dall'altro computer, estraili ora. Assicurati che siano nella cartella .zcash sul tuo drive esterno.
+
+```bash
+tar - xvzf blocks.tar.gz
+tar - xvzf chainstate.tar.gz
+```
+
+
+Configura /media/portableHD/.zcash/zcash.conf
+
+<img src="https://user-images.githubusercontent.com/81990132/197373699-18cc2c9f-b47d-44e9-9e6b-4c5cccf78d9e.png" alt="zconf" width="700" height="400"/>
+
+
+ 
+Nota come abbiamo spostato la datadir sull'SSD/HDD esterno che ha molto più spazio disponibile. Poiché la posizione predefinita della cartella .zcash è stata spostata, dobbiamo comunicarlo a *zcashd* usando i collegamenti simbolici:
+
+```markdown
+cp -rp ~/.zcash/* /new_dir         // Make copy of datadir or supply with an external HD
+rm -rf ~/.zcash                    // Remove default folder
+ln -s /media/portableHD/ ~/.zcash  // Symbolic link new data location to the default so zcashd is happy
+```
+   
+
+Esegui lo script fetch-params.sh per scaricare i dati necessari a zcashd
+   
+    `./fetch-params.sh`
+
+
+Avvia un nuovo 'screen' [ programma in linux ]. Apri zcashd con -datadir impostato:
+
+```bash
+screen -S zcashScreen`     
+./zcashd -datadir=/media/portableHD/.zcash/
+```
+     
+Stacca lo screen:
+
+`Ctrl+a , Ctrl+d`
+
+
+Crea un alias così non devi digitare tutti questi comandi extra sulla posizione dei dati
+
+     `alias zcash-cli="./zcash-cli -datadir=/media/portableHD/.zcash/"`
+
+
+Pronto all'uso!
+
+    `zcash-cli getblockchaininfo`
+
+  <img src="https://user-images.githubusercontent.com/81990132/197373098-672aa228-d180-47ea-8a7c-c58dc3882426.png" alt="getblockchaininfo" width="400" height="400"/>
+
+
+
+### Usare *zcashd*
+
+<iframe class="w-full h-auto md:h-96" src="https://www.youtube.com/embed/KNhd1KC0Bqk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+---
+
+Come controlli lo stato del tuo nodo?
+
+     `tail -n 500 <path to>/.zcash/debug.log`
+
+  <img src="https://user-images.githubusercontent.com/81990132/197684416-9a083de4-4a62-4fe8-9cab-798781b38cd2.png" alt="status" width="700" height="400"/>
+
+
+  
+     
+Per ottenere l'altezza attuale dal tuo log
+
+     `tail -n 10 <path to>/.zcash/debug.log | grep -o  'height=[^b]*'`
+
+  <img src="https://user-images.githubusercontent.com/81990132/199630447-6a6cd491-0cb3-47f8-95f0-45f6b6555870.png" alt="logHeight" width="500" height="400"/>
+
+
+     
+     `zcash-cli getinfo`
+  
+<img src="https://user-images.githubusercontent.com/81990132/199646508-132da0eb-899e-49a6-8b31-e9011e159700.png" alt="getInfo" width="400" height="400"/>
+
+     
+     
+Come invii un memo? Come mostrato [qui](https://zcash.readthedocs.io/en/latest/rtd_pages/memos.html), scarica *ascii2hex* e *hex2ascii* e rendili eseguibili 
+
+`chmod +x ascii2hex hex2ascii`
+          
+Crea un memo e convertilo in hex. Puoi riconvertirlo in ascii per fare una verifica.
+          
+<img src="https://user-images.githubusercontent.com/81990132/199646812-782142d6-8846-443a-8dd9-4f332e49d3e9.png" alt="asciiGOOD" width="400" height="400"/>
+
+
+  
+Crea una transazione z2z (Sapling) usando la versione hex del tuo memo qui sopra
+
+`zcash-cli z_sendmany "ztestsapling1kg3u0y7szv6509732at34alct46cyn0g26kppgf2a7h5tpqxldtwm7cmhf8rqmhgt" "[{\"address\": \"ztestsapling2kg3u0y7szv6509732at34alct46cyn0g26kppgf2a7h5tpqxldtwm7cmhf8rqmhgtmpakcz5mdv\",\"amount\": 0.0001, \"memo\":\"5A656348756221\"}]"`
+
+Come riprendi il tuo zcashScreen dopo averlo staccato?
+
+`screen -r zcashScreen`
+     
+Come fermi *zcashd*?
+
+`zcash-cli stop`
+     
+Come crei una UA?
+
+`zcash-cli z_getnewaccount`
+     
+  <img src="https://user-images.githubusercontent.com/81990132/202352436-04c17be2-e914-4b9b-95d1-00cf6fc496d3.png" alt="newAccount" width="400" height="400"/>
+
+    
+Ora costruisci un receiver per la UA in base alle *tue esigenze*. Questo include solo Orchard, Orchard + Sapling, e infine Orchard + Sapling + Transparent. Nota che puoi distinguere i receiver dalla loro lunghezza.
+     
+<img src="https://user-images.githubusercontent.com/81990132/202354319-2da6be33-ca95-4b6b-b29c-14805dcb9c21.png" alt="chars" width="200" height="100"/>
+
+
+`zcash-cli z_getaddressforaccount 0 '["orchard"]'`
+     
+<img src="https://user-images.githubusercontent.com/81990132/202353642-c36b5fea-de8a-41f6-a27c-d9ff42a0c8d3.png" alt="uaOrchard" width="400" height="400"/>
+
+<img src="https://user-images.githubusercontent.com/81990132/202355586-eaeb36e7-b000-4b99-8192-81e5002e6f11.png" alt="OrchQR" width="400" height="400"/>
+
+`zcash-cli z_getaddressforaccount 0 '["orchard","sapling"]'`
+     
+<img src="https://user-images.githubusercontent.com/81990132/202353732-740828e3-77b8-4684-8cf8-fb14256b1e61.png" alt="uaOrchardSapling" width="400" height="400"/>
+<img src="https://user-images.githubusercontent.com/81990132/202355596-c7b62854-9a9e-4627-ab5d-51091340de71.png" alt="OrchSapQR" width="300" height="200"/>
+
+
+`zcash-cli z_getaddressforaccount 0 '["orchard","sapling","p2pkh"]'`
+     
+<img src="https://user-images.githubusercontent.com/81990132/202353793-3331c593-5286-4b84-93a7-adc4928839fd.png" alt="uaFull" width="400" height="400"/>
+<img src="https://user-images.githubusercontent.com/81990132/202355607-75de0750-2a57-4e10-883b-e0a626ed892a.png" alt="FullQR" width="400" height="400"/>
+
+
+Come invii ZEC usando una UA?
+
+`zcash-cli z_sendmany "fromOaddress" "[{\"address\": \"dOrchardAddress\",\"amount\": 0.0001, \"memo\":\"yourMemoinHex\"}]" <minconf> <fee> <privacyPolicy>`
+
+<img src="https://user-images.githubusercontent.com/81990132/202365280-c184f622-eb7e-4095-bc38-90795121c43c.png" alt="UAsuccess" width="400" height="400"/>
+<img src="https://user-images.githubusercontent.com/81990132/202366758-40650460-aaeb-4e03-891f-b4bd08e18234.png" alt="pic" width="400" height="400"/>
+
+    
+##### Va sottolineato che sia l'indirizzo *di partenza* SIA quello *di destinazione* possono essere indirizzi transparent, sapling o orchard, tuttavia potresti dover regolare il flag privacyPolicy affinché la transazione sia valida. (Alcune combinazioni non funzioneranno se privacyPolicy non ha senso!)
+
+
+Dove posso trovare maggiori informazioni sulle UA?
+
+> Dai un'occhiata al [post](https://medium.com/@hanh425/transaction-privacy-78f80f9f175e) di [Hanh](https://medium.com/@hanh425/transaction-privacy-78f80f9f175e) sulla privacy delle transazioni. Anche [questo](https://forum.zcashcommunity.com/t/unified-addresses-full-node-rpc-api/41980/2) post dal forum di zcash.
+
+> [Questo](https://github.com/zcash/zips/issues/470)
+
+     
+### Fonti
+
+<div>
+
+- https://ubuntu.com/tutorials/how-to-install-ubuntu-on-your-raspberry-pi#1-overview
+- https://github.com/zcash/zcash
+- https://zcash.readthedocs.io/en/latest/rtd_pages/Debian-Ubuntu-build.html
+- https://zcash.readthedocs.io/en/latest/rtd_pages/memos.html
+- https://en.wikipedia.org/wiki/Secure_Shell
+- https://itsfoss.com/how-to-find-what-devices-are-connected-to-network-in-ubuntu/
+- https://youtu.be/YS5Zh7KExvE
+- https://twitter.com/BostonZcash/status/1531798627512877059
+- https://forum.zcashcommunity.com/t/unified-addresses-full-node-rpc-api/41980/2
+- https://medium.com/@hanh425/transaction-privacy-78f80f9f175e
+- https://znewsletter.netlify.app/
+- https://github.com/zcash/zips/issues/470
+- https://zips.z.cash/protocol/nu5.pdf#unifiedpaymentaddrencoding
+
+</div>

--- a/translations/it/site/guides/Raspberry_pi5_Zebra_Lightwalletd_Zingo.md
+++ b/translations/it/site/guides/Raspberry_pi5_Zebra_Lightwalletd_Zingo.md
@@ -1,0 +1,119 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Raspberry_pi5_Zebra_Lightwalletd_Zingo.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# RPi5 Zebra Lightwalletd con Zingo
+
+## Video tutorial
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/FfH5jiX8pT0"
+    title="Using Zcash Zebra Node with Lightwalletd: TUTORIAL"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+## Dipendenze
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+sudo apt install libclang-dev clang pkg-config openssl protobuf-compiler npm
+```
+
+## Compila Zebra
+
+[Zebra Github](https://github.com/ZcashFoundation/zebra)
+
+* `time cargo install --git https://github.com/ZcashFoundation/zebra --tag v3.1.0 zebrad`
+
+## Configura zebrad.toml
+
+aggiungi:
+
+`listen_addr = '127.0.0.1:8232'`
+
+`cache_dir = "/media/zebra5/zebra/"`
+
+## Sincronizza Zebra
+
+* `zebrad start`
+
+## Compila lightwalletd
+
+* installa go
+
+```bash
+wget https://go.dev/dl/go1.25.5.linux-arm64.tar.gz
+sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.25.5.linux-arm64.tar.gz go/
+export PATH=$PATH:/usr/local/go/bin
+```
+
+* installa lightwalletd
+
+```bash
+git clone https://github.com/zcash/lightwalletd
+cd lightwalletd
+make
+make install
+export PATH=$PATH:~/go/bin/`
+```
+
+## Sincronizza lightwalletd
+
+* nota la modifica della data-dir
+
+  `lightwalletd --zcash-conf-path ~/.config/zcash.conf --data-dir /media/zebra5/zebra/.cache/lightwalletd --log-file /dev/stdout --no-tls-very-insecure`
+
+
+## Installa NodeJS
+
+```bash
+ curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh
+ sudo -E bash nodesource_setup.sh
+ sudo apt update
+ sudo apt install nodejs
+```
+Se riscontri errori, [qui](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-22-04) trovi alcuni modi alternativi per installare NodeJS.
+
+## Installa Yarn
+
+`corepack enable`
+
+## Installa Zingo
+
+```bash
+git clone https://github.com/zingolabs/zingo-pc.git
+cd zingo-pc
+yarn install
+sudo apt install libopenjp2-tools protobuf-compiler openssl libssl-dev libfuse2
+export USE_SYSTEM_FPM="true"
+sudo apt-get install ruby-dev build-essential && sudo gem i fpm -f
+yarn dist:linux
+```
+
+## Avvia Zingo-PC
+
+* Puoi usare l'appimage, oppure il binario nella cartella unpacked
+* Buon divertimento! :)
+
+# Fonti
+
+```markdown
+https://github.com/ZcashFoundation/zebra
+https://github.com/zcash/lightwalletd
+https://askubuntu.com/questions/1278447/installing-fpm-on-ubuntu-20-04
+https://github.com/oxen-io/session-desktop/issues/1635
+https://askubuntu.com/questions/1363783/cant-run-an-appimage-on-ubuntu-20-04
+https://www.beekeeperstudio.io/blog/electron-apps-for-arm-and-raspberry-pi
+https://github.com/electron-userland/electron-builder/issues/3901
+https://askubuntu.com/questions/1278447/installing-fpm-on-ubuntu-20-04
+https://yarnpkg.com/getting-started/install
+https://pimylifeup.com/raspberry-pi-nodejs/
+https://go.dev/dl/#stable
+https://askubuntu.com/questions/1177492/openssl-installed-but-no-openssl-pc-needed-by-pkg-config
+```

--- a/translations/it/site/guides/Raspberry_pi_4_Zebra_Node.md
+++ b/translations/it/site/guides/Raspberry_pi_4_Zebra_Node.md
@@ -1,0 +1,80 @@
+<a href="https://github.com/henryquincy/zechub/edit/main/site/guides/Raspberry_pi_4_Zebra_Node.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Guida al Raspberry Pi 4 per eseguire Zebra
+
+<img src="https://i.ibb.co/V3rjKwv/image-2023-11-28-172907488.png" alt="raspberry pi" width="300" height="300"/>
+
+Eseguire il software del nodo Zebra su un Raspberry Pi 4 ti permette di partecipare alla rete Zcash come nodo indipendente e compatibile con il consenso. Questa guida ti accompagnerà attraverso i passaggi per configurare ed eseguire Zebra sul tuo Raspberry Pi 4.
+
+## Prerequisiti
+
+1. Raspberry Pi 4 (2GB di RAM o superiore consigliato).
+
+2. Scheda MicroSD (16GB o superiore consigliato) con Raspberry Pi OS (Raspbian) installato.
+
+3. Connessione a internet stabile.
+
+4. Tastiera, mouse e un monitor (per la configurazione iniziale).
+
+5. Client SSH (facoltativo, per l'accesso remoto).
+
+## Installazione
+
+1. __Aggiorna il tuo sistema__
+   Apri un terminale o accedi via SSH al tuo Raspberry Pi e assicurati che il tuo sistema sia aggiornato eseguendo:
+
+   __sudo apt update__
+
+   __sudo apt upgrade__
+
+2. __Installa le dipendenze__
+   Dovrai installare alcune dipendenze necessarie per compilare ed eseguire Zebra:
+
+   __sudo apt install build-essential cmake git clang libssl-dev pkg-config__
+
+3. __Clona il repository di Zebra__
+   Apri un terminale e clona il repository di Zebra sul tuo Raspberry Pi:
+
+   __git clone https://github.com/ZcashFoundation/zebra.git__
+
+   __cd zebra__
+
+4. __Compila Zebra__
+   Per compilare Zebra, usa i seguenti comandi:
+
+   __cargo build --release__
+
+   Questo processo potrebbe richiedere del tempo. Assicurati che il tuo Raspberry Pi sia adeguatamente raffreddato, poiché la compilazione può generare calore.
+
+5. __Configurazione__
+   Crea un file di configurazione per Zebra. Puoi usare la configurazione predefinita come punto di partenza:
+
+   __cp zcash.conf.example zcash.conf__
+
+   Modifica il file zcash.conf per personalizzare le impostazioni del tuo nodo. Puoi specificare la rete, abilitare il mining, configurare le connessioni con i peer e altro.
+
+6. __Avvia Zebra__
+   Ora puoi avviare Zebra con la tua configurazione personalizzata:
+
+   __./target/release/zebrad -c zcash.conf__
+
+   __git comment__ 
+
+   Questo comando avvierà il nodo Zebra, che inizierà a sincronizzarsi con la blockchain di Zcash.
+
+7. __Monitoraggio__
+   Puoi monitorare l'avanzamento e lo stato del tuo nodo Zebra aprendo un browser web e navigando su __http://127.0.0.1:8233/status__.
+
+<img src="https://i.ibb.co/BCtKrGp/image-2023-11-28-173024853.png" alt="zebra logo" width="200" height="200"/>
+
+## Risoluzione dei problemi
+
+Se incontri problemi nella compilazione o nell'esecuzione di Zebra, consulta la [documentazione di Zebra](https://doc.zebra.zfnd.org/docs/intro.html) per suggerimenti sulla risoluzione dei problemi e informazioni aggiuntive.
+
+Assicurati di mantenere il tuo Raspberry Pi fresco, poiché eseguire un nodo può generare calore. Potresti voler usare una soluzione di raffreddamento, come una ventola o un dissipatore di calore.
+
+## Conclusione
+
+Seguendo questa guida, dovresti aver configurato ed eseguito Zebra con successo sul tuo Raspberry Pi 4. Ora stai contribuendo alla rete Zcash come nodo indipendente, aiutando a proteggere la privacy delle transazioni Zcash.

--- a/translations/it/site/guides/ShapeShift_Zcash.md
+++ b/translations/it/site/guides/ShapeShift_Zcash.md
@@ -1,0 +1,178 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/ShapeShift_Zcash.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ShapeShift e Zcash: Trading Decentralizzato che Mette la Privacy al Primo Posto
+
+---
+
+## Introduzione
+
+La privacy e l'autocustodia sono principi fondamentali delle criptovalute, eppure molti utenti si affidano ancora a exchange centralizzati che richiedono la verifica dell'identità e detengono i fondi degli utenti. L'integrazione tra ShapeShift e Zcash riunisce una piattaforma di exchange completamente decentralizzata e una delle criptovalute più avanzate nella tutela della privacy, offrendo agli utenti un modo per scambiare ZEC senza sacrificare la privacy o il controllo dei propri asset.
+
+Questo articolo spiega cos'è ShapeShift, come funziona Zcash, come puoi scambiare ZEC su ShapeShift e perché questa partnership è importante per il futuro della finanza privata e decentralizzata.
+
+---
+
+## Cos'è ShapeShift?
+
+[ShapeShift](https://shapeshift.com/) è una piattaforma di criptovalute decentralizzata e open-source che permette agli utenti di scambiare, monitorare e gestire asset digitali su più blockchain senza creare un account, presentare documenti d'identità o cedere la custodia dei propri fondi.
+
+### Una Breve Storia
+
+ShapeShift è stata originariamente fondata nel 2014 da Erik Voorhees come exchange di criptovalute centralizzato con sede in Svizzera. La piattaforma divenne rapidamente popolare per la sua interfaccia semplice che permetteva agli utenti di scambiare una criptovaluta con un'altra senza creare un account.
+
+Nel 2021, ShapeShift ha subito una trasformazione radicale. L'azienda ha sciolto la propria struttura societaria ed è passata a essere un'**Organizzazione Autonoma Decentralizzata (DAO)**, governata dai detentori del **token FOX**. Come parte di questa transizione, circa 340 milioni di token FOX sono stati distribuiti tramite airdrop a oltre un milione di utenti, rendendolo uno dei più grandi airdrop nella storia delle cripto. Da quel momento in poi, tutte le decisioni importanti sulla piattaforma sono state prese tramite proposte e votazioni di governance comunitaria.
+
+### Caratteristiche Principali
+
+- **Non Custodiale**: Gli utenti scambiano direttamente dai propri wallet. ShapeShift non detiene mai i tuoi fondi.
+- **Nessun KYC Richiesto**: Nessuna verifica dell'identità, nessuna creazione di account e nessuna raccolta di dati personali.
+- **Supporto Multichain**: Accesso a oltre 10.000 asset su più di 15 blockchain, tra cui Bitcoin, Ethereum, Cosmos e Zcash.
+- **Aggregazione DEX**: ShapeShift instrada gli scambi attraverso protocolli decentralizzati come THORChain, 0x e altri per trovare le migliori tariffe.
+- **Scambi Cross-Chain**: Scambia asset in modo nativo tra diverse blockchain senza usare token wrappati o bridge centralizzati.
+- **Completamente Open-Source**: L'intera piattaforma, inclusa l'app mobile, è open-source senza alcun backend proprietario oltre ai dati della blockchain.
+
+---
+
+## Come Funziona Zcash
+
+[Zcash](https://z.cash/) (ZEC) è una criptovaluta costruita su solide fondamenta crittografiche che danno agli utenti la possibilità di effettuare transazioni in modo privato. Lanciata nel 2016, Zcash è un fork di Bitcoin che aggiunge tecnologia avanzata per la privacy mantenendo al contempo l'offerta fissa di Bitcoin di 21 milioni di monete e il consenso proof-of-work.
+
+### Transazioni Schermate e Prove a Conoscenza Zero
+
+L'innovazione centrale di Zcash è il suo uso di **prove a conoscenza zero** (nello specifico, una forma chiamata **zk-SNARKs**). Queste prove crittografiche permettono a una parte di dimostrare a un'altra che un'affermazione è vera senza rivelare alcuna informazione oltre alla validità dell'affermazione stessa.
+
+In pratica, questo significa che le transazioni Zcash possono essere completamente **schermate**: l'indirizzo del mittente, l'indirizzo del destinatario e l'importo della transazione sono tutti cifrati sulla blockchain. La rete può comunque verificare che la transazione sia valida (nessuna doppia spesa, saldi corretti) senza mai vedere quei dettagli.
+
+### Tipi di Transazione
+
+Zcash supporta due tipi di indirizzi:
+
+- **Indirizzi trasparenti** (indirizzi-t): Funzionano come gli indirizzi Bitcoin, dove i dettagli della transazione sono pubblicamente visibili sulla blockchain.
+- **Indirizzi schermati** (indirizzi-z): Usano prove a conoscenza zero per mantenere privati i dettagli della transazione.
+
+Gli utenti possono inviare ZEC tra indirizzi trasparenti e schermati. Per la massima privacy, le transazioni da un indirizzo schermato a un altro non rivelano alcuna informazione pubblicamente.
+
+### Unified Address
+
+I wallet Zcash moderni come [Zashi](https://electriccoin.co/zashi/) usano gli **Unified Address**, che combinano sia i ricevitori trasparenti che quelli schermati in un singolo indirizzo. Questo semplifica l'esperienza utente impostando come predefinito il più alto livello di privacy disponibile.
+
+### Perché la Privacy è Importante
+
+La privacy finanziaria non riguarda il nascondere atti illeciti. Protegge gli individui dalla sorveglianza, dalla raccolta dati aziendale e dagli attacchi mirati. Proprio come non vorresti che il saldo del tuo conto bancario fosse visibile al pubblico, le transazioni in criptovaluta meritano lo stesso livello di riservatezza. Zcash fornisce questo per progettazione.
+
+---
+
+## Come Scambiare ZEC su ShapeShift
+
+La piattaforma ShapeShift permette agli utenti di acquisire e scambiare ZEC attraverso un processo completamente decentralizzato. Ecco come funziona.
+
+### Passo 1: Visita ShapeShift
+
+Naviga su [app.shapeshift.com](https://app.shapeshift.com/) nel tuo browser web o scarica l'app mobile di ShapeShift. Non è richiesta alcuna creazione di account o verifica dell'identità.
+
+### Passo 2: Connetti il Tuo Wallet
+
+Connetti un wallet di autocustodia compatibile. ShapeShift supporta una serie di wallet, tra cui:
+
+- **KeepKey** (hardware wallet)
+- **MetaMask**
+- **XDEFI / Ctrl Wallet**
+- **Keplr** (per asset basati su Cosmos)
+- **Wallet compatibili con WalletConnect**
+
+Dal momento che stai scambiando verso o da ZEC, assicurati di avere pronto un wallet compatibile con Zcash (come Zashi) per ricevere i tuoi fondi.
+
+### Passo 3: Seleziona la Tua Coppia di Scambio
+
+Usa l'interfaccia di scambio per selezionare l'asset da cui vuoi scambiare (per esempio, BTC, ETH o un token ERC-20) e imposta ZEC come asset di destinazione. L'interfaccia di ShapeShift è progettata con un layout pulito, in stile Uniswap, ottimizzato sia per desktop che per mobile.
+
+### Passo 4: Inserisci l'Importo e Rivedi
+
+Inserisci l'importo che desideri scambiare. ShapeShift instraderà lo scambio attraverso il miglior protocollo decentralizzato disponibile (come THORChain per gli scambi cross-chain) e mostrerà il tasso stimato, le commissioni e l'importo in uscita.
+
+### Passo 5: Conferma ed Esegui
+
+Rivedi i dettagli della transazione e conferma. Lo scambio viene eseguito on-chain attraverso protocolli decentralizzati. I tuoi ZEC saranno consegnati all'indirizzo che hai specificato. Nessun intermediario detiene mai i tuoi fondi.
+
+### Passo 6: Scherma i Tuoi ZEC
+
+Una volta arrivati i tuoi ZEC, usa la funzione **shield** del tuo wallet Zcash (disponibile in wallet come Zashi) per spostare i fondi nel pool schermato. Questo garantisce che il tuo saldo e le tue future transazioni rimangano completamente privati.
+
+### Coppie Cross-Chain Supportate
+
+ShapeShift abilita gli scambi di ZEC su molteplici ecosistemi blockchain, tra cui:
+
+- **Bitcoin** (BTC) &lt;-&gt; ZEC
+- **Ethereum** (ETH) &lt;-&gt; ZEC
+- Asset **Arbitrum** &lt;-&gt; ZEC
+- Token dell'ecosistema **Cosmos** &lt;-&gt; ZEC
+
+---
+
+## Perché Questa Integrazione è Importante
+
+### Riconquistare la Privacy nella DeFi
+
+La maggior parte degli exchange decentralizzati tratta la privacy come un ripensamento. Le transazioni sui DEX basati su Ethereum, per esempio, sono completamente trasparenti: chiunque può tracciare la cronologia del tuo wallet, i saldi dei token e i pattern di trading. L'integrazione ShapeShift-Zcash sfida questa norma fornendo accesso a ZEC schermato attraverso una piattaforma decentralizzata e senza KYC.
+
+Come ha dichiarato Houston Morgan, responsabile del workstream di crescita e community di ShapeShift: *"La privacy non dovrebbe fare paura, ma scambiare ZEC su exchange centralizzati spesso la fa. La loro stessa struttura e il loro rischio legale uccidono la vera privacy."*
+
+### Dal Delisting al Predefinito
+
+La storia rende questa integrazione ancora più significativa. Nel 2020, quando ShapeShift era ancora un'azienda centralizzata, ha **delistato le privacy coin** tra cui Zcash sotto pressione normativa. La transizione a una struttura DAO ha liberato ShapeShift da quei vincoli. Ora, come protocollo governato dalla community, ShapeShift non solo ha re-listato Zcash, ma ne ha fatto una parte centrale della propria strategia di privacy.
+
+Con il rilascio di **ShapeShift v4.0** nel dicembre 2025, Zcash è diventato l'**asset primario di pagamento e instradamento per la tutela della privacy** della piattaforma. La privacy è ora posizionata come funzionalità predefinita, non come componente aggiuntivo opzionale, con ZEC integrato direttamente nello stack di wallet e instradamento di ShapeShift.
+
+### Supporto degli Zcash Community Grants
+
+Il programma [Zcash Community Grants](https://zcashcommunitygrants.org/) ha stanziato **50.000 $** per supportare l'infrastruttura tecnica e gli sforzi di marketing di ShapeShift per l'integrazione di Zcash. Questo finanziamento ha aiutato il team di ShapeShift a collaborare con **Liquify**, un fornitore di infrastruttura Web3 che supporta oltre 90 blockchain, per gestire gli endpoint di remote procedure call (RPC) per un'esecuzione più rapida e una maggiore affidabilità della rete.
+
+### Far Progredire la Finanza Decentralizzata
+
+Questa integrazione dimostra che privacy e decentralizzazione possono funzionare insieme nella DeFi. Gli utenti possono:
+
+- **Scambiare** asset tra catene senza intermediari centralizzati
+- **Mantenere la piena autocustodia** dei propri fondi durante tutto il processo
+- **Accedere a ZEC schermato** senza KYC o raccolta dati
+- **Partecipare alla governance** attraverso il token FOX per plasmare il futuro della piattaforma
+
+Man mano che gli ambienti normativi si inaspriscono in tutto il mondo, con regioni come l'UE che esplorano restrizioni sulle tecnologie per la tutela della privacy, piattaforme come ShapeShift forniscono un'importante infrastruttura alternativa per la privacy finanziaria.
+
+---
+
+## Riepilogo
+
+| Caratteristica | Dettagli |
+|---|---|
+| **Piattaforma** | ShapeShift DAO (decentralizzata, open-source) |
+| **Governance** | Detentori del token FOX |
+| **Supporto Zcash** | Trading completo di ZEC con supporto per transazioni schermate |
+| **KYC Richiesto** | No |
+| **Custodia** | Non custodiale (gli utenti mantengono le proprie chiavi) |
+| **Scambi Cross-Chain** | BTC, ETH, Arbitrum, Cosmos e altro |
+| **Infrastruttura** | Alimentata da Liquify (supporto RPC per oltre 90 blockchain) |
+| **Finanziamento Zcash Community Grants** | 50.000 $ per supporto tecnico e di marketing |
+
+L'integrazione di ShapeShift e Zcash rappresenta un significativo passo avanti per la privacy nella finanza decentralizzata. Combinando l'infrastruttura di trading non custodiale e multichain di ShapeShift con la tecnologia delle prove a conoscenza zero di Zcash, gli utenti ottengono accesso a un trading di criptovalute realmente privato e senza permessi. Per chiunque dia valore alla privacy finanziaria e all'autosovranità, questa integrazione fornisce un percorso pratico e accessibile per usare ZEC senza compromessi.
+
+---
+
+### Risorse
+
+[Piattaforma ShapeShift](https://shapeshift.com/)
+
+[Sito Ufficiale di Zcash](https://z.cash/)
+
+[Zashi Wallet (di Electric Coin Co.)](https://electriccoin.co/zashi/)
+
+[Governance di ShapeShift DAO (Token FOX)](https://shapeshift.com/fox-token)
+
+[Zcash Community Grants](https://zcashcommunitygrants.org/)
+
+[ShapeShift integrates Zcash to bolster onchain privacy (crypto.news)](https://crypto.news/shapeshift-integrates-zcash-to-enable-true-onchain-privacy/)
+
+[ShapeShift unveils v4.0, re-centering privacy and self-custody in DeFi (Invezz)](https://invezz.com/news/2025/12/18/shapeshift-unveils-version-4-0-re-centering-privacy-and-self-custody-in-defi/)
+
+[ShapeShift rolls out support for shielded Zcash transactions (CoinTelegraph)](https://cointelegraph.com/news/shapeshift-rolls-out-support-for-shielded-zcash-transactions-for-true-privacy)

--- a/translations/it/site/guides/Using_ZEC_Privately.md
+++ b/translations/it/site/guides/Using_ZEC_Privately.md
@@ -1,0 +1,96 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Using_ZEC_Privately.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Usare ZEC, in privato
+
+#### Schermato (privato) vs. Trasparente
+
+Allo stato attuale, in Zcash esistono due tipi di indirizzi e di transazioni: schermato e trasparente. La differenza tra ZEC schermato e ZEC trasparente è molto semplice. ZEC schermato mantiene privati il tuo denaro e le tue transazioni, mentre ZEC trasparente funziona come Bitcoin, completamente trasparente. Questo significa che chiunque può vedere il tuo saldo e tutte le tue transazioni se conosce il tuo indirizzo.
+
+Quando le persone iniziano a usare ZEC, potrebbero non rendersi conto di quale tipo di indirizzo stanno usando. Questo perché non tutti gli exchange supportano ZEC schermato e/o i prelievi di ZEC schermato. 
+
+Quindi, per esempio, se qualcuno usa Coinbase e acquista ZEC, acquisterebbe ZEC trasparente e potrebbe prelevare quel ZEC solo verso un indirizzo trasparente in un wallet. Wallet come [Zodl](https://zodl.com/) possono schermare i fondi inviati a un indirizzo trasparente per risolvere questo problema, ma non tutti lo sanno. Molte persone, in parole povere, usano ZEC nel modo in cui il loro exchange o il loro wallet principale consente loro.
+
+#### Assicurarti che il tuo ZEC sia schermato
+
+Consigliamo a tutti di autocustodire il proprio ZEC. Vale a dire, sposta il tuo ZEC da un exchange a un wallet. Il modo migliore per sapere se stai usando ZEC schermato, ovvero privato, è guardare l'indirizzo in cui si trova il saldo. Se l'indirizzo inizia con una "z" o "u1", allora il tuo saldo è schermato. Se l'indirizzo inizia con una "t", allora il saldo è trasparente.
+
+In genere ci sono due percorsi per arrivare a ZEC schermato.
+
+Da un exchange che supporta i prelievi **schermati**:
+
+  1. Acquista ZEC in un exchange
+  2. Avvia la procedura di prelievo nell'exchange
+  3. Apri il tuo wallet ZEC schermato e assicurati che l'indirizzo di ricezione inizi con "u1" o "z"
+  4. Esegui il prelievo dal tuo exchange
+
+Da un exchange che supporta i prelievi **trasparenti**:
+
+
+  1. Acquista ZEC in un exchange
+  2. Avvia la procedura di prelievo nell'exchange
+  3. Apri il tuo wallet ZEC con autoshielding e usa l'indirizzo di ricezione trasparente
+  4. Esegui il prelievo dal tuo exchange
+  5. Attendi dieci conferme, quindi scherma il ZEC dal tuo indirizzo trasparente a un indirizzo schermato
+
+
+Ecco un tutorial su come prelevare ZEC da un exchange. Nota che questo è un prelievo schermato.
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/REUbkLzK7J4"
+    title="Buy and withdraw ZEC to a shielded wallet from Gemini"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+    
+
+---
+Ecco un tutorial su come schermare il tuo ZEC da un indirizzo trasparente a un indirizzo schermato.
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/W2msuzrxr3s"
+    title="Shield your ZEC from a transparent to shielded address"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+---
+Ecco un tutorial su come acquistare ZEC su Coinbase e inviarlo a Zashi.
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/Avweu5V9QRc"
+    title="Coinbase + Zashi: Buy Zcash & Shield Instantly"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+#### Transazioni
+
+Dopo esserti assicurato che il tuo ZEC sia in un wallet schermato che supporta gli indirizzi schermati, puoi ora decidere se desideri effettuare transazioni con quel ZEC. Effettuare transazioni con ZEC è semplicissimo. Puoi inviare ZEC a indirizzi schermati o trasparenti a seconda della preferenza della persona. Come per qualsiasi transazione monetaria, ci sono piccole probabilità che le persone possano far trapelare dati. ZEC è il migliore nel contrastare la fuga di dati, ma questo non significa che dovresti usarlo con noncuranza. Ecco alcune cose che è opportuno evitare quando effettui transazioni con ZEC.
+
+- Divulgare il tuo indirizzo schermato
+- Usare un indirizzo schermato come tramite per gli indirizzi-t (ovvero il "mixing")
+- Effettuare, e divulgare di effettuare, un numero elevato di transazioni da schermato a trasparente
+- Far sapere regolarmente alle persone dove spendi ZEC schermato
+
+
+In sostanza, la cosa migliore da fare con il tuo ZEC è tenerlo in un wallet schermato, effettuare transazioni tra indirizzi schermati ed essere prudente su come usi ZEC in pubblico (ad es. in un bar). Garantire la privacy comporta un certo grado di responsabilità. 
+
+#### Risorse
+
+[Transazioni Zcash](https://zechub.wiki/using-zcash/transactions)

--- a/translations/it/site/guides/Using_ZEC_in_DeFi.md
+++ b/translations/it/site/guides/Using_ZEC_in_DeFi.md
@@ -1,0 +1,75 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Using_ZEC_in_DeFi.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Usare Zcash nella DeFi
+
+
+## Near Intents 
+
+Zcash e NEAR Intents sono stati integrati, permettendo agli utenti di scambiare Zcash (ZEC) con altre principali altcoin, tra cui Bitcoin, Solana, NEAR e XRP, senza pagare alcuna commissione. Questa integrazione fa parte degli sforzi di NEAR Protocol per creare un'infrastruttura di bot di IA autonomi e verificabili, il che porta benefici anche a Zcash abilitando rotaie di pagamento basate sull'IA. Gli utenti di Zcash possono ora accedere agli smart contract e a [applicazioni DeFi](https://nym.com/blog/what-is-defi) più ampie preservando al contempo la loro privacy tramite [Near Intents](https://app.near-intents.org).
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/mKVvXY4yjjA"
+    title="Crosschain Swaps with Zcash x NEAR Intents"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+---
+
+## Maya Protocol 
+
+Maya Protocol ha integrato Zcash per migliorare la propria decentralizzazione, liquidità e privacy delle transazioni. Questa integrazione permette agli utenti di Zcash di beneficiare di scambi decentralizzati, offrendo loro maggiore flessibilità e liquidità preservando al contempo la privacy. Scopri di più: [https://www.mayaprotocol.com/blog-maya-academy/zcash-integrates-maya](https://www.mayaprotocol.com/blog-maya-academy/zcash-integrates-maya)
+
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/f1k6xhNfTV8"
+    title="How to Swap Ethereum to Zcash on LeoDex"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+**Nota**: È anche possibile fare il bridge di qualsiasi ETH che già possiedi per conservarlo privatamente come Zcash schermato usando la scheda "Release" e inserendo il tuo indirizzo trasparente. Puoi poi usare l'opzione "Autoshield" nel tuo wallet mobile/desktop. Affinché questa applicazione rimanga privata, si raccomanda di non effettuare scambi da ZEC > ETH e poi di nuovo da ETH > ZEC. 
+
+---
+
+## Innovazione attorno alla DeFi di Zcash 
+
+**Soluzione Layer 1**
+
+Si stanno attualmente esplorando opzioni per abilitare applicazioni DeFi all'interno dell'ecosistema Zcash usando l'attuale Layer 1. Questo potrebbe essere possibile eseguendo la maggior parte delle operazioni del contratto off-chain con un sequencer e facendo eseguire on-chain la validazione di tali azioni. Una versione di questo è stata creata in collaborazione con JP Morgan sulla loro blockchain enterprise. A partire da NU5 esiste un meccanismo (TZE) per aggiungere questo tipo di estensione a Zcash. 
+
+**zkEVM**
+
+Questo porterebbe la programmabilità nativa a Zcash con una macchina virtuale compatibile con l'EVM che supporta il calcolo di prove a conoscenza zero. Questo permetterebbe a Zcash di crescere grazie a una comunità di sviluppatori più diversificata e favorire un ecosistema di applicazioni e token che preservano la privacy. Lo renderebbe paragonabile ad altre soluzioni di privacy L2 esistenti. 
+
+La ricerca continua su Proof-of-Stake e sul Cosmos Interblockchain Communication Protocol è guidata dall'ECC. I prossimi passi vengono valutati insieme al successo del Merge di Ethereum verso il PoS e a eventuali problemi che potrebbero emergere. 
+
+**ZSA/UDA**
+
+Gli Zcash Shielded Assets / User Defined Assets sono in sviluppo con l'assistenza di un team dedicato. A seguito dell'aggiornamento del protocollo NU5 sono significativamente più vicini alla realizzazione. Sono attualmente in corso di sviluppo meccanismi per il bridging cross-chain trustless e privato di questi asset, abilitando l'interoperabilità. Di seguito un link alla presentazione di Zcon3 su questo argomento. 
+
+
+### Risorse:
+
+[Zcon3 Private Cross-Chain Transfers](https://youtu.be/vCvMk2-CJN8)
+
+[Zcon3 QEDIT Presentation on Defi](https://youtu.be/EGjcYhovty0) / [Drawing Board](https://miro.com/app/board/uXjVOhuveHo=/)
+
+[Ian Miers on ZSA's & Stablecoins](https://www.youtube.com/watch?v=hJMWE3zLIcs)
+
+[Proof-of-Stake Research](https://electriccoin.co/blog/proof-of-stake-research-overview-1/)
+
+__
+
+Il vantaggio inequivocabile che Zcash ha rispetto ad altre piattaforme di smart contract esistenti è il suo Layer 1 nativamente privato. Questo elimina completamente ogni possibilità di fuga di informazioni durante l'uso di qualsiasi applicazione Layer 2. Permette un livello applicativo fondamentalmente più semplice e più sicuro, in grado di gestire molto più facilmente i permessi di accesso alle informazioni. 

--- a/translations/it/site/guides/Visualizing_Zcash_Addresses.md
+++ b/translations/it/site/guides/Visualizing_Zcash_Addresses.md
@@ -1,0 +1,78 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Visualizing_Zcash_Addresses.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+# Visualizzare gli indirizzi Zcash
+
+Se stai imparando a conoscere Zcash per la prima volta, ti renderai subito conto che esistono due tipi di [transazioni](https://zechub.wiki/using-zcash/transactions) che possono verificarsi: *trasparenti* e *schermate*.
+Inoltre, se hai seguito gli ultimi sviluppi nell'ecosistema Zcash, potresti aver appreso degli [Unified Address](https://electriccoin.co/blog/unified-addresses-in-zcash-explained/), o UA.
+Quando le persone nel settore Zcash parlano di transazioni *schermate*, intendono transazioni che coinvolgono indirizzi codificati per i protocolli sapling o orchard. 
+Gli UA sono progettati per unificare *qualsiasi* tipo di transazione schermata o trasparente in un unico indirizzo. Questa generalizzazione è la chiave per semplificare la UX in futuro. Lo scopo di questa guida è integrare la comprensione degli UA con esempi visivi concreti.
+
+## Tipi di indirizzi Zcash
+
+Attualmente esistono tre tipi principali di indirizzi in uso. Questi includono
+
+* transparent
+
+![img1](https://user-images.githubusercontent.com/81990132/219261771-a9957ec3-2841-4073-9cfd-1db9d6356693.png)
+
+* sapling
+
+![img2](https://user-images.githubusercontent.com/81990132/219261784-1a617e70-f588-4eed-96bf-f0789d7af58a.png)
+
+* Unified Address (completo)
+
+![img3](https://user-images.githubusercontent.com/81990132/219261794-bcc79db6-4dc6-4c6a-867b-3717b81e6b71.png)
+
+
+La prima cosa da notare è quanto sia diversa la lunghezza di ciascun tipo di indirizzo. Puoi vederlo visivamente dal numero di caratteri nella stringa dell'indirizzo *oppure* osservando i codici QR associati. Man mano che la lunghezza dell'indirizzo aumenta, il codice QR tende a rimpicciolirsi per far entrare più dati nel quadrato.
+
+* `t1goiSyw2JinFCmUnfiwwp72LEZzD42TyYu` è lungo 35 caratteri
+* `zs1cpf4prtmnqpg6x2ngcrwelu9a39z9l9lqukq9fwagnaqrknk34a7n3szwxpjuxfjdxkuzykel53` è lungo 78 caratteri
+* `u1ckeydud0996ftppqrnpdsqyeq4e57qcyjr4raht4dc8j3njuyj3gmm9yk7hq9k88cdkqfuqusgpcpjfhwu3plm2vrd32g8du78kzkm5un357r4vkhz4vhxd4yfl8zvszk99cmsc89qv4trd7jzkcs8h6lukzgy25j8cv76p0g603nrrg6yt6cxsh2v8rmkasskd69ylfyphhjyv0cxs` è lungo 213 caratteri
+
+La seconda cosa da notare è il prefisso di ciascuna stringa di indirizzo -- quelli transparent iniziano con una *t*, quelli sapling con *zs*, e infine gli UA con *u1*.
+
+È importante notare:
+
+#### "Gli indirizzi di pagamento Orchard non hanno una codifica stringa autonoma. Definiamo invece gli "unified address" che possono raggruppare insieme indirizzi di diversi tipi, incluso Orchard. Gli unified address hanno una Human-Readable Part pari a "u" sulla Mainnet, ovvero avranno il prefisso "u1"."
+
+## Ricevitori degli Unified Address
+
+Come discusso [qui](https://medium.com/@hanh425/transaction-privacy-78f80f9f175e), si possono costruire UA con ricevitori diversi -- una qualche combinazione dei tipi di indirizzo transparent, sapling e orchard.
+Oltre a un UA completo, ecco i più comuni che troverai in circolazione:
+
+* transparent + sapling
+
+![img4](https://user-images.githubusercontent.com/81990132/219267475-38ad1419-0aac-4205-b18e-6873283f9d85.png)
+
+* transparent + orchard
+
+
+![img5](https://user-images.githubusercontent.com/81990132/219267496-90db21ff-f4e1-4a50-8f2a-1a71d995652a.png)
+
+* sapling + orchard
+
+
+![img6](https://user-images.githubusercontent.com/81990132/219267520-6b731ec2-e911-4469-acc5-c39d4addcac2.png)
+
+* orchard
+  
+![img7](https://user-images.githubusercontent.com/81990132/219267538-1a748fff-4034-4559-96ac-182723409b3a.png)
+
+La prima cosa da notare è che ciascuno di questi UA proviene dalla stessa chiave privata! La seconda cosa da notare è la lunghezza di ciascun tipo di UA:
+
+* t+s `u13qutpuktq026dwczvxmnh8mxdacsjx3kg2rrhzgns8zsty53t9y0hqp5d440zc9w7z7zkkjqw8dq0uuc0mkt883464mq8mkys7l4xjnhylh7u3u02ukknurm5yxerqlf500y2atq28e` 141 caratteri
+* t+o `u1yvwppp7ann6n3pgkysdu0spvr50w4jf4jwgme3c8x8fp4av59rupgvdd3fddc3f2cwrk3ghs5lxt87ggj8cvjuzcrf4jkejwlu9pc83gk2vtx03ucqcc3ed0furcuypqs6d6swu3nws` 141 caratteri
+* s+o `u1dq8kg78fgpjsc7dn2ynpdzc8xu99wra0jec4jy30rjqk5frsj62qtgqcu9nn0j8g352phlwprshancgxcuhdcclx0wxtvqylhmuegas7ul8hwnwggy727l05pyujuywtnn4nkfznctaelpkcrqcm9cxhkgv3t9jtrvgym7la5varrmzc` 178 caratteri
+* o   `u1cysntkxwt0h4sahp7rhj7u27pgc2ga7685ekf65g0d5ht5glkfm4zkumhvkd2zg2pdrgv3mrwq2x3vw2yl5u7zef3cr2nqwrzu7v2dsa` 106 caratteri
+
+La terza cosa da notare è come visivamente ogni UA sia leggermente diverso! Il potere degli UA è la *scelta* che permettono agli utenti finali. Se in futuro sarà necessario un nuovo protocollo, gli UA saranno pronti a entrare in azione.
+
+## Fonti
+
+https://zcash.github.io/orchard/design/keys.html
+
+https://medium.com/@hanh425/transaction-privacy-78f80f9f175e

--- a/translations/it/site/guides/Visualizing_the_Zcash_Network.md
+++ b/translations/it/site/guides/Visualizing_the_Zcash_Network.md
@@ -1,0 +1,249 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Visualizing_the_Zcash_Network.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+
+#  Visualizzare la rete Zcash
+
+Quella che segue è una guida su come eseguire il crawler Ziggurat 3.0 per Zcash insieme ai programmi associati Crunchy e P2P-Viz su Ubuntu 22.04 per raccogliere e visualizzare le informazioni sulla rete Zcash.  
+Il video collegato qui sotto segue lo stesso procedimento.
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/Nq5cLiAHxPI"
+    title="ziggurat 3.0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+    
+----------------
+## Requisiti di installazione: 
+
+Rust -> [https://rustup.rs/](https://rustup.rs/)
+
+## Facoltativo:
+jq -> [https://jqlang.github.io/jq/download/](https://jqlang.github.io/jq/download/)
+(per visualizzare le informazioni json nel terminale)
+
+curl -> [https://everything.curl.dev/get/linux](https://everything.curl.dev/get/linux)
+(per interrogare l'RPC del crawler)
+
+npm (con nvm) -> [https://medium.com/@iam_vinojan/how-to-install-node-js-and-npm-using-node-version-manager-nvm-143165b16ce1](https://medium.com/@iam_vinojan/how-to-install-node-js-and-npm-using-node-version-manager-nvm-143165b16ce1)
+(per visualizzare P2P-Viz nel browser)
+
+----------------
+
+
+----------------
+Repository Ziggurat 3.0 | [https://github.com/runziggurat](https://github.com/runziggurat)
+
+Repo del crawler | [https://github.com/runziggurat/zcash.git](https://github.com/runziggurat/zcash.git)
+
+Repo di Crunchy | [https://github.com/runziggurat/crunchy.git](https://github.com/runziggurat/crunchy.git)
+
+Repo di P2P-Viz | [https://github.com/runziggurat/p2p-viz.git](https://github.com/runziggurat/p2p-viz.git)
+
+----------------
+
+Inizia applicando i normali aggiornamenti.
+
+>  Esegui i seguenti comandi:
+```bash
+sudo apt update
+sudo apt upgrade
+```
+
+----------------
+
+## Crawler della rete Zcash
+
+Il crawler di Zcash risiede dentro una cartella chiamata 'zcash', quindi potrebbe essere consigliabile creare una nuova directory prima di clonare il crawler (repo runziggurat/zcash).
+
+
+>  Dalla directory /Home, esegui i seguenti comandi:
+```bash
+mkdir runziggurat
+cd runziggurat
+git clone https://github.com/runziggurat/zcash.git
+cd zcash
+```
+
+Naviga nel browser fino a 
+[https://github.com/runziggurat/zcash/blob/main/src/tools/crawler/README.md](https://github.com/runziggurat/zcash/blob/main/src/tools/crawler/README.md)
+
+Oppure apri il readme in 
+'/runziggurat/zcash/src/tools/crawler/README.md'
+
+Questa pagina contiene informazioni sull'utilizzo specifico. 
+
+----------------
+
+
+```bash
+$ cargo run --release --features crawler --bin crawler -- --help
+
+OPTIONS:
+    -c, --crawl-interval <CRAWL_INTERVAL>
+            The main crawling loop interval in seconds [default: 5]
+
+    -h, --help
+            Print help information
+
+    -r, --rpc-addr <RPC_ADDR>
+            If present, start an RPC server at the specified address
+
+    -s, --seed-addrs <SEED_ADDRS>...
+            A list of initial standalone IP addresses and/or DNS servers to connect to
+
+    -n, --node-listening-port <NODE_LISTENING_PORT>
+            Default port used for connecting to the nodes [default: 8233]
+
+    -V, --version
+            Print version information
+```
+
+`--seed-addrs` \ `--dns-seed` è l'unico argomento obbligatorio e necessita di almeno un indirizzo specificato per poter funzionare.
+
+
+
+----------------
+
+Il comando 'cargo run --release --features crawler --bin crawler -- --help' è il comando di esecuzione letterale e stamperà il menu di aiuto mostrato.
+
+
+>  Esegui il comando
+```bash
+cargo run --release --features crawler --bin crawler -- --help
+```
+
+
+Questo compilerà il programma e si assicurerà che tutto funzioni correttamente.
+
+Per eseguire il crawler, è necessario aggiungere un flag '--seed-addrs' al comando di avvio, contenente almeno un indirizzo IP valido di un nodo Zcash. Il crawler dovrebbe essere lasciato in esecuzione per un periodo di tempo ragionevole per ottenere un risultato accurato. Alcuni indirizzi IP di nodi di esempio si possono trovare su [https://zcashblockexplorer.com/nodes](https://zcashblockexplorer.com/nodes).
+
+Per ottenere informazioni dal crawler mentre è in esecuzione, è necessario aggiungere il flag '--rpc-addr' al comando di avvio. Non è richiesto per eseguire solamente il crawler in sé, ma altrimenti richiederà di arrestare il crawler (ctrl+c o SIGKILL) per visualizzare qualsiasi informazione.
+
+
+>  Esegui il comando
+```bash
+cargo run --release --features crawler --bin crawler -- --seed-addrs 157.245.172.190:8233 194.135.81.61:8233 35.233.224.178:8233 --rpc-addr 127.0.0.1:54321
+```
+
+Il crawler inizierà a comunicare con la rete (per impostazione predefinita ogni 20 secondi) e a raccogliere dati di rete. 
+Le informazioni dal crawler possono essere visualizzate usando curl per interrogare il nodo (questo richiede jq per visualizzare tali informazioni). 
+L'indirizzo RPC del crawler in questo esempio è impostato su '127.0.0.1:54321'
+
+
+>  In un altro terminale, esegui il comando
+```bash
+curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ | jq .result.protocol_versions
+```
+
+Questo visualizzerà i dati '.protocol_version' attualmente raccolti contenuti nel campo '.result'. Il campo '.result' è molto grande, quindi è utile richiamarne porzioni specifiche invece di tutto. Altri tipi di dati utili sono '.num_known_nodes', '.num_good_nodes', '.user_agents' ecc. Vedi la sezione metriche [Qui](https://github.com/runziggurat/zcash/tree/main/src/tools/crawler#metrics)
+
+----------------
+
+
+----------------
+Per eseguire Crunchy e P2P-Viz, è necessario reindirizzare il '.result' in un file .json. 
+
+
+>  Esegui il comando
+```bash
+curl --data-binary '{"jsonrpc": "2.0", "id":0, "method": "getmetrics", "params": [] }' -H 'content-type: application/json' http://127.0.0.1:54321/ > latest.json
+```
+
+Questo creerà un file 'latest.json' nella directory corrente. Questo file 'latest.json' verrà usato con Crunchy. 
+
+A questo punto, il crawler può essere arrestato con 'ctrl+c' se non sono necessari altri dati. Il crawler stamperà un report di informazioni utili nel terminale.
+
+
+----------------
+
+## Crunchy
+
+Crunchy è necessario per aggregare il file json di output da usare con P2P-Viz.
+
+
+Per compilare Crunchy, naviga fino alla tua cartella '/runziggurat' 
+
+>  Per clonare il repo di Crunchy, esegui i seguenti comandi
+```bash
+git clone https://github.com/runziggurat/crunchy.git
+cd crunchy
+```
+Copia e incolla il file 'latest.json' nella cartella 'crunchy/testdata/'.
+
+>  Esegui i seguenti comandi 
+```bash
+cargo run --release -- -i testdata/latest.json -o testdata/state.json -g testdata/geoip-cache.json -f Zcash
+```
+
+Questo creerà un file 'state.json' filtrato sui nodi Zcash nella cartella 'crunchy/testdata/' da usare con P2P-Viz.
+
+----------------
+
+## P2P-Viz
+
+Per compilare P2P-Viz, è necessario avere npm. 
+
+
+>  Per installare npm con nvm, esegui i seguenti comandi:
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+```
+
+Chiudi e riavvia il terminale.
+
+
+>  Esegui il comando:
+```bash
+nvm install --lts
+```
+
+naviga fino alla tua cartella '/runziggurat'
+
+
+>  Per clonare il repo di P2P-Viz e avviarlo, esegui i seguenti comandi
+```bash
+git clone https://github.com/runziggurat/p2p-viz.git
+cd p2p-viz
+npm i
+npm run build
+npm run start http
+```
+
+----------------
+
+Apri un browser su [http://localhost:3000](http://localhost:3000). 
+
+Seleziona 'Geolocation' e poi seleziona 'Choose state file'.
+
+Dalla finestra pop-up dell'esplora file, seleziona il file 'state.json'. 
+
+La mappa mondiale dell'esploratore di nodi si popolerà con i dati del file. Vedi il readme [Qui](https://github.com/runziggurat/p2p-viz#build-and-run-the-app) per maggiori dettagli sulle opzioni di utilizzo e sulle impostazioni.
+
+
+----------------
+CONSIGLI! 
+
+Puoi impostare il crawler su una scansione a tempo semplicemente con il comando 'timeout', che emetterà uno specifico comando di terminazione dopo un determinato lasso di tempo. Esegui 'timeout --help' per maggiori informazioni.
+Il seguente comando avvierà e arresterà automaticamente il crawler dopo 50 minuti.
+
+>  Esegui il comando
+```bash
+timeout --signal=2 50m cargo run --release --features crawler --bin crawler -- --seed-addrs 157.245.172.190:8233 194.135.81.61:8233 35.233.224.178:8233 --rpc-addr 127.0.0.1:54321
+```
+
+----------------
+CONSIGLI! 
+
+Il 'latest.json' può essere richiamato e scritto direttamente in '/testdata' così da non doverlo copiare e incollare manualmente.
+
+----------------
+CONSIGLI! 
+
+Le informazioni sugli indirizzi IP possono essere raccolte dall'output e poi usate per ri-inizializzare (reseed) il crawler all'avvio (--seed-addrs). Questo ridurrà il tempo necessario per condurre una scansione completa! 

--- a/translations/it/site/guides/Ywallet_FROST_Demo.md
+++ b/translations/it/site/guides/Ywallet_FROST_Demo.md
@@ -1,0 +1,75 @@
+# Demo FROST con Ywallet
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/3IZgxDqQNbw"
+    title="FROST + Ywallet Transaction Demo"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+## Compila i binari FROST
+
+[Link GitHub](https://github.com/ZcashFoundation/frost-zcash-demo/tree/update-zcash-sign)
+
+Usa il repo qui sopra e segui le indicazioni sulla compilazione: 
+
+```bash
+cargo build --bin trusted-dealer
+cargo build --bin dkg
+cargo build --bin coordinator
+cargo build --bin participants
+```
+
+I binari si troveranno nella cartella target.
+
+## Crea una UA FROST
+
+`./generateFROST_UA.sh`
+
+
+
+## Importa la UFVK in Ywallet
+
+Accounts -> Clicca + e incolla la ufvk dal passo precedente
+
+## Crea una transazione con Ywallet
+
+Incolla una qualsiasi UA e invia una tx. Salva il file.
+
+## Avvia la procedura di firma FROST 
+
+`./signFROST_tx.sh rawtxs/mytx signedtxs/mysignedtx`
+
+il primo input è la posizione della tx grezza ottenuta dal passo precedente
+il secondo input è la posizione e il nome della tx firmata che vuoi trasmettere
+Questa è la parte in cui indichi a FROST quale transazione vuoi che tutti firmino
+
+## Avvia il Coordinator
+
+`./runCoordinator.sh`
+
+Questo coordina la firma di ciascun partecipante e crea una firma di gruppo
+
+## Fai firmare a ciascun Partecipante questa transazione
+
+```bash
+./participantSign.sh key-package-1.json
+./participantSign.sh key-package-2.json
+```
+
+## Finalizza la transazione firmata
+
+Nella finestra del coordinator, copia la firma di gruppo che viene mostrata in output e incollala nella finestra di firma FROST.
+Questo completerà la firma FROST e produrrà 'mysingedtx'
+
+
+## Trasmetti la tua transazione con Ywallet
+
+Clicca su 'More' nella parte in basso a destra di Ywallet e trova 'Broadcast'. Trova 'mysignedtx' e clicca ok.
+
+Se tutto funziona otterrai un ID della transazione :)

--- a/translations/it/site/guides/Zcash_Devtool.md
+++ b/translations/it/site/guides/Zcash_Devtool.md
@@ -1,0 +1,36 @@
+# Il Zcash Devtool
+
+[Cos'è il Zcash-Devtool?](https://github.com/zcash/zcash-devtool?tab=readme-ov-file) 
+
+Il Zcash Devtool è una piattaforma per sperimentare con Zcash. È costruito dagli sviluppatori, per gli sviluppatori, per il test e lo sviluppo di nuove funzionalità di Zcash; e non deve essere considerato pronto per la produzione. L'API a riga di comando che questo strumento espone può cambiare e cambierà in qualsiasi momento e senza preavviso. NON affidare somme ingenti alla gestione del wallet integrato di zcash-devtool.
+
+### Video tutorial del Zcash Devtool:
+Kris Nuttycombe (@nuttycom) ha presentato questo strumento durante ZconVI.
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/5gvQF5oFT8E"
+    title="zcash-devtool: the Zcash development multitool with Kris Nuttycombe - ZconVI"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+---
+
+Per una guida passo passo su come iniziare a usare questi strumenti, consulta [questa procedura dettagliata](https://github.com/zcash/zcash-devtool/blob/main/doc/walkthrough.md). Documenta una procedura completa su come configurare e usare gli strumenti zcash devtool. È pensata per fungere da guida su come effettuare la configurazione e su come aggiungere le tue funzionalità allo strumento.
+
+
+**Avvisi di Sicurezza:**
+NON USARE QUESTO IN PRODUZIONE!!!
+L'app non è stata scritta tenendo conto della sicurezza. Tuttavia dispone di accorgimenti come la cifratura delle frasi seed mnemoniche che dovrebbero renderla utilizzabile per la sperimentazione su piccola scala, a tuo rischio e pericolo.
+
+### Avanzato (tutorial librustzcash)
+
+
+[guarda il video qui](https://free2z.cash/uploadz/public/ZcashTutorial/librustzcash-a-rust-crates.mp4)
+
+

--- a/translations/it/site/guides/Zcash_Improvement_Proposals.md
+++ b/translations/it/site/guides/Zcash_Improvement_Proposals.md
@@ -1,0 +1,53 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Zcash_Improvement_Proposals.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zcash Improvement Proposals
+
+<img width="672" height="378" alt="1" src="https://github.com/user-attachments/assets/fbce4a28-585b-4caa-b306-4cf06bcb5977" />
+
+
+
+# Cos'è una ZIP
+Una Zcash Improvement Proposal (ZIP) è un documento di progettazione che fornisce informazioni alla community di Zcash, oppure che descrive una nuova funzionalità per Zcash o per i suoi processi o il suo ambiente. La ZIP dovrebbe fornire una specifica tecnica concisa della funzionalità e una motivazione per la stessa.
+
+Intendiamo le ZIP come il meccanismo principale per proporre nuove funzionalità, per raccogliere il contributo della community su una questione e per documentare le decisioni di progettazione che sono confluite in Zcash. Gli Owner della ZIP (di solito gli autori) sono responsabili di costruire il consenso all'interno della community e di documentare le opinioni dissenzienti.
+
+Poiché le ZIP sono mantenute come file di testo in un repository versionato, la loro cronologia delle revisioni è il registro storico della proposta della funzionalità.
+
+-> [zips.z.cash](https://zips.z.cash)
+
+
+## Editor delle ZIP
+
+Per ogni ZIP che arriva, essa deve sottoporsi al processo di review. Gli editor delle ZIP hanno il compito di garantire che il formato e il contenuto di qualsiasi ZIP descrivano adeguatamente termini, motivazione e modifiche tecniche apportate. 
+
+```markdown
+* Jack Grigg, Kris Nuttycombe and Daira-Emma Hopwood associated with the ECC.
+* Conrado, and Arya, associated with the ZF.
+* Sam and Mark, associated with SL.
+```
+
+## ZIP in bozza attuali degne di nota
+
+> Bozza: [Transarent Zcash Extensions](https://github.com/zcash/zips/blob/main/zip-0222)
+
+> Bozza: [Transfer and Burn of Zcash Shielded Assets](https://github.com/zcash/zips/blob/main/zip-0226)
+
+> Bozza: [Issuance of Zcash Shielded Assets](https://github.com/zcash/zips/blob/main/zip-0227)
+
+> Bozza: [Version 6 Transaction Format](https://github.com/zcash/zips/blob/main/zip-0230)
+
+> Bozza: [Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions](https://github.com/zcash/zips/blob/main/zip-0245)
+
+> Bozza: [Standardized Memo Field Format](https://github.com/zcash/zips/blob/main/zip-0302)
+
+> Bozza: [Sapling Address Signatures](https://github.com/zcash/zips/blob/main/zip-0304)
+
+> Bozza: [Light Client Protocol for Payment Detection](https://github.com/zcash/zips/blob/main/zip-0307.)
+
+> Bozza: [Security Properties of Sapling Viewing Keys](https://github.com/zcash/zips/blob/main/zip-0310)
+
+> Bozza: [Defining an Address Type to which funds can only be sent from Transparent Addresses](https://github.com/zcash/zips/blob/main/zip-0320)
+
+> Bozza: [Wallet.dat format](https://github.com/zcash/zips/blob/main/zip-0400)

--- a/translations/it/site/guides/Zenith_Installation.md
+++ b/translations/it/site/guides/Zenith_Installation.md
@@ -1,0 +1,161 @@
+# Installazione del wallet full node con GUI Zenith  
+
+## Video tutorial
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/zu8nvr4FlXE"
+    title="Zenith Full Node Wallet Installation & Demo"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+---
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/-gawirv0L_U"
+    title="Using RPC's with Zebrad + Zenith"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+## Installa Haskell
+
+> curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+
+
+## Installa Rust
+
+> curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+
+## Installa Zebra
+
+> sudo apt install libclang-dev
+
+> cargo install --git https://github.com/ZcashFoundation/zebra --tag v2.1.0 zebrad
+
+> zebrad generate -o ~/.config/zebrad.toml
+
+> nano ~/.config/zebrad.toml
+
+
+#### ascolta le query RPC su localhost
+
+> listen_addr = "127.0.0.1:8232"
+
+#### usa automaticamente più thread della CPU
+
+parallel_cpu_threads = 0
+
+enable_cookie_auth = false
+
+## Installa Zenith
+
+**Scarica il file tar.gz ed estrailo nella tua home directory**
+
+> wget https://code.vergara.tech/Vergara_Tech/zenith/archive/0.7.2.0-beta.tar.gz
+
+> tar -C ~ -xvzf 0.7.2.0-beta.tar.gz
+
+> cd zenith
+
+> rmdir zcash-haskell
+
+> git clone https://git.vergara.tech/Vergara_Tech/zcash-haskell.git
+
+
+### Installa le dipendenze
+
+> sudo apt install libssl-dev libgmp-dev libsecp256k1-dev libtinfo-dev libsdl2-dev libfreetype-dev libglew-dev gdk-pixbuf-tests raspi-config
+  
+> cargo install cargo-c
+
+> stack install c2hs
+
+> mousepad ~/.bashrc
+
+> export PATH="/home/zebra5/.local/bin:$PATH"
+
+> source ~/.bashrc
+
+
+### Adatta il sorgente per aarch64
+
+> nano configure
+
+**cambia il triple in: "aarch64-unknown-linux-gnu" su entrambe le righe.**
+
+> nano Setup.hs
+ 
+ **Modifica Setup.hs sia nella cartella zcash-haskell sia nella cartella zenith**
+
+### Compila 
+
+- ./configure
+
+- cabal build
+
+- mkdir ~/Zenith
+
+- cd ~/Zenith
+
+- mkdir assets  
+
+- cp ~/zenith/dist-newstyle/build/aarch64-linux/ghc-9.6.5/zenith-0.7.2.0/build/zenith/zenith ~/Zenith
+
+- cp ~/zenith/zenith.cfg ~/Zenith
+
+- cp -r ~/zenith/assets ~/Zenith/assets
+
+
+### Adatta zenith.cfg
+
+nodeUser = yourusername
+
+nodePwd = superSecret
+
+nodePort = 8234
+
+dbFileName = zenith.db
+
+zebraHost = 127.0.0.1
+
+zebraPort = 8232
+
+
+> cd ~/Zenith
+
+## Raspi-config
+
+> [scarica l'ultima versione di gldriver-test](https://archive.raspberrypi.org/debian/pool/main/g/gldriver-test/)
+  
+> sudo dpkg - gldriver-test_0.15_all.deb
+  
+> sudo raspi-config
+
+  **vai su advance e seleziona opengl => GL (Full KMS)**
+
+  **riavvia**
+
+
+
+## Esegui zenith
+
+ ./zenith gui
+ oppure
+ ./zenith tui
+ oppure
+ ./zenithserver
+
+## RPC
+
+[guida pratica](https://github.com/ZecHub/zechub/blob/main/site/tutorials/zenithserver/zenithBeta.md)

--- a/translations/it/site/guides/Zero-Knowledge_vs_Decoys.md
+++ b/translations/it/site/guides/Zero-Knowledge_vs_Decoys.md
@@ -1,0 +1,88 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Zero-Knowledge_vs_Decoys.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zero Knowledge vs sistemi basati su decoy
+
+"La criptovaluta espone tutte le tue attività di spesa al pubblico, poiché è proprio come avere un Twitter collegato al tuo conto bancario, e questo è un grande problema che deve essere risolto adottando la privacy on-chain." - Ian Miers a [Devcon4](https://youtube.com/watch?v=9s3EbSKDA3o&feature=share9).
+
+Alcuni progetti cripto hanno ottenuto riconoscimento per i loro approcci incentrati sulla privacy. Zcash è rinomato per l'impiego delle Zero Knowledge Proof (ZK) per proteggere gli importi e gli indirizzi delle transazioni. Monero si distingue per l'utilizzo di un'offuscazione del mittente basata su decoy in combinazione con altri schemi di cifratura per ottenere la privacy degli utenti sulla blockchain.
+
+
+<a href="">
+    <img src="https://user-images.githubusercontent.com/38798812/257773807-af8ae27d-0805-4a60-a5ba-749e2fea2490.png" alt="" width="400" height="300"/>
+</a>
+
+
+## Comprendere le ZK Proof e i sistemi basati su decoy
+
+Le Zero Knowledge Proof sono sistemi crittografici che consentono a una parte (il prover) di dimostrare a un'altra parte (il verifier) la validità di un'affermazione senza rivelare *alcuna informazione sottostante sull'affermazione stessa*. Nel contesto di Zcash, le ZK proof vengono impiegate per verificare la validità di una transazione senza divulgare i dettagli della transazione, come il MITTENTE, il DESTINATARIO o l'IMPORTO della transazione. 
+
+**Questo garantisce che la privacy dell'utente sia preservata, poiché la transazione rimane confidenziale pur essendo comunque validata. Questa tecnologia è progettata per garantire la confidenzialità delle transazioni finanziarie sulla rete Zcash.**
+
+Nei sistemi basati su decoy come [RingCT](https://twitter.com/ZecHub/status/1636473585781948416), più transazioni vengono combinate, rendendo arduo o difficile tracciare l'effettiva origine e destinazione dei fondi. L'algoritmo introduce input e output decoy nelle transazioni, impiegando anche la cifratura degli indirizzi usati come input e usando le Range proof per validare che l'importo trasferito sia spendibile. 
+
+Questo approccio offusca la traccia della transazione. L'uso di input decoy rende difficile per chiunque analizzi la blockchain identificare il vero mittente, destinatario o importo della transazione. 
+
+**Nota importante**: questo metodo di transazione che preserva la privacy on-chain rivela comunque esplicitamente gli input (cifrati) di tutte le transazioni degli utenti. È comunque possibile raccogliere metadati come il *FLUSSO DELLE TRANSAZIONI* tra i diversi utenti della rete. Se un avversario partecipa attivamente alla generazione di transazioni sulla rete, di fatto deanonimizza gli input decoy degli altri utenti. 
+
+
+## Vantaggi delle ZK rispetto ai sistemi basati su decoy
+
+Sia Zcash che Monero sono criptovalute incentrate sulla privacy, ma raggiungono la privacy in modi diversi. 
+
+Ecco alcuni vantaggi delle prove a conoscenza zero (ZK) di Zcash rispetto al sistema di decoy di Monero:
+
+1) **Divulgazione selettiva**: con il set di funzionalità ZK di Zcash, gli utenti hanno la possibilità di rivelare i dettagli delle transazioni a parti specifiche [Leggi il blog di ECC sulla divulgazione selettiva](https://electriccoin.co/blog/viewing-keys-selective-disclosure/). In Zcash, i contenuti cifrati delle transazioni schermate consentono agli individui di rivelare selettivamente i dati di un determinato trasferimento. Inoltre, può essere fornita una viewing key per divulgare tutte le transazioni associate a uno specifico indirizzo schermato. Questa funzionalità consente la conformità normativa e la verificabilità senza compromettere la privacy complessiva della rete. 
+
+Sebbene l'algoritmo di decoy di Monero (firma ad anello) aiuti a fornire privacy, non offre la divulgazione *selettiva* nello stesso modo.
+
+
+<a href="">
+    <img src="https://user-images.githubusercontent.com/38798812/257793324-2dcc6047-300e-4fa7-a28d-2e6cbbadf1df.png" alt="" width="400" height="80"/>
+</a>
+
+
+2) **Visibilità opzionale**: Zcash consente agli utenti di scegliere tra transazioni trasparenti (non private) e schermate (private). Questo significa che Zcash offre agli utenti la flessibilità di mantenere private le proprie informazioni finanziarie (schermate) oppure di renderle trasparenti e pubblicamente disponibili, in modo simile alla maggior parte delle altre blockchain, come spiegato sul [sito ufficiale di Zcash](https://z.cash/learn/what-is-the-difference-between-shielded-and-transparent-zcash/). Questa privacy opt-in consente una maggiore flessibilità e casi d'uso rilevanti per aziende/organizzazioni, poiché alcune transazioni possono richiedere meno privacy per il controllo pubblico, mentre altre traggono beneficio da una privacy potenziata.
+
+
+3) **Anonymity set**: l'[anonymity set](https://blog.wasabiwallet.io/what-is-the-difference-between-an-anonymity-set-and-an-anonymity-score/) delle shielded pool a conoscenza zero comprende tutte le transazioni che si sono *mai* verificate. Questo è significativamente più grande della maggior parte delle altre tecniche on-chain per ottenere la non collegabilità delle transazioni. Nota: questo si applica solo alle transazioni all'interno della stessa shielded pool.
+
+L'uso dei decoy aumenta effettivamente l'anonymity set. Tuttavia, questo approccio dipende interamente dal numero di utenti *reali* sulla rete. 
+
+4) **Nessun trusted setup**: il setup Sprout e Sapling di Zcash utilizzava un calcolo multipartitico noto come "trusted setup ceremony". Il recente upgrade NU5 non ha richiesto alcun Trust (fiducia) nell'integrità del setup del circuito a conoscenza zero. [Leggi il blog di ECC su NU5](https://electriccoin.co/blog/nu5-activates-on-mainnet-eliminating-trusted-setup-and-launching-a-new-era-for-zcash/).
+
+5) **Privacy dei dati**: la [tecnologia zk-SNARK](https://wiki.zechub.xyz/zcash-technology) usata nelle shielded pool di Zcash consente una sicurezza notevolmente potenziata per gli utenti. La riduzione della fuga di metadati on-chain significa che gli utenti sono al sicuro da avversari come potenziali hacker o organismi statali oppressivi. 
+
+Ci sono stati diversi casi in cui sono stati identificati bug nell'algoritmo di selezione dei decoy di Monero. Questi bug avevano il potenziale di rivelare le spese degli utenti, secondo un report di [Coindesk](https://coindesk.com/markets/2021/07/27/bug-found-in-decoy-algorithm-for-privacy-coin-monero). 
+
+
+In sintesi, ciò che conta davvero di più è ridurre o eliminare la fuga di informazioni e dati degli utenti, come spiegato da Zooko alla [sessione live AMA di Orchid (priv8)](https://youtube.com/watch?v=XpRzKqEfpP4&feature=share9) 
+
+
+<a href="">
+    <img src="https://user-images.githubusercontent.com/38798812/257788813-509f1139-7daa-4f95-bbb4-c535641962f6.png" alt="" width="400" height="200"/>
+</a>
+
+
+____
+
+***Link di riferimento***
+
+https://z.cash/learn/
+
+https://www.getmonero.org/get-started/what-is-monero/
+
+https://youtu.be/9s3EbSKDA3o
+
+https://electriccoin.co/blog/nu5-activates-on-mainnet-eliminating-trusted-setup-and-launching-a-new-era-for-zcash/
+
+https://youtu.be/XpRzKqEfpP4
+
+https://electriccoin.co/blog/zcash-evolution/
+
+https://electriccoin.co/zcash-metrics/
+https://electriccoin.co/blog/viewing-keys-selective-disclosure/
+
+
+

--- a/translations/it/site/guides/Zgo_Payment_Processor.md
+++ b/translations/it/site/guides/Zgo_Payment_Processor.md
@@ -1,0 +1,130 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Zgo_Payment_Processor.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZGo Payment Processor: accettare Zcash senza custodia
+
+ZGo è un payment processor non-custodial per Zcash. Un cliente paga in ZEC dal proprio wallet, ZGo monitora la blockchain di Zcash in attesa della transazione, e i fondi arrivano direttamente nel wallet del commerciante tramite un trasferimento schermato. ZGo non detiene mai il denaro nel frattempo.
+
+Questa guida spiega come funziona il flusso di pagamento, come configurare un account e come integrare ZGo con Xero e WooCommerce. Copre inoltre i due errori che causano la maggior parte dei problemi al primo setup.
+
+## In questa pagina
+
+1. [Perché usare ZGo](#perché-usare-zgo)
+2. [Come funziona ZGo](#come-funziona-zgo)
+3. [Configurare un account](#configurare-un-account)
+4. [ZGo con Xero](#zgo-con-xero)
+5. [ZGo con WooCommerce](#zgo-con-woocommerce)
+6. [Funzionalità](#funzionalità)
+7. [Errori comuni](#errori-comuni)
+8. [Conclusione](#conclusione)
+9. [Risorse](#risorse)
+
+## Perché usare ZGo
+
+La maggior parte dei payment processor di criptovalute è custodial. I fondi finiscono prima nell'account del processor e vengono inoltrati al commerciante in un secondo momento, il che significa che una terza parte controlla temporaneamente il denaro e può congelarlo, ritardarlo o segnalarlo.
+
+ZGo adotta l'approccio opposto. I pagamenti si spostano dal wallet del cliente direttamente al wallet del commerciante tramite una transazione schermata Zcash. Il processor genera solo la fattura e osserva la blockchain in attesa della conferma. Non c'è alcun saldo intermedio, nessun flusso di prelievo e nessuna terza parte che possa bloccare il regolamento.
+
+Per un commerciante, questo significa tre cose pratiche: piena custodia degli ZEC in entrata, privacy delle transazioni schermate per impostazione predefinita e nessuna dipendenza dalla presenza online o dalla solvibilità di un fornitore centralizzato.
+
+## Come funziona ZGo
+
+Il flusso di pagamento è lo stesso indipendentemente dal fatto che ZGo venga usato in modalità standalone, tramite Xero o tramite WooCommerce:
+
+1. Il commerciante genera una richiesta di pagamento in ZGo, che viene visualizzata come codice QR con l'importo, l'ID fattura e un indirizzo di ricezione Zcash.
+2. Il cliente scansiona il QR con un wallet Zcash (i tipi di indirizzo Orchard, Sapling e Transparent sono tutti supportati nel plugin WordPress) e approva il pagamento.
+3. La transazione viene trasmessa alla rete Zcash come trasferimento schermato dal wallet del cliente al wallet del commerciante.
+4. ZGo monitora la blockchain di Zcash in attesa della transazione.
+5. Dopo cinque conferme, ZGo segna il pagamento come definitivo e notifica eventuali integrazioni collegate (Xero, WooCommerce o un webhook).
+
+La soglia delle cinque conferme è il numero chiave. Tutto ciò che avviene prima è un pagamento in corso, non un pagamento ricevuto. L'evasione dell'ordine, gli aggiornamenti dell'inventario e qualsiasi azione irreversibile dal lato del commerciante dovrebbero attendere il passaggio 5.
+
+ZGo funziona in qualsiasi browser moderno su desktop o mobile, senza installazione da nessuna delle due parti. Il cliente ha bisogno di un wallet Zcash; il commerciante ha bisogno di un wallet Zcash e di un account ZGo.
+
+<img width="672" height="378" alt="ZGo payment request and blockchain monitoring overview" src="https://github.com/user-attachments/assets/de50885b-b068-4157-bbda-0981ca23efc8" />
+
+## Configurare un account
+
+Per creare un account ZGo, è necessario un wallet Zcash con una piccola quantità di ZEC. Il piccolo saldo di ZEC copre la commissione on-chain per la transazione di inizializzazione dell'account. Qualsiasi wallet Zcash importante va bene per questo; vedi [ZecHub Wallets](https://zechub.wiki/wallets) per le opzioni attuali.
+
+Il setup di base:
+
+1. Apri [zgo.cash](https://zgo.cash/) in un browser.
+2. Crea un account usando un wallet Zcash sotto il controllo del commerciante. Questo wallet deve detenere le chiavi. Un indirizzo di deposito di un exchange non funzionerà (vedi [Errori comuni](#errori-comuni)).
+3. Verifica il wallet inviando la piccola transazione di inizializzazione.
+4. Configura l'indirizzo di ricezione. Tutti i pagamenti elaborati tramite questo account finiranno in questo wallet.
+
+Una volta che l'account è attivo, lo stesso commerciante può usare ZGo per pagamenti una tantum (un singolo codice QR a un evento pop-up) o integrarlo in una configurazione permanente tramite Xero o WooCommerce.
+
+## ZGo con Xero
+
+[Xero](https://www.xero.com/) è una piattaforma di contabilità cloud usata da molte piccole e medie imprese. L'integrazione ZGo–Xero consente a un commerciante di emettere una fattura in Xero, far pagare al cliente in ZEC e far sì che Xero contrassegni automaticamente la fattura come pagata una volta che la transazione è confermata.
+
+Come funziona:
+
+1. Il commerciante crea una fattura in Xero come al solito.
+2. ZGo allega un'opzione di pagamento Zcash alla fattura.
+3. Il cliente paga in ZEC tramite il proprio wallet.
+4. ZGo monitora la [blockchain di Zcash](https://z.cash/) in attesa della transazione.
+5. Dopo cinque conferme, ZGo segnala il pagamento a Xero, che contrassegna la fattura come saldata.
+
+Gli ZEC finiscono nel wallet del commerciante, non in un account controllato da ZGo o da Xero. Il record contabile in Xero rimane sincronizzato automaticamente con il regolamento on-chain.
+
+Per il setup iniziale, segui la procedura dedicata: [Configurazione dell'integrazione Xero](https://hedgedoc.vergara.tech/s/4iXC67fmb).
+
+## ZGo con WooCommerce
+
+Per i negozi online che girano su [WooCommerce](https://woocommerce.com/) e [WordPress](https://wordpress.org/), ZGo fornisce un plugin dedicato. Il plugin aggiunge Zcash come metodo di pagamento al checkout e gestisce automaticamente lo stato dell'ordine quando il pagamento viene confermato.
+
+<img width="672" height="378" alt="ZGo WooCommerce plugin checkout and order flow" src="https://github.com/user-attachments/assets/55a791bb-1947-4f55-b5b9-55083be8ed49" />
+
+Flusso end-to-end all'interno di un negozio WooCommerce:
+
+1. Il cliente raggiunge il checkout e seleziona Zcash come metodo di pagamento.
+2. Il plugin genera una richiesta di pagamento e mostra il codice QR nella pagina di checkout.
+3. Il cliente paga dal proprio wallet.
+4. La transazione viene trasmessa alla rete Zcash e ZGo inizia a monitorarla.
+5. Dopo cinque conferme, ZGo segnala il pagamento come definitivo al plugin.
+6. Il plugin contrassegna l'ordine WooCommerce come pagato e aggiorna il database degli ordini.
+
+L'ordine è pagato solo quando si completa il passaggio 6. Gli stati precedenti (trasmissione, prime conferme) possono essere mostrati al cliente come "pagamento ricevuto, in attesa di conferma", ma l'inventario, l'evasione e qualsiasi automazione a valle dovrebbero attendere lo stato finale.
+
+Il plugin installa anche una dashboard amministrativa all'interno di WordPress, dove il commerciante può monitorare gli ordini e i pagamenti ZEC in entrata insieme alla normale vista degli ordini WooCommerce. Il plugin supporta tutti i tipi di indirizzo Zcash attuali: Orchard, Sapling e Transparent. I clienti che pagano da qualsiasi wallet conforme possono completare la transazione.
+
+## Funzionalità
+
+**Non-custodial.** I pagamenti si spostano direttamente dal wallet del cliente al wallet del commerciante tramite transazioni schermate. ZGo non detiene mai i fondi nel frattempo, e il commerciante mantiene il pieno controllo per tutto il tempo.
+
+**Distribuzione flessibile.** ZGo può essere usato per un singolo pomeriggio a un mercatino pop-up, per una configurazione permanente di punto vendita, o come backend per un negozio online tramite le integrazioni Xero o WooCommerce.
+
+**Basato su browser.** Nessuna installazione né dal lato del cliente né da quello del commerciante. ZGo funziona in qualsiasi browser moderno su desktop o mobile.
+
+**Compatibilità con i wallet.** I principali wallet Zcash, inclusi quelli che supportano i tipi di indirizzo Orchard, Sapling e Transparent, possono pagare una fattura ZGo senza configurazioni aggiuntive dal lato del cliente.
+
+**Integrazioni.** Le integrazioni dirette con Xero (contabilità) e WooCommerce (e-commerce) coprono i due workflow più comuni dei commercianti out of the box.
+
+## Errori comuni
+
+**Trattare l'ordine come pagato prima delle cinque conferme.** Una transazione trasmessa non è la stessa cosa di un pagamento confermato. La transazione può ancora non confermarsi o essere sostituita. Solo dopo cinque conferme ZGo segnala il pagamento come definitivo, e solo allora l'ordine dovrebbe essere contrassegnato come pagato a valle. Se un commerciante configura l'inventario o l'evasione perché si attivino sull'evento di trasmissione, pagamenti fraudolenti o falliti causeranno perdite reali.
+
+**Puntare ZGo a un indirizzo di deposito di un exchange.** Sembra un indirizzo Zcash, ma gli indirizzi di deposito degli exchange sono controllati dall'exchange, non dal commerciante. L'exchange detiene le chiavi, il che significa che l'exchange detiene i fondi, vanificando il motivo per cui si usa un processor non-custodial. L'indirizzo del wallet configurato in ZGo deve essere un wallet la cui seed phrase è controllata direttamente dal commerciante.
+
+**Trattare ZGo come un wallet.** ZGo è un payment processor, non un wallet. Non memorizza chiavi, non detiene saldi e non consente al commerciante di spendere fondi. È necessario un wallet Zcash separato, sotto il controllo del commerciante, per ricevere il denaro che ZGo instrada.
+
+## Conclusione
+
+ZGo offre ai commercianti un modo per accettare pagamenti Zcash senza rinunciare alla custodia, senza dipendere da un intermediario e senza esporre i dettagli delle transazioni su una chain pubblica. Le due integrazioni (Xero e WooCommerce) coprono i workflow più comuni dei commercianti; per tutto il resto, ZGo può essere usato in modalità standalone da qualsiasi browser.
+
+Per il setup, il percorso è breve: ottieni un wallet Zcash, crea un account su [zgo.cash](https://zgo.cash/) e inizia a generare richieste di pagamento direttamente oppure installa l'integrazione pertinente.
+
+## Risorse
+
+- [Sito ufficiale di ZGo](https://zgo.cash/)
+- [Procedura di configurazione dell'integrazione Xero](https://hedgedoc.vergara.tech/s/4iXC67fmb)
+- [WooCommerce](https://woocommerce.com/) e [WordPress](https://wordpress.org/)
+- [Xero](https://www.xero.com/)
+- [Homepage del progetto Zcash](https://z.cash/)
+- [ZecHub Wallets](https://zechub.wiki/wallets), l'elenco dei wallet Zcash compatibili
+- [Panoramica ZecHub dei Payment Processor](https://zechub.wiki/payment-processors), ZGo nel contesto delle altre opzioni di pagamento Zcash
+- [BTCPayServer Zcash Plugin](https://zechub.wiki/guides/btcpayserver-zcash-plugin), la relativa guida ZecHub per un'alternativa self-hosted

--- a/translations/it/site/guides/Zingolib_and_Zaino_Tutorial.md
+++ b/translations/it/site/guides/Zingolib_and_Zaino_Tutorial.md
@@ -1,0 +1,99 @@
+# Z3: (zebrad)(zaino)(zingo-cli)
+
+**zebrad**    : full node zcash
+
+**zaino**     : indicizzatore della blockchain zcash
+
+**zingo-cli** : client da riga di comando zaino-proxy per zcash (sottoinsieme di Zingolib)
+
+## Video
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/b5dIuGstMvI"
+    title="An introduction to Zingolib + Zaino"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+## Visione d'insieme
+
+[Architettura del sistema](https://github.com/zingolabs/zaino/blob/dev/docs/zaino_live_system_architecture.pdf)
+
+
+- L'utente Zcash installa/compila Zingolib, che dà accesso a zingo-cli. Può inviare/ricevere ZEC secondo necessità.
+- Zingo-cli si connette a zaino sia localmente sia tramite un canale sicuro online (all'utente Zcash non importa come funziona!)
+- Zaino consente l'accesso sia a zebrad sia a zcashd            
+- Un zebrad completamente sincronizzato è la fonte di verità (qui niente più wallet!)
+
+
+
+## Installazione
+
+Dovrai installare 3 cose perché tutto funzioni correttamente. Consiglio anche screen o qualcosa di simile per aiutare nella gestione delle sessioni
+
+`sudo apt install screen`
+
+### zebrad
+
+```
+git clone https://github.com/ZcashFoundation/zebra.git
+cd zebra
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v2.0.1 zebrad
+```
+
+ 
+*facoltativo* (crea una sessione screen per zebrad)
+
+```
+screen -S zebra
+zebrad start
+```
+
+nota: questo dovrà sincronizzarsi completamente! 
+
+### zaino
+
+```
+git clone https://github.com/zingolabs/zaino.git
+cd zaino
+cargo build --release
+PATH=$PATH:~/Desktop/zaino/target/release/
+```
+
+
+*facoltativo* (crea una sessione screen per zaino)
+
+```
+screen -S zaino
+cd ~/zaino/zainod
+nano zindexer.toml  => Imposta la porta su 8232 per la mainnet
+zainod --config zindexer.toml
+```
+
+
+### zingo-cli
+
+```
+git clone https://github.com/zingolabs/zingolib.git
+cd zingolib
+cargo build --release --package zingo-cli
+```
+
+*facoltativo* (crea una sessione screen per zingo-cli)
+
+```
+screen -S zingo
+./zingo-cli --server http://127.0.0.1:8137 --data-dir /media/zebra5/zebra/.cache/lightwalletd
+```
+
+nota: questo dovrà sincronizzarsi completamente, proprio come ha fatto lightwalletd. Consiglio di usare un disco esterno per risparmiare tempo :)
+
+
+## Esecuzione
+
+Se li stai eseguendo in screen, `screen -r` elencherà ogni screen, così potrai passare da uno all'altro secondo necessità

--- a/translations/it/site/guides/Zkool_Multisig.md
+++ b/translations/it/site/guides/Zkool_Multisig.md
@@ -1,0 +1,134 @@
+# Guida al Multisig di Zkool
+
+Questa guida fornisce una procedura passo passo su come effettuare transazioni multisig usando Zkool. Include la creazione di account, l'invio o la ricezione di fondi e l'impostazione della generazione distribuita delle chiavi (DKG) per il multisig. Sono inclusi screenshot per ogni passaggio principale.
+
+## Tutorial
+
+<div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
+  <iframe
+    className="w-full h-full"
+    src="https://www.youtube.com/embed/eagkCIv3BlQ"
+    title="Zkool Demo | The Successor to Ywallet"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+    loading="lazy"
+  />
+</div>
+
+
+## 1. Creare un account
+
+
+1. Apri l'**app Zkool** e vai su **New Account**.
+
+
+![img1](https://github.com/user-attachments/assets/ee906e49-361a-49b6-9484-904897fe2e3f)
+
+3. Inserisci un **Nome account** (es. Anabelle).  
+   
+
+![img2](https://github.com/user-attachments/assets/e9c325d3-8507-433a-a0c6-6e8c1ea2a254)
+
+
+4. Opzionalmente attiva **Use Internal Change** o **Restore Account** se necessario.
+
+
+5. Dopo la creazione, l'account comparirà nella tua **Lista degli account**.  
+
+
+![img3](https://github.com/user-attachments/assets/c446cbca-fb3e-49b9-b1d4-fd727cd1b0fb)
+
+
+## 2. Ricevere fondi
+
+Ogni account genera più tipi di indirizzo:
+
+**Unified Address**
+
+**Indirizzo solo Orchard**
+
+**Indirizzo Sapling**
+  
+**Indirizzo trasparente**
+
+
+Seleziona il tipo che vuoi usare e condividilo per ricevere fondi.  
+
+
+![img4](https://github.com/user-attachments/assets/c9de5dfe-e9d7-423d-8d90-35c1a08ffd5d)
+
+
+
+
+
+## 3. Inviare fondi
+
+1. Vai alla sezione **Recipient**.  
+
+
+![img5](https://github.com/user-attachments/assets/9f3a03b9-dd56-450c-a8dc-4370f9289138)
+
+
+3. Inserisci l'**indirizzo del destinatario**.  
+
+4. Specifica l'**importo** e un eventuale **memo** opzionale.  
+
+5. Rivedi i dettagli della transazione e **conferma**.  
+
+
+Una volta completata, il saldo si aggiorna nella tua lista degli account.  
+
+
+![img6](https://github.com/user-attachments/assets/6e6da76b-cd18-4567-a5c0-74f07ddefc64)
+
+
+## 4. Eseguire transazioni multisig: impostare la generazione distribuita delle chiavi (Multisig)
+
+Il multisig in Zkool usa la **generazione distribuita delle chiavi (DKG)** per garantire che più partecipanti controllino un account condiviso.
+
+
+
+### Passo 1: avvia la DKG
+Scegli un **Nome** per il wallet condiviso (es. Anabelle).
+
+Imposta il **Numero di partecipanti**.
+  
+Scegli il tuo **ID partecipante**.
+  
+Definisci il **Numero di firmatari richiesti (soglia)**.
+    
+Seleziona l'**Account di finanziamento**.
+  
+
+![img7](https://github.com/user-attachments/assets/8a90ca85-5439-4937-b16d-a570e69d55f0)
+
+
+
+### Passo 2: aggiungi gli indirizzi dei partecipanti
+- Inserisci l'**Unified Address** di ciascun partecipante (consigliato).
+
+
+**Nota:** se usi un indirizzo solo Orchard o solo Sapling, il multisig sarà limitato a quel solo pool (Orchard o Sapling).  
+Questo significa che il wallet condiviso non può ricevere fondi da altri pool.  
+Per la massima compatibilità e flessibilità, usa sempre gli **Unified Address**.  
+
+
+### Passo 3: esegui i round della DKG
+Attendi che tutti i partecipanti scambino i pacchetti del **round 1** e del **round 2**.  
+
+
+![img8](https://github.com/user-attachments/assets/cdaf6e00-3cb0-4774-8a96-5ded19bf31c4)
+
+
+
+### Passo 4: finalizza l'indirizzo condiviso
+Una volta completato, viene generato un **indirizzo condiviso**.  
+
+
+![img9](https://github.com/user-attachments/assets/741d1bc6-0102-4e67-bb83-9a1c184bd747)
+
+
+
+## Conclusione
+
+Con Zkool puoi: creare account, inviare e ricevere fondi e impostare un **wallet multisig** usando la generazione distribuita delle chiavi. Questo garantisce una **sicurezza potenziata** e una **gestione dei fondi collaborativa e privata**.  

--- a/translations/it/site/guides/coinholder_log_parser/help.md
+++ b/translations/it/site/guides/coinholder_log_parser/help.md
@@ -1,0 +1,25 @@
+# Filtro dei log delle elezioni
+
+`./filterForElection.sh <logname> <election #>`    
+
+mostra gli sighash e le altezze delle schede per le voci che coinvolgono il numero di elezione indicato
+
+
+<img width="1818" height="542" alt="Screenshot_2026-02-01_08-41-48" src="https://github.com/user-attachments/assets/27ac6417-84de-4da8-a9c7-220919a1a180" />
+
+---
+
+`./numberOfBallets.sh <logname> <election #>`      
+
+mostra il conteggio dell'ultima voce (la più recente) per l'altezza delle schede dato un numero di elezione
+
+<img width="904" height="56" alt="Screenshot_2026-02-01_08-42-33" src="https://github.com/user-attachments/assets/3dae0a32-ec1d-48c4-8b96-1b775fcc6811" />
+
+---
+
+`./displayCurrentResults.sh`                      
+
+Riepilogo in output di tutte le elezioni dato un file di log
+
+
+<img width="1062" height="324" alt="Screenshot_2026-02-01_08-41-13" src="https://github.com/user-attachments/assets/9055e642-d1b9-493b-8c86-3982eeaaf80b" />

--- a/translations/it/site/guides/frostdemo/Ywallet_FROST_Demo.md
+++ b/translations/it/site/guides/frostdemo/Ywallet_FROST_Demo.md
@@ -1,0 +1,65 @@
+# Demo FROST con Ywallet
+
+## Compila i binari FROST
+
+https://github.com/ZcashFoundation/frost-zcash-demo/tree/update-zcash-sign
+
+Usa il repo qui sopra e segui le indicazioni sulla compilazione: 
+
+`cargo build --bin trusted-dealer`
+
+`cargo build --bin dkg`
+
+`cargo build --bin coordinator`
+
+`cargo build --bin participants`
+
+I binari si troveranno nella cartella target.
+
+
+## Crea una UA FROST
+
+`./generateFROST_UA.sh`
+
+
+
+## Importa la UFVK in Ywallet
+
+Accounts -> Clicca + e incolla la ufvk dal passo precedente
+
+## Crea una transazione con Ywallet
+
+Incolla una qualsiasi UA e invia una tx. Salva il file.
+
+## Avvia la procedura di firma FROST 
+
+`./signFROST_tx.sh rawtxs/mytx signedtxs/mysignedtx`
+
+il primo input è la posizione della tx grezza ottenuta dal passo precedente
+il secondo input è la posizione e il nome della tx firmata che vuoi trasmettere
+Questa è la parte in cui indichi a FROST quale transazione vuoi che tutti firmino
+
+## Avvia il Coordinator
+
+`./runCoordinator.sh`
+
+Questo coordina la firma di ciascun partecipante e crea una firma di gruppo
+
+## Fai firmare a ciascun Partecipante questa transazione
+
+`./participantSign.sh key-package-1.json`
+
+
+`./participantSign.sh key-package-2.json`
+
+## Finalizza la transazione firmata
+
+Nella finestra del coordinator, copia la firma di gruppo che viene mostrata in output e incollala nella finestra di firma FROST.
+Questo completerà la firma FROST e produrrà 'mysingedtx'
+
+
+## Trasmetti la tua transazione con Ywallet
+
+Clicca su 'More' nella parte in basso a destra di Ywallet e trova 'Broadcast'. Trova 'mysignedtx' e clicca ok.
+
+Se tutto funziona otterrai un ID della transazione :)

--- a/translations/it/site/guides/multisigdemo/MultiSigDemo.md
+++ b/translations/it/site/guides/multisigdemo/MultiSigDemo.md
@@ -1,0 +1,101 @@
+# Demo MultiSig
+
+Questa demo richiede zcashd 
+
+## Raccogli le chiavi pubbliche dalle persone necessarie
+
+* https://github.com/iancoleman/bip39
+* Se usi zcashd, puoi creare un UA e usare anche il tuo ricevente trasparente. Poi usa `getPubkey.sh` per estrarre la tua chiave pubblica.
+
+
+## Crea due indirizzi multisig (2 su 3) t3
+
+esegui createMultiSig.sh per generare il tuo indirizzo multisig e lo script di redenzione. Servono 3 chiavi pubbliche
+
+`./createMultiSig.sh pubk1 pubk2 pubk3`      # 1° t3
+
+`./createMultiSig.sh pubk4 pubk5 pubk6`      # 2° t3 per l'indirizzo di resto. 
+
+#### NOTA: in questo esempio pubk1 e pubk4 sono la stessa persona, pubk2 e pubk5 sono la stessa persona e così via ...
+
+#### NOTA2: l'ORDINE delle tue pubkey è importante! Fai attenzione a questo!!!!
+
+
+## Finanzia l'indirizzo t3
+
+Usa qualsiasi wallet/faucet per finanziare l'indirizzo
+
+## Crea la transazione MultiSig
+
+`./createMultiSigTX.sh txid voutIndex scriptPubKey redeemScript oldAmount tAddy amount changeTaddy`
+
+dove,
+
+```
+        txid: un ID di transazione della transazione che ha inviato denaro al tuo nuovo t3
+   voutIndex: l'indice dell'output in vout che ha il valore più grande
+scriptPubKey: lo script di blocco P2SH contiene l'hash di un altro script di blocco (Script Hash), circondato dagli opcode HASH160 ed EQUAL. È in formato esadecimale e si trova tramite la rpc getrawtransaction, cerca scriptPubKey
+redeemScript: il valore esadecimale del redeemScript prodotto in output durante la creazione del nostro t3. È necessario a tutte le persone che vogliono spendere dal t3.
+   oldAmount: importo inviato al tuo nuovo t3 dal txid sopra
+       tAddy: l'indirizzo a cui vuoi inviare i fondi
+      amount: l'importo di ZEC da inviare a tAddy
+ changeTaddy: indirizzo di resto (nuovo t3 con un nuovo redeemScript!)
+
+```
+
+`./txDetails.sh txid`   => ti aiuterà a trovare le informazioni necessarie
+
+```
+
+txid              : ./txDetails.sh 6742b37b4db10ee177a3551e69b3726705bb0178483ed37e253de9869b549530 | jq .txid
+
+valueInitialTX    : ./txDetails.sh 6742b37b4db10ee177a3551e69b3726705bb0178483ed37e253de9869b549530 | jq .vout[].value   ** questo è necessario per la firma! **
+
+voutIndex         : ./txDetails.sh 6742b37b4db10ee177a3551e69b3726705bb0178483ed37e253de9869b549530 | jq .vout[].n
+
+scriptPubKey      : ./txDetails.sh 6742b37b4db10ee177a3551e69b3726705bb0178483ed37e253de9869b549530 | jq .vout[].scriptPubKey.hex
+
+```
+
+
+
+## Firma la transazione MultiSig
+
+Apri signMultiSigTX.sh e aggiungi le tue chiavi private nelle variabili pk1, pk2, ...
+ 
+
+*** Non consiglierei di digitarle nel tuo terminale. ***
+
+
+Se hai accesso a tutte le tue chiavi private, puoi usarle tutte in una volta per risparmiare tempo,
+ma nella maggior parte degli esempi del mondo reale la firma sarà eseguita da persone in giro per il mondo, quindi ciascuno dei partecipanti richiesti dovrà firmare,
+poi rinviare l'output "hex" della rawTX aggiornata che gli altri useranno per firmare e completare la procedura di firma.
+
+Chiunque crei la prima tx firmerà con la propria chiave privata e invierà l'hex della rawTX aggiornata che deve essere firmata dagli altri partecipanti.
+
+`./signMultiSigTX.sh rawTX txid voutIndex scriptPubKey redeemScript valueInitialTX`
+
+Per firmare questa tx, almeno 2 delle tre chiavi private devono firmarla. Se la chiave pubblica che hai fornito è stata esportata usando un indirizzo-T da zcashd, puoi ottenere la chiave privata del tuo indirizzo-T con: 
+
+
+`zcash-cli dumpprivkey "t-addr"`
+
+
+Per questa demo, ho usato il bip39 di iancoleman per isolare rapidamente le chiavi private necessarie.
+
+
+## Trasmetti la TX firmata
+
+`./sendMultiSignedTX.sh signedTXfromLastStep`
+
+
+
+# Fonti
+
+* https://learnmeabitcoin.com/technical/script/p2sh/
+* https://bitcoin.stackexchange.com/questions/6100/how-will-multisig-addresses-work
+* https://zcash.github.io/rpc/
+
+
+
+

--- a/translations/it/site/guides/workshops/zcashContributorWorkshopDay3.md
+++ b/translations/it/site/guides/workshops/zcashContributorWorkshopDay3.md
@@ -1,0 +1,102 @@
+# Workshop Giorno 3
+
+
+
+## Analisi dei dati
+
+* La scienza di analizzare dati grezzi usando sistemi, strumenti e tecniche specializzati per identificare schemi, tendenze e intuizioni
+
+
+Comprende:
+```markdown
+                     \
+-> collecting         \
+-> cleaning     =====  \  DATA
+-> organizing   =====  / 
+-> transforming       /
+-> optimizing        /
+```
+
+
+
+
+## Zcash 
+
+* Contante elettronico cifrato. La prima criptovaluta a sviluppare la cifratura a conoscenza zero per pagamenti privati peer-to-peer.
+
+nota: se vuoi dati accurati di cui ti FIDI, è consigliato far girare un proprio nodo completo [zebrad]. Puoi configurare l'infrastruttura
+z3 [ zebrad + zainod/lightwalletd + "wallet a scelta qui" ] se vuoi una soluzione completa e robusta. Accedi
+ai dati usando gli RPC (Remote Procedure Call)
+
+Per una rapida dimostrazione di come funziona, guarda questo video:
+
+
+https://www.youtube.com/watch?v=Ok9Wa8FNbMA
+
+
+## Demo del workshop
+
+Questo workshop si concentrerà sulla raccolta e trasformazione dei dati a livello di wallet. Questo è il livello a cui la maggior parte delle persone accederà
+alla blockchain di Zcash.
+
+
+### Caso d'uso ( Creare un file .csv di tutte le transazioni di un dato account in Zkool)
+
+Questo è uno scenario molto diffuso in cui si avrebbe bisogno di organizzare e ottimizzare le proprie finanze personali *digitali*.
+
+#### Passo 1
+
+Apri Zkool e seleziona l'account che vuoi usare
+
+nota: useremo un wallet testnet per questa demo.
+
+nota2: scegliamo Zkool qui, ma QUALSIASI wallet che disponga di una funzionalità di esportazione andrà bene!
+
+https://github.com/hhanh00/zkool2
+
+<img width="1496" height="646" alt="1" src="https://github.com/user-attachments/assets/125adfe8-6be3-4798-8ee8-b96bba9fb9ac" />
+
+
+
+#### Passo 2
+
+
+Vai al menu in alto a destra e seleziona "Export Transactions"
+
+<img width="1398" height="718" alt="2" src="https://github.com/user-attachments/assets/4287ceb6-669b-4ef0-ba24-3f7e2d9860b6" />
+
+
+#### Passo 3
+
+Scarica lo script bash che useremo per trasformare i nostri dati. Per gli sviluppatori che stanno guardando, userò bash che
+è standard nella maggior parte delle distro Linux, ma puoi usare il linguaggio che preferisci. 
+
+Per i non sviluppatori o gli studenti che si stanno facendo le ossa, usa l'IA! 
+
+Alcuni esempi di prompt che possono aiutarti a iniziare:
+
+"Come posso usare "bash/rust/python/ ... ecc." per trasformare file CSV"
+
+<img width="1098" height="480" alt="3" src="https://github.com/user-attachments/assets/6503f4be-6fbc-473f-919c-8914e09181bc" />
+
+nota: devi comunque comprendere le basi, ma è facendo questi workshop che capisci il FLUSSO del processo.
+
+nota2: l'IA di solito non è privata, quindi fai molta attenzione quando la usi come studente!
+
+#### Passo 4
+
+Prepara gli script per l'uso ed eseguili
+
+`chmod +x cleanCSV.sh`
+
+`./cleanCSV.sh "name_of_exportBackup"`
+
+#### Passo 5 Usa i dati
+
+Apri in libreOffice o in qualsiasi visualizzatore CSV per l'uso!
+
+
+
+<img width="2132" height="942" alt="4" src="https://github.com/user-attachments/assets/1097030d-c0f4-44c4-b15c-f86706a77bdc" />
+
+

--- a/translations/it/site/tutorials/Exchanges.md
+++ b/translations/it/site/tutorials/Exchanges.md
@@ -1,0 +1,34 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/tutorials/Exchanges.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Exchange Zcash
+
+- Comprare ZEC sull'exchange Gemini 
+ 
+[![Video Thumbnail](https://img.youtube.com/vi/REUbkLzK7J4/hqdefault.jpg)](https://www.youtube.com/watch?v=REUbkLzK7J4)
+
+
+___
+
+
+- Usare il DEX Atomix
+
+[![Video Thumbnail](https://img.youtube.com/vi/TwKQE8X7McA/hqdefault.jpg)](https://www.youtube.com/watch?v=TwKQE8X7McA)
+
+
+___
+
+- Comprare Zcash su Coinbase per schermarlo
+
+[![Video Thumbnail](https://img.youtube.com/vi/3xyKKer1Qvk/hqdefault.jpg)](https://www.youtube.com/watch?v=3xyKKer1Qvk)
+
+
+___
+
+- Zcash schermato sull'exchange Sideshift 
+
+[![Video Thumbnail](https://img.youtube.com/vi/joQtS8QUpdg/hqdefault.jpg)](https://www.youtube.com/watch?v=joQtS8QUpdg)
+
+
+____

--- a/translations/it/site/tutorials/Full_Node_Tutorials.md
+++ b/translations/it/site/tutorials/Full_Node_Tutorials.md
@@ -1,0 +1,40 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/tutorials/Full_Node_Tutorials.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Tutorial sui full node
+
+I full node Zcash validano le transazioni trasparenti e schermate sulla rete. Eseguendo un full node contribuisci alla resilienza e alla stabilità della rete. Inoltre, gestire un full node fornisce all'utente garanzie di sicurezza e protezione potenziate. Di seguito trovi guide video per configurare/aggiornare full node zcashd o zebrad.
+
+Leggi le nostre [guide](/site/Guides/Full_Nodes) per maggiori informazioni.
+
+- Come compilare Zcashd su Raspberry Pi 4
+
+[![Video Thumbnail](https://img.youtube.com/vi/SGYrzhs1l2k/hqdefault.jpg)](https://www.youtube.com/watch?v=SGYrzhs1l2k)
+____
+
+- Zcashd Wallet Tool
+
+[![Video Thumbnail](https://img.youtube.com/vi/9t2LX3HFldw/hqdefault.jpg)](https://www.youtube.com/watch?v=9t2LX3HFldw)
+____
+
+- L'uso pratico di Zcashd 
+
+[![Video Thumbnail](https://img.youtube.com/vi/KNhd1KC0Bqk/hqdefault.jpg)](https://www.youtube.com/watch?v=KNhd1KC0Bqk)
+____
+
+- Come aggiornare un nodo Zcashd
+
+[![Video Thumbnail](https://img.youtube.com/vi/YjAkaseEqAE/hqdefault.jpg)](https://www.youtube.com/watch?v=YjAkaseEqAE)
+_____
+
+- Usare il server Lightwalletd con Zebra
+
+[![Video Thumbnail](https://img.youtube.com/vi/FfH5jiX8pT0/hqdefault.jpg)](https://www.youtube.com/watch?v=FfH5jiX8pT0)
+
+
+____
+
+- Pubblicare commenti su Free2Z con Zenith CLI
+
+[![Video Thumbnail](https://img.youtube.com/vi/HtorP8TJ5vk/hqdefault.jpg)](https://www.youtube.com/watch?v=HtorP8TJ5vk)

--- a/translations/it/site/tutorials/Using_Zcash.md
+++ b/translations/it/site/tutorials/Using_Zcash.md
@@ -1,0 +1,37 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/tutorials/Using_Zcash.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Tutorial per usare Zcash 
+
+
+- Consigli utili quando si usa Zcash
+
+[![Video Thumbnail](https://img.youtube.com/vi/tEfQaYPV0UE/hqdefault.jpg)](https://www.youtube.com/watch?v=tEfQaYPV0UE)
+
+
+____
+
+- Come effettuare richieste di pagamento Zcash
+
+[![Video Thumbnail](https://img.youtube.com/vi/l5auYQIzYsQ/hqdefault.jpg)](https://www.youtube.com/watch?v=l5auYQIzYsQ)
+
+
+____ 
+
+
+- Aggiungere un widget per donazioni Zcash al tuo sito web
+
+[![Video Thumbnail](https://img.youtube.com/vi/NbP4BcHC0uM/hqdefault.jpg)](https://www.youtube.com/watch?v=NbP4BcHC0uM)
+
+
+___ 
+
+
+- Come eseguire una transazione schermata
+
+[![Video Thumbnail](https://img.youtube.com/vi/5bx4GhQTi_8/hqdefault.jpg)](https://www.youtube.com/watch?v=5bx4GhQTi_8)
+
+___
+
+

--- a/translations/it/site/tutorials/Wallet_Tutorials.md
+++ b/translations/it/site/tutorials/Wallet_Tutorials.md
@@ -1,0 +1,51 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/tutorials/Wallet_Tutorials.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Tutorial sui wallet Zcash
+
+Di seguito trovi un elenco di tutorial sui wallet che possono aiutarti a iniziare con ZEC.
+
+
+- Zashi Wallet 
+
+[![Video Thumbnail](https://img.youtube.com/vi/G92zBIr-Wms/hqdefault.jpg)](https://www.youtube.com/watch?v=G92zBIr-Wms)
+
+____
+
+
+- Confronto tra wallet Zcash
+
+[![Video Thumbnail](https://img.youtube.com/vi/ao4ORC_VNcY/hqdefault.jpg)](https://www.youtube.com/watch?v=ao4ORC_VNcY)
+
+____ 
+
+- Ywallet Cold Storage
+
+[![Video Thumbnail](https://img.youtube.com/vi/hJaAccp-77k/hqdefault.jpg)](https://www.youtube.com/watch?v=hJaAccp-77k)
+
+____
+
+- Ywallet Batch Backup
+
+[![Video Thumbnail](https://img.youtube.com/vi/0skM-RziBv8/hqdefault.jpg)](https://www.youtube.com/watch?v=0skM-RziBv8)
+
+
+____
+
+- Funzionalità Multipay di Ywallet
+
+[![Video Thumbnail](https://img.youtube.com/vi/ovlNktpxURI/hqdefault.jpg)](https://www.youtube.com/watch?v=ovlNktpxURI)
+
+
+____
+
+- Tutorial su Unstoppable Wallet 
+
+[![Video Thumbnail](https://img.youtube.com/vi/B9tpkgVRsq4/hqdefault.jpg)](https://www.youtube.com/watch?v=B9tpkgVRsq4)
+
+____
+
+
+
+

--- a/translations/it/site/tutorials/shieldedNewsletter/daoAddresses.md
+++ b/translations/it/site/tutorials/shieldedNewsletter/daoAddresses.md
@@ -1,0 +1,3 @@
+u1zhgy24tweexhjcsstya5qqzrus4cgv0amasfv5jp6f3p3qvw265rugn8ref5djg472l5s382mwuffremffr7se6xjlh5exagwg2d6frs
+
+

--- a/translations/it/site/tutorials/shieldedNewsletter/mynewsletter.md
+++ b/translations/it/site/tutorials/shieldedNewsletter/mynewsletter.md
@@ -1,0 +1,62 @@
+DIGEST DELL'ECOSISTEMA ZCASH | 6 LUGLIO
+
+Zebra 1.8.0 ultima release, FROST è pubblicato, Zooko avvia un nuovo progetto Zcash e test degli swap schermati su Maya Protocol 
+
+### Aggiornamenti ECC e ZF:
+
+[Zebra 1.8.0 latest release](https://github.com/ZcashFoundation/zebra/releases/tag/v1.8.0)
+
+[ECC Update: Onward a Legacy in Motion](https://x.com/jswihart/status/1809385692512022710)
+
+[ECC Transparency Report for Q4 '23'](https://electriccoin.co/blog/ecc-transparency-report-for-q4-2023/)
+
+[Zcash Foundation's Engineering update for Sprint 13](https://forum.zcashcommunity.com/t/zf-engineering-update-2024-sprint-13-june-18th-july-1st/48210)
+
+[ECC Endorsements & ZIP withdrawn](https://forum.zcashcommunity.com/t/ecc-endorsements-its-zip-withdrawn/48200)
+
+[Zooko leaves Bootstrap to start New Project](https://electriccoin.co/blog/zooko-and-a-new-focus-for-zcash-resilience/)
+
+[FROST Protocol is Publised](https://x.com/conradoplg/status/1808612054200373757)
+
+
+
+### Zcash Community Grants:
+
+[Zcash Avalanche Elastic Subnet Bridge Update](https://forum.zcashcommunity.com/t/zcash-elastic-subnet-bridge-on-avalanche/44220/63)
+
+[Shielded ZEC swaps with Maya Protocol](https://x.com/GiMa9550/status/1808960168681476288)
+
+[Official shielded support for zcash in ledger hw-wallet](https://forum.zcashcommunity.com/t/official-shielded-support-for-zcash-in-ledger-hw-wallet/45965/90)
+
+[Zcash Ecosystem Security Lead update](https://forum.zcashcommunity.com/t/grant-update-zcash-ecosystem-security-lead/47541/4)
+
+[Zcash Community Grants Meeting Minutes 6-25](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-6-25-2024/48199)
+
+[Official Shielded Support for Zcash in Ledger update](https://forum.zcashcommunity.com/t/official-shielded-support-for-zcash-in-ledger-hw-wallet/45965/90)
+
+
+
+
+### Progetti della community:
+
+[Zcash Brazil Weekly Call 22](https://x.com/zcashbrazil/status/1808206303107731746)
+
+[Dont use the MacOS Signal app - alberdioni8406 on Free2z](https://x.com/free2zcash/status/1809716224940781965)
+
+[The Hidden Costs of Web 2.0 - Zcash Media ](https://x.com/zcashmedia/status/1809580807616397557)
+
+[Shielding Summit - July 10th](https://x.com/ShieldingSummit/status/1809234609818718714)
+
+[Noam Chom ZIP proposal](https://x.com/NoamChom1984/status/1808561866177659250)
+
+[Aztec Network Privacy Space with zksquirrel](https://x.com/aztecnetwork/status/1807740519193456768)
+
+[@GorbitSM is a digital transformation agency for Community Building - ZcashEsp](https://x.com/zcashesp/status/1808532402634887472)
+
+[Graphene OS app has Zcash Donation](https://x.com/BostonZcash/status/1807814199667515713)
+
+[Russian Language version of Zcash Media's Web 3 video - ruZcash](https://x.com/ruZCASH/status/1809647252715262418)
+
+[How to Buy Playstation subscription with ZEC - GordonesTV](https://x.com/gordonesTV/status/1809201058230796323)
+
+[Zcash Brazil Spaces 11th July with guests @Aamandita & @castacrypto](https://x.com/zcashbrazil/status/1808992178238337287)

--- a/translations/it/site/tutorials/shieldedNewsletter/readme.md
+++ b/translations/it/site/tutorials/shieldedNewsletter/readme.md
@@ -1,0 +1,127 @@
+# Newsletter schermate
+
+
+## Configurazione
+
+ * Nodo Zebrad in esecuzione e completamente sincronizzato, con gli RPC attivi e configurati per usare i cookie
+ * Zainod completamente sincronizzato
+ * Zallet configurato per eseguire gli RPC
+
+
+### Avviare Zallet
+
+`./target/release/zallet -c /home/zktails/.zallet/zallet.toml start`
+
+con un file zallet.toml configurato
+
+esempio di toml:
+
+```markdown
+[builder]
+
+trusted_confirmations = 1
+
+untrusted_confirmations = 1
+
+[builder.limits]
+
+[consensus]
+
+network = "main"
+
+[database]
+
+[external]
+
+[features]
+
+as_of_version = "0.0.0"
+
+[features.deprecated]
+
+[features.experimental]
+
+#
+[indexer]
+
+
+validator_address = "127.0.0.1:8232"
+
+# Enable validator RPC cookie authentication.
+validator_cookie_auth = true
+
+# Path to the validator cookie file.
+validator_cookie_path = "/home/zktails/.cache/zebra/.cookie"
+
+
+db_path = "/home/zktails/.cache/zaino"
+
+[keystore]
+
+require_backup = false
+
+[note_management]
+
+[rpc]
+
+bind = ["127.0.0.1:8237"]
+```
+
+
+### toCurl.sh
+
+`chmod +x toCurl.sh`
+
+modifica la porta RPC corretta di zebrad (8232) e includi username e password dal cookie di zebrad
+
+
+`__cookie__:yourpasswordhere`
+
+
+### Testare gli RPC
+
+`./target/release/zallet -c /home/zktails/.zallet/zallet.toml rpc help`
+
+Dovrebbe produrre
+
+```bash
+getrawtransaction
+getwalletinfo
+help
+listaddresses
+rpc.discover
+stop
+walletlock
+walletpassphrase
+z_getaddressforaccount
+z_getnewaccount
+z_getnotescount
+z_getoperationresult
+z_getoperationstatus
+z_gettotalbalance
+z_listaccounts
+z_listoperationids
+z_listunifiedreceivers
+z_listunspent
+z_recoveraccounts
+z_sendmany
+z_viewtransaction
+```
+Nota: assicurati di avere una copia dell'eseguibile zallet nella cartella in cui esegui lo script
+
+### Eseguire gli script
+
+`chmod +x ascii2hex hex2ascii shieldNewsletter.sh txBuilderFromFile.sh toCurl.sh`
+
+Aggiorna daoAddress.md con gli UA che vuoi usare
+
+Apri txBuilderFromFile.sh e aggiorna la variabile "from" con l'UA finanziato presente nel tuo wallet zallet
+
+Poi,
+
+`./shieldNewsletter.sh yourNewsletterHere.md`
+
+
+
+
+

--- a/translations/it/site/tutorials/zenithserver/zenithBeta.md
+++ b/translations/it/site/tutorials/zenithserver/zenithBeta.md
@@ -1,0 +1,35 @@
+# Zenith 0.10 Beta
+
+Avrai bisogno di uno zebrad in esecuzione con gli RPC abilitati
+
+# Installa NIX
+
+```bash
+sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --no-daemon
+sudo chown -R <username> /nix'
+. /home/<username>/.nix-profile/etc/profile.d/nix.sh
+```
+
+
+Aggiungi quanto segue a ~/.config/nix/nix.conf o /etc/nix/nix.conf:
+
+`experimental-features = nix-command flakes`
+
+
+# Installa Zenith
+
+```bash
+nix profile install git+https://code.vergara.tech/Vergara_Tech/zenith?ref=master#gui --impure
+nix profile install git+https://code.vergara.tech/Vergara_Tech/zenith?ref=master
+```
+
+
+
+# Esegui Zenith
+
+
+`zenithgui`
+
+oppure
+
+`zenithserver`


### PR DESCRIPTION
## What & why

The Italian curated corpus is **incomplete in production**. PR #1789 merged the phase-1 branch (`i18n/it-corpus`, **90/180** pages); the phase-2 completion landed on a separate branch and was never published. As a result these sections currently **fall back to English** on the live site:

| Section | Pages |
|---|---|
| `guides` | 34 |
| `Zcash_Social_Media` | 14 |
| `Research` | 13 |
| `ZFAV_Club` | 10 |
| `tutorials` | 8 |
| `contribute` | 6 |
| `Privacy_Tools` (remaining) | 4 |
| `footer.md` | 1 |
| **Subtotal** | **90** |

This PR adds those 90 pages **plus** `Zcash_Organizations/Sovright.md` (which had been dropped from the curated set in every locale), bringing the Italian corpus to **181** pages.

## Scope & safety

- **Purely additive** — every file is new; no already-merged translation is modified.
- All changes are confined to `translations/it/site/**`.
- English source and other locales are untouched.

## Validation

`node scripts/check-protected-terms.mjs` passes for **all 181** Italian pages against the current `main` English source (0 missing terms, 0 pages without a matching source), so every added page resolves via the runtime lookup rather than falling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)