### PR TITLE
Add Portal — Zcash Login track (Hackathon 3.0)

### DIFF
--- a/Hackathon/2026/Portal/LICENSE
+++ b/Hackathon/2026/Portal/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stanley Nnaka
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Hackathon/2026/Portal/README.md
+++ b/Hackathon/2026/Portal/README.md
@@ -1,32 +1,95 @@
 # Portal
 
-**ZecHub Hackathon 3.0 submission — Zcash Login track.**
+This is Portal, a new way to sign in, get paid, and pay someone else using nothing but a Zcash wallet. Built for the ZecHub Hackathon 3.0 Login track.
 
-Live instance: [tryportal.xyz](https://tryportal.xyz)
 Source repository: [github.com/IamHarrie-Labs/portal](https://github.com/IamHarrie-Labs/portal)
 
-**Sign in with Zcash.** Portal turns a shielded Zcash transaction into a login, a paywall, and a payment link. A visitor scans a QR code with their own wallet, sends a zero value shielded memo carrying a one time code, and Portal watches it arrive on mainnet and lets them in. No email, no password, and nobody, including the site they signed into, learns who they are.
+You send a private, shielded transaction with a one time code in the memo. Portal sees it arrive on the Zcash mainnet and signs you in. No email, no password, and nobody, including the site you're signing into, learns who you are.
 
-Everything here runs against the real Zcash mainnet. There is no testnet mode and nothing is simulated.
+The same flow lets you unlock paid content or send and receive money with a simple link. Everything here runs on real Zcash mainnet. There's no testnet mode and nothing is simulated.
 
-## What Portal does
+Live site: [tryportal.xyz](https://tryportal.xyz)
+Demo video: [youtu.be/UxJZrXAuWY4](https://youtu.be/UxJZrXAuWY4?si=oJp3IOc9NXAIijAq)
+Follow along: [x.com/trypayportal](https://x.com/trypayportal)
 
-**Login.** A drop in button for any website. The visitor's wallet sends a zero value shielded transaction with a one time code in the memo. Portal detects it within seconds and issues a session token. It works like Sign in with Google, except there is no Google, and no identity provider watching your logins.
+## What it does
 
-**Gates.** Paywalls and memberships where the login payment is the access fee. One shielded transaction both authenticates the visitor and pays for what they unlock. Gates can settle instantly on mempool detection, or wait for a mined block for higher priced content.
+**Login.** A button for any website. Your wallet sends a zero value shielded transaction with a one time code in the memo. Portal detects it within seconds and hands your site a session token. Think Sign in with Google, but there's no Google, and nobody's watching where you log in.
 
-**Paylinks.** Shareable payment request links. Set an amount and a label, share the URL, and get paid to a shielded address with live detection and downloadable receipts. Paylinks never expire.
+**Gates.** Paywalls and memberships where the login payment is the price of entry. One transaction both proves who you are and pays for what you're unlocking.
 
-**The Shielded Wall.** A live demonstration on the site. Any text after the code in a login memo becomes a public post, which means every message on the Wall traveled through Zcash mainnet inside an encrypted memo and was published without anyone knowing who wrote it.
+**Paylinks.** A shareable payment link. Set an amount and a label, share the URL, and anyone can pay you straight from their wallet. Links never expire.
 
-**Creator dashboard.** Anyone can sign in with their own wallet, no signup form, and get their own receiving address, their own priced Gates, their own Paylinks, and HMAC signed webhooks, all served by one Portal instance. A creator's identity is their wallet: the reply address in the login memo, hashed, is the account key.
+**The Shielded Wall.** Add a few words after the code in your login memo and they show up as a public post, sent through a real, encrypted mainnet transaction, with no way to trace who wrote it.
 
-## How a login works
+**Creator dashboard.** Sign in with your wallet, no signup form, and get your own receiving address, your own Gates and Paylinks, and webhooks for your payments, all on one Portal instance.
 
-1. The site requests a challenge and shows a QR code on desktop or a tap to open wallet link on mobile. Both are a standard ZIP 321 `zcash:` URI carrying the one time code in the memo field.
-2. The visitor scans or taps with any shielded Zcash wallet such as Zashi, Ywallet, or Zingo, and sends the zero value memo.
-3. The Portal server, a Zcash light client watching mainnet through a public lightwalletd, sees the memo in the mempool within seconds and issues a session token.
-4. Afterward the visitor can save a receipt card or open the transaction in a block explorer, where the world sees nothing at all. No sender, no receiver, no amount, no memo. That is the point.
+## How to add Portal to your own site
+
+You don't need to run anything to try this. Include the SDK and point it at a running Portal server, either the live instance at `tryportal.xyz` or your own if you're self-hosting.
+
+**1. Include the SDK**
+
+```html
+<script src="https://tryportal.xyz/sdk/portal.js"></script>
+```
+
+**2. Log a visitor in**
+
+```js
+const session = await Portal.login({ server: 'https://tryportal.xyz' });
+// session.token  -> a signed JWT, treat it like any other session token
+// session.txid   -> the real mainnet transaction that proved it
+// session.code   -> the one time code that got matched
+```
+
+That's the whole login. The SDK handles the QR code, the mobile deep link, the polling while it waits for your wallet's transaction to land, and every error state. If someone closes the modal, the promise rejects with `cancelled`.
+
+**3. Gate something behind a payment**
+
+Same call, just pass a `purpose`:
+
+```js
+await Portal.login({ server: 'https://tryportal.xyz', purpose: 'gate:vip' });
+// only resolves once a payment meeting that gate's price is seen on mainnet
+```
+
+If you sign in to the dashboard first, you can create your own priced gates under your own account instead of using the shared demo gate, each with its own key, price, and label, and choose whether it unlocks instantly or waits for a mined confirmation.
+
+**4. Take a payment with a link**
+
+```js
+await Portal.pay({ server: 'https://tryportal.xyz', slug: 'your-paylink-slug' });
+```
+
+Create the paylink itself from your dashboard, or directly against the API:
+
+```js
+POST /creators/me/paylinks
+{ "amount": "0.05", "label": "Coffee tip" }
+```
+
+**5. Get notified server side**
+
+If you'd rather not poll, register a webhook URL on your creator account and Portal will send a signed POST the moment a payment is detected, and again once it's confirmed. Every delivery carries an `x-portal-signature` header, an HMAC-SHA256 of the body signed with your own webhook secret, so you can verify it came from Portal before trusting it.
+
+**6. Run your own instance instead of using the shared one**
+
+Portal is two processes and no database. Build `zingo-cli` from [zingolib](https://github.com/zingolabs/zingolib), create a wallet, back up the seed phrase with `recovery_info`, then:
+
+```
+cd server && npm install
+PORTAL_ADDRESS=u1yourshieldedaddress npm start
+```
+
+Point your own SDK include and `server` option at your own instance from there. Every environment variable, the full HTTP API, and a deeper walkthrough live in the docs at [tryportal.xyz/docs](https://tryportal.xyz/docs).
+
+## How a login actually works
+
+1. Your site asks Portal for a challenge. Portal generates a one time code and wraps it into a standard Zcash payment request, a QR code for desktop, a tap to open link for mobile.
+2. The visitor scans or taps with any shielded Zcash wallet, Zashi, Ywallet, or Zingo, and sends the transaction. No typing, no new account.
+3. Portal, a Zcash light client watching mainnet through a public lightwalletd, sees the memo arrive, usually while it's still sitting in the mempool, and matches it to the code.
+4. Your site gets a signed session token. Afterward, anyone can look the transaction up on a public block explorer and find nothing. No sender, no receiver, no amount, no memo. That's the whole point.
 
 ## Architecture
 
@@ -45,42 +108,29 @@ Everything here runs against the real Zcash mainnet. There is no testnet mode an
 +----------+           (zec.rocks)               (mempool, 0-conf)
 ```
 
-- **server/** is the Node.js server: challenge issuance, memo watching, JWT sessions, creator accounts, gates, paylinks, and webhooks. No database, state persists as JSON on disk.
-- **sdk/** is a single dependency free JavaScript file: a `<script>` tag plus `Portal.login()` opens the QR modal and resolves with a session.
-- **demo/** is the website: landing page, live products, creator dashboard, pay pages, and documentation.
+- **server/** is the Node.js server: challenge issuance, memo watching, JWT sessions, creator accounts, gates, paylinks, and webhooks. No database, everything persists as JSON on disk.
+- **sdk/** is a single dependency free JavaScript file. A script tag plus `Portal.login()` opens the QR modal and resolves with a session.
+- **demo/** is the website itself: landing page, live dashboard, pay pages, and documentation.
 - **docs/** holds the project spec and playbook.
 
-Full source for all of the above lives in the source repository linked above rather than duplicated into this folder.
+## The trust model, honestly
 
-## Trust model, honestly
+Portal is built on real cryptography, and the parts that aren't trustless yet are written down here instead of hidden.
 
-Portal is built on real cryptography, and the parts that are not yet trustless are stated here rather than hidden.
+**Custody.** Creator receiving addresses are diversified addresses derived from the Portal instance's own wallet seed. They're unlinkable on chain, but the operator's keys can spend them, so today a creator is trusting the operator to forward their funds, the same way an early hot wallet payment processor works. The planned fix is Unified Full Viewing Keys: a creator hands Portal a viewing key for their own wallet, Portal can then see payments arrive but can never spend them, and money lands straight in the creator's wallet with no custody at all.
 
-**Custody.** Creator receiving addresses are diversified addresses derived from the Portal instance's own wallet seed. They are unlinkable on chain, but the operator's keys can spend them, so today a creator trusts the operator to forward funds, the same way an early BTCPay style hot wallet works. The planned fix is Unified Full Viewing Keys: a creator hands Portal a viewing key for their own wallet, Portal can then see payments arrive but can never spend them, and money goes straight to the creator with no custody at all.
+**Identity.** Shielded Zcash has no sender field, so a creator's identity is just the reply address they put in their login memo. Portal checks that a real transaction carried that claim, not that the sender actually owns the address. The fix is a reply handshake: Portal sends an encrypted memo with a secret back to the claimed address, and only the real owner can read it and echo it back, since a shielded memo can only be decrypted by whoever it was sent to.
 
-**Identity.** Shielded Zcash has no protocol level sender field, so a creator's identity is the reply address they include in their login memo. Portal verifies that a real shielded transaction carried the claim, but not that the sender owns the claimed address. The planned fix is a reply handshake: Portal sends an encrypted memo containing a secret back to the claimed address, and only the true owner can read it and echo it back, because a shielded memo can only be decrypted by the address owner. That proves ownership without revealing anything on chain.
+**Availability.** One wallet process watches the chain for the whole instance. It's crash hardened and serialized, but a production deployment would run more than one.
 
-**Availability.** One wallet process watches the chain for the whole instance. It is serialized and crash hardened, but a production deployment would run redundant watchers.
+These were the right tradeoffs for a first version, they made a complete, working product possible on real mainnet. Knowing exactly where the rough edges are is how they get fixed next.
 
-These tradeoffs were the right ones for version one: they made a working, end to end product possible on mainnet. The fixes above are designed and documented, not vaporware, and they are the next things to build.
+## What's next
 
-## Roadmap
-
-- Reply handshake so a claimed address becomes a proven address
+- The reply handshake, so a claimed address becomes a proven one
 - Viewing key based creator accounts, removing custody entirely
-- Pay from any chain and settle in ZEC through NEAR Intents
-- Automated test suite over the memo parser, challenge lifecycle, and webhook signing
-
-## Running it yourself
-
-Portal is two processes and no database. Build zingo-cli from [zingolib](https://github.com/zingolabs/zingolib), create a wallet, back up the seed phrase with `recovery_info`, then:
-
-```
-cd server && npm install
-PORTAL_ADDRESS=u1yourshieldedaddress npm start
-```
-
-The full walkthrough, every environment variable, and the HTTP API live in the documentation served at `/docs`. A live instance is running at [tryportal.xyz](https://tryportal.xyz), with docs at [tryportal.xyz/docs](https://tryportal.xyz/docs).
+- Paying from any chain and settling in ZEC through NEAR Intents
+- An automated test suite over the memo parser, the challenge lifecycle, and webhook signing
 
 ## License
 

--- a/Hackathon/2026/Portal/README.md
+++ b/Hackathon/2026/Portal/README.md
@@ -1,0 +1,87 @@
+# Portal
+
+**ZecHub Hackathon 3.0 submission — Zcash Login track.**
+
+Live instance: [tryportal.xyz](https://tryportal.xyz)
+Source repository: [github.com/IamHarrie-Labs/portal](https://github.com/IamHarrie-Labs/portal)
+
+**Sign in with Zcash.** Portal turns a shielded Zcash transaction into a login, a paywall, and a payment link. A visitor scans a QR code with their own wallet, sends a zero value shielded memo carrying a one time code, and Portal watches it arrive on mainnet and lets them in. No email, no password, and nobody, including the site they signed into, learns who they are.
+
+Everything here runs against the real Zcash mainnet. There is no testnet mode and nothing is simulated.
+
+## What Portal does
+
+**Login.** A drop in button for any website. The visitor's wallet sends a zero value shielded transaction with a one time code in the memo. Portal detects it within seconds and issues a session token. It works like Sign in with Google, except there is no Google, and no identity provider watching your logins.
+
+**Gates.** Paywalls and memberships where the login payment is the access fee. One shielded transaction both authenticates the visitor and pays for what they unlock. Gates can settle instantly on mempool detection, or wait for a mined block for higher priced content.
+
+**Paylinks.** Shareable payment request links. Set an amount and a label, share the URL, and get paid to a shielded address with live detection and downloadable receipts. Paylinks never expire.
+
+**The Shielded Wall.** A live demonstration on the site. Any text after the code in a login memo becomes a public post, which means every message on the Wall traveled through Zcash mainnet inside an encrypted memo and was published without anyone knowing who wrote it.
+
+**Creator dashboard.** Anyone can sign in with their own wallet, no signup form, and get their own receiving address, their own priced Gates, their own Paylinks, and HMAC signed webhooks, all served by one Portal instance. A creator's identity is their wallet: the reply address in the login memo, hashed, is the account key.
+
+## How a login works
+
+1. The site requests a challenge and shows a QR code on desktop or a tap to open wallet link on mobile. Both are a standard ZIP 321 `zcash:` URI carrying the one time code in the memo field.
+2. The visitor scans or taps with any shielded Zcash wallet such as Zashi, Ywallet, or Zingo, and sends the zero value memo.
+3. The Portal server, a Zcash light client watching mainnet through a public lightwalletd, sees the memo in the mempool within seconds and issues a session token.
+4. Afterward the visitor can save a receipt card or open the transaction in a block explorer, where the world sees nothing at all. No sender, no receiver, no amount, no memo. That is the point.
+
+## Architecture
+
+```
++----------+   1. GET /auth/challenge    +--------------+
+| Website  | --------------------------> |    Portal    |
+| (any app | <-------------------------- |    server    |
+| with SDK)|   challenge + zcash: URI QR |              |
++----------+                             |  zingo-cli   |
+     ^                                   |  sidecar     |
+     | 4. session JWT                    |  (light      |
+     |                                   |   client)    |
++----------+   2. zero value shielded    +------+-------+
+|  User's  |      memo with the code            | 3. detects memo
+|  wallet  | ---------- Zcash mainnet ----------+    via lightwalletd
++----------+           (zec.rocks)               (mempool, 0-conf)
+```
+
+- **server/** is the Node.js server: challenge issuance, memo watching, JWT sessions, creator accounts, gates, paylinks, and webhooks. No database, state persists as JSON on disk.
+- **sdk/** is a single dependency free JavaScript file: a `<script>` tag plus `Portal.login()` opens the QR modal and resolves with a session.
+- **demo/** is the website: landing page, live products, creator dashboard, pay pages, and documentation.
+- **docs/** holds the project spec and playbook.
+
+Full source for all of the above lives in the source repository linked above rather than duplicated into this folder.
+
+## Trust model, honestly
+
+Portal is built on real cryptography, and the parts that are not yet trustless are stated here rather than hidden.
+
+**Custody.** Creator receiving addresses are diversified addresses derived from the Portal instance's own wallet seed. They are unlinkable on chain, but the operator's keys can spend them, so today a creator trusts the operator to forward funds, the same way an early BTCPay style hot wallet works. The planned fix is Unified Full Viewing Keys: a creator hands Portal a viewing key for their own wallet, Portal can then see payments arrive but can never spend them, and money goes straight to the creator with no custody at all.
+
+**Identity.** Shielded Zcash has no protocol level sender field, so a creator's identity is the reply address they include in their login memo. Portal verifies that a real shielded transaction carried the claim, but not that the sender owns the claimed address. The planned fix is a reply handshake: Portal sends an encrypted memo containing a secret back to the claimed address, and only the true owner can read it and echo it back, because a shielded memo can only be decrypted by the address owner. That proves ownership without revealing anything on chain.
+
+**Availability.** One wallet process watches the chain for the whole instance. It is serialized and crash hardened, but a production deployment would run redundant watchers.
+
+These tradeoffs were the right ones for version one: they made a working, end to end product possible on mainnet. The fixes above are designed and documented, not vaporware, and they are the next things to build.
+
+## Roadmap
+
+- Reply handshake so a claimed address becomes a proven address
+- Viewing key based creator accounts, removing custody entirely
+- Pay from any chain and settle in ZEC through NEAR Intents
+- Automated test suite over the memo parser, challenge lifecycle, and webhook signing
+
+## Running it yourself
+
+Portal is two processes and no database. Build zingo-cli from [zingolib](https://github.com/zingolabs/zingolib), create a wallet, back up the seed phrase with `recovery_info`, then:
+
+```
+cd server && npm install
+PORTAL_ADDRESS=u1yourshieldedaddress npm start
+```
+
+The full walkthrough, every environment variable, and the HTTP API live in the documentation served at `/docs`. A live instance is running at [tryportal.xyz](https://tryportal.xyz), with docs at [tryportal.xyz/docs](https://tryportal.xyz/docs).
+
+## License
+
+MIT


### PR DESCRIPTION
## Portal — Zcash Login track

This is Portal, a new way to sign in, get paid, and pay someone else using nothing but a Zcash wallet.

You send a private, shielded transaction with a one time code in the memo. Portal sees it arrive on the Zcash mainnet and signs you in. No email, no password, and nobody, including the site you're signing into, learns who you are. The same flow lets you unlock paid content or send and receive money with a simple link. Everything runs on real Zcash mainnet, nothing simulated.

**Live site:** https://tryportal.xyz
**Demo video:** https://youtu.be/-fWFFc_u6j4?si=bzDL61TwNeV8caqo
**Source repository:** https://github.com/IamHarrie-Labs/portal
**Follow along:** https://x.com/trypayportal

The submission folder contains the full project writeup, including a step by step walkthrough for adding Portal to any site, the trust model stated honestly (what isn't trustless yet and the planned fixes), and self-hosting instructions.

### What's included in this PR
- `Hackathon/2026/Portal/README.md` — full project writeup and integration guide
- `Hackathon/2026/Portal/LICENSE` — MIT

Full source code lives in the linked repository rather than duplicated here.