### PR TITLE
Update Full Nodes docs for the zcashd deprecation (Zebra/Zallet)

### DIFF
--- a/site/Zcash_Tech/Full_Nodes.md
+++ b/site/Zcash_Tech/Full_Nodes.md
@@ -10,7 +10,9 @@ It holds a complete record of every transaction that has occurred since genesis 
 
 ## Zcashd
 
-Zcashd is currently the main Full Node implementation used by Zcash developed and maintained by the Electric Coin Company.
+> **Note:** zcashd is being deprecated. The Electric Coin Company has [formally announced](https://z.cash/support/zcashd-deprecation/) that zcashd is being retired, with its full-node role replaced by [Zebra](https://github.com/ZcashFoundation/zebra) (`zebrad`) and its wallet role by [Zallet](https://github.com/zcash/zallet). For new deployments, use Zebra (see below). If you already run a zcashd node, follow the [Migration Guide: zcashd to Zebrad/Zallet](https://zechub.wiki/migration-guide-zcashd-to-zebrad-zallet).
+
+zcashd was the original Full Node implementation for Zcash, developed and maintained by the Electric Coin Company. The build instructions below are retained for reference and for operators migrating away from zcashd.
 
 Zcashd exposes a set of API's via its RPC interface. These API's provide functions that allow external applications to interact with the node.
 
@@ -56,15 +58,13 @@ Zcashd exposes a set of API's via its RPC interface. These API's provide functio
 
 ## Zebra
 
-Zebra is an independent full node implementation for the Zcash Protocol created by the Zcash Foundation. 
+Zebra is an independent, production-ready full node implementation of the Zcash protocol, created by the Zcash Foundation and written in Rust. As zcashd is retired, Zebra (`zebrad`) is the recommended full node for new deployments.
 
-It is currently undergoing testing and is still experimental.
+Zebra validates blocks and transactions, participates in the peer-to-peer network, and exposes an RPC interface for applications. Wallet functionality is provided separately by [Zallet](https://github.com/zcash/zallet), which connects to a Zebra node — this modular split of node and wallet replaces the combined design of zcashd.
 
-There are two main components of Zebra. The client component which is responsible for blockchain scanning and trial decryption of transactions. 
+To serve shielded light wallets, Zebra is typically paired with an indexer such as [Zaino](https://zechub.wiki/zaino) in place of the older lightwalletd setup.
 
-The second part is the zebra command line tool. This tool manages spending keys, addresses & communicates with the Client component in zebrad to provide basic wallet functionality.
-
-Anyone interested in trying out Zebra to mine blocks is invited to join the R&D discord server. Also be sure to read the Zebra book for set-up instructions. 
+Be sure to read the Zebra book for set-up instructions, and join the R&D Discord server for support. 
 
 [Github](https://github.com/ZcashFoundation/zebra/)
 

--- a/site/tutorials/Full_Node_Tutorials.md
+++ b/site/tutorials/Full_Node_Tutorials.md
@@ -6,7 +6,9 @@
 
 Zcash Full Nodes validate transparent and shielded transactions on the Network. By running a full node you contribute to network resilience & stability. Additionally operating a full node provides enhanced safety and security guarantees to the user. Below are video guides for setting up/upgrading zcashd or zebrad Full Nodes.
 
-Please read our [guides](/site/Guides/Full_Nodes) for more information.
+> **Note:** zcashd is being [deprecated](https://z.cash/support/zcashd-deprecation/) in favour of [Zebra](https://github.com/ZcashFoundation/zebra) (`zebrad`) for the node and [Zallet](https://github.com/zcash/zallet) for the wallet. The zcashd videos below are kept for reference; for new setups follow the [Migration Guide: zcashd to Zebrad/Zallet](https://zechub.wiki/migration-guide-zcashd-to-zebrad-zallet).
+
+Please read our [Full Nodes guide](https://zechub.wiki/full-nodes) for more information.
 
 - How to Compile Zcashd on Raspberry Pi 4
 


### PR DESCRIPTION
## Summary

Updates the Full Nodes documentation to reflect the [zcashd deprecation](https://z.cash/support/zcashd-deprecation/): zcashd's full-node role is replaced by **Zebra** (`zebrad`) and its wallet role by **Zallet**. Framing is aligned with the existing [Migration Guide: zcashd to Zebrad/Zallet](https://zechub.wiki/migration-guide-zcashd-to-zebrad-zallet) already in the repo.

### `Zcash_Tech/Full_Nodes.md`
- Add a deprecation notice under the **Zcashd** section linking the ECC announcement and the migration guide; frame the zcashd build steps as legacy/reference.
- Correct the **Zebra** section: it previously said Zebra "is currently undergoing testing and is still experimental" and described a wallet-like CLI. Zebra is production-ready and the recommended full node; wallet functionality now lives in the separate Zallet, and shielded light-wallet indexing uses Zaino in place of the older lightwalletd setup.

### `tutorials/Full_Node_Tutorials.md`
- Add a note that zcashd is deprecated in favour of Zebra/Zallet, linking the migration guide (existing zcashd videos kept for reference).
- Fix a broken internal link (`/site/Guides/Full_Nodes` → `https://zechub.wiki/full-nodes`).

All external links added were verified to resolve.