### PR TITLE
Add Zecd, Nozy, and Zipher to Zcash Wallets directory

### DIFF
--- a/site/Using_Zcash/Wallets.md
+++ b/site/Using_Zcash/Wallets.md
@@ -283,3 +283,33 @@
 - Wallet Support: Unified Address 
 - Pools: Transparent | Sapling | Orchard
 - Features: End-to-end encrypted Messenger | NEAR Intents | P2P.me Offramp | Beta
+
+---
+
+## [Zecd](https://zecd.org)
+![logo](https://zecd.org/favicon.png "Zecd")
+- Devices: Desktop
+- Operating System: Linux
+- Wallet Support: Seed Phrase | Viewing Key | Unified Address
+- Pools: Transparent | Sapling | Orchard
+- Features: Bitcoin Core RPC | JSON-RPC Interface | Shielded First | Watch-only Wallets | Docker Support
+
+---
+
+## [Nozy](https://github.com/LEONINE-DAO/Nozy-wallet)
+![logo](https://raw.githubusercontent.com/LEONINE-DAO/Nozy-wallet/master/assets/logo.png "Nozy")
+- Devices: Desktop
+- Operating System: Windows | Linux | macOS
+- Wallet Support: Seed Phrase | Viewing Key | Unified Address
+- Pools: Orchard
+- Features: Command Line Interface | Shielded Memo | Tor Support | Multi Coin | Testnet Support
+
+---
+
+## [Zipher](https://zipher.to/)
+![logo](https://zipher.to/zipher-logo.png "Zipher")
+- Devices: Mobile | Desktop
+- Operating System: Android | iOS | Linux
+- Wallet Support: Seed Phrase | Viewing Key | Unified Address
+- Pools: Transparent | Sapling | Orchard
+- Features: Automatic Shielding | DEX Swaps | Near Intents | Shielded Memo | Agent Tooling | Testnet Support


### PR DESCRIPTION
Adds 3 wallets to site/Using_Zcash/Wallets.md using the same format as the existing entries (Devices, Operating System, Wallet Support, Pools, Features).

- Zecd (https://zecd.org) is a shielded-first Zcash wallet server from Zec.rocks that speaks the Bitcoin Core JSON-RPC dialect. Linux and Docker.
- Nozy (https://github.com/LEONINE-DAO/Nozy-wallet) is an Orchard-only shielded CLI wallet from LEONINE-DAO. Windows, Linux and macOS.
- Zipher (https://zipher.to/) is a mobile and CLI wallet from Atmosphere Labs with shielding, swaps and NEAR Intents.

I checked each one against the project's own site, repo and forum posts before writing the entries. The logos are linked from official sources.

Two things worth flagging:

The task also listed a wallet called "Zend: Zcash Wallet", but I couldn't find it anywhere. Not on the forum, the app stores, GitHub or the wiki. I left it out instead of guessing. If someone has a link for it I'm happy to add it.

The task spelled the third one "Nozzy", but the project's actual name is Nozy, so that's what I used.
