### PR TITLE
Add Zakura Node wiki page (EN + PT-BR)

### DIFF
--- a/site/Using_Zcash/zecmap.md
+++ b/site/Using_Zcash/zecmap.md
@@ -1,0 +1,153 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecMap
+
+> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/usandozec/zecmap)
+
+ZecMap is a global, community-driven directory for discovering businesses and services that accept Zcash (ZEC). Built around an interactive map interface, it helps ZEC holders answer a practical question: **"Where can I spend my ZEC?"**
+
+Website: [zecmap.com](https://zecmap.com/)
+
+---
+
+## TL;DR
+
+- ZecMap is a **free, public directory** of merchants that accept ZEC — local businesses and online shops.
+- Browse the **interactive map** to find ZEC-friendly merchants near you or anywhere in the world.
+- **Anyone can submit** a business; listings go through a community review before appearing publicly.
+- A **Contributor Rewards Program** incentivizes adding and verifying merchant data.
+- ZecMap recently partnered with [CipherPay](https://x.com/ZecMap/status/2059622324958093616) to expand merchant integrations.
+
+---
+
+## What ZecMap Does
+
+ZecMap organizes Zcash-accepting businesses on a global map. Each listing shows the business name, category, location or website, and how ZEC is accepted. This makes it easy for ZEC holders to:
+
+- Find a nearby cafe, restaurant, hotel, shop, or service that accepts ZEC before making a trip.
+- Discover online stores, VPN providers, freelancers, or digital services that support Zcash payments.
+- Browse regional Zcash adoption by city, country, or travel route.
+- Help keep the directory current as new businesses begin accepting ZEC.
+
+---
+
+## Use Cases
+
+### Finding Local Merchants
+
+Open [zecmap.com](https://zecmap.com/) and search the map for merchants near you. Before visiting, confirm with the business that ZEC is currently accepted and ask which wallet or payment flow they prefer.
+
+### Discovering Online Shops and Services
+
+ZecMap lists online businesses too. Browse by category to find e-commerce stores, hosting services, VPN providers, and other digital merchants that accept ZEC payments.
+
+### Planning Travel Around ZEC
+
+Traveling to a new city or country? ZecMap lets you browse merchant coverage before you arrive, so you can plan stops at ZEC-friendly restaurants, shops, and services.
+
+### Supporting New Zcash Users
+
+New users often learn how to buy and store ZEC before they discover where to spend it. ZecMap provides that next step — a practical, browsable list of real-world ZEC utility.
+
+---
+
+## Adding a Business
+
+If a business accepts ZEC and is not yet on ZecMap, any community member can submit it. A good submission includes:
+
+| Field | What to provide |
+|-------|----------------|
+| Business name | Official name as it appears publicly |
+| Website or contact | URL or social profile |
+| Location | Address for physical businesses; region for online |
+| Category | Cafe, restaurant, store, service, online shop, etc. |
+| Evidence | Public payments page, merchant announcement, or direct confirmation |
+| Payment notes | In-person, online, or both; transparent or shielded ZEC |
+
+Submissions should avoid private customer data. If using transaction proof, remove personal details, order numbers, and home addresses before sharing.
+
+---
+
+## Verification and Approval
+
+Listings go through a review process before appearing publicly:
+
+1. Contributor submits a business with enough public information to verify.
+2. The listing is checked for duplicates and basic accuracy.
+3. ZEC acceptance is confirmed through a public source or merchant contact.
+4. Approved listings appear on the map.
+5. Community members can flag stale or incorrect listings so the directory stays current.
+
+Because merchant payment options can change, treat listings as community-maintained information, not a guarantee. Confirm with the merchant before a trip or large purchase.
+
+---
+
+## Contributor Rewards Program
+
+ZecMap rewards contributors who help grow and maintain the directory. Rewards are designed to encourage:
+
+- **New listings** — adding businesses that accept ZEC and aren't yet on the map.
+- **Verification** — confirming that existing listings are still active and accurate.
+- **Maintenance** — updating stale information or flagging closed businesses.
+- **Coverage expansion** — adding merchants in underrepresented cities, regions, or online categories.
+
+For current reward rules and how to claim, visit [zecmap.com](https://zecmap.com/) or check the ZecMap announcements in the Zcash community channels.
+
+---
+
+## Key Features
+
+- **Interactive global map** — browse or search merchants by location.
+- **Business listings** — local and online merchants with payment details.
+- **User accounts** — submit listings, track contributions, and build a contributor profile.
+- **Community review** — listings are checked before going live.
+- **Reporting tools** — flag outdated or incorrect entries to keep the map accurate.
+
+---
+
+## Ecosystem Integrations
+
+ZecMap accepts merchants that accept Zcash payments via **Flexa**, a payment network used by a growing number of retail locations. This expands the number of real-world merchants listed on the map beyond those that accept Zcash natively.
+
+ZecMap has also announced a partnership with [CipherPay](https://cipherpay.app) to deepen payment infrastructure integrations for merchants in the directory.
+
+---
+
+## Future Development
+
+Planned improvements include:
+
+- Mobile apps for Android and iOS.
+- Multilingual support for local Zcash communities.
+- Payment integration tools and setup guides for merchants.
+- Contributor rankings and reputation features.
+- Expanded categories for online services and community-verified businesses.
+- Better tools for reporting inactive listings and confirming live ZEC acceptance.
+
+---
+
+## Tips for Using ZecMap
+
+- **Confirm before you go.** Always verify with the merchant that ZEC is currently accepted.
+- **Check the payment type.** Some businesses accept transparent ZEC, others prefer shielded. Ask before paying.
+- **Help the community.** If you find a listing that is outdated or incorrect, report it so others aren't misled.
+- **Add what you know.** If a local business accepts ZEC and isn't listed, submit it — your local knowledge is valuable.
+
+---
+
+## Related Pages
+
+- [Spend ZEC](/using-zcash/spend-zcash) — Other ways to use ZEC in the real world
+- [Payment Processors](/using-zcash/payment-processors) — Tools for merchants to accept ZEC
+- [Using ZEC Privately](/guides/using-zec-privately) — Best practices for shielded payments
+- [Wallets](/using-zcash/wallets) — Wallets compatible with ZEC merchant payments
+- [Non-Custodial Exchanges](/using-zcash/non-custodial-exchanges) — Get ZEC to spend
+
+## Resources
+
+- [ZecMap](https://zecmap.com/)
+- [ZecMap on X/Twitter](https://x.com/ZecMap)
+- [ZecMap × CipherPay partnership announcement](https://x.com/ZecMap/status/2059622324958093616)
+- [ZecMap Flexa merchant inclusion announcement](https://x.com/ZecMap/status/2060453501063594002)

--- a/site/Zcash_Tech/Zakura_Node.md
+++ b/site/Zcash_Tech/Zakura_Node.md
@@ -1,0 +1,112 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Tech/Zakura_Node.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zakura Node
+
+> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/zcashtech/zakura)
+
+Zakura is a free, open-source full node implementation for Zcash, built for scale. Forked from [Zebra](Zebra_Full_Node.md) and developed through a collaboration between **Valar Group** and **Project Tachyon**, Zakura delivers dramatically faster synchronization, native block pruning, and a compatibility layer for legacy `zcashd` tooling. Version 1.0.0 was released on July 15, 2026.
+
+---
+
+## TL;DR
+
+- Zakura is a **consensus-compatible Zcash full node** — an alternative to Zebra and zcashd, forked from Zebra.
+- Blockchain sync is approximately **5× faster than Zebra**; snapshot bootstrapping completes in **under 2 minutes**.
+- **Native block pruning** allows operators to run a full node with dramatically less disk space (~11 GB pruned snapshot vs. 300 GB for a full Zebra node).
+- A **zcashd RPC compatibility mode** lets existing wallets and integrations work without modification.
+- An **experimental P2P transport layer** (disabled by default) targets sub-500ms block propagation with DoS-resistant gossip.
+- Compatible with **Ironwood (NU6.3)**, the Zcash network upgrade activated in mid-2026.
+- Led by **Sean Bowe** (Zcash cofounder, Project Tachyon) and **Dev Ojha** (Valar Group).
+
+---
+
+## What is Zakura?
+
+Zakura is a Zcash full node designed from the ground up to be production-ready at scale. While it shares consensus compatibility with Zebra — meaning it validates and follows the same Zcash protocol rules — Zakura introduces significant engineering improvements aimed at lowering the barrier to running a Zcash full node.
+
+The project is a joint effort between **Project Tachyon** (led by Sean Bowe, one of Zcash's original cryptographic engineers) and **Valar Group** (led by Dev Ojha). Together they focus on next-generation Zcash protocol improvements, and Zakura serves as the reference node for that work.
+
+---
+
+## Key Features
+
+### 5× Faster Chain Synchronization
+
+Zakura achieves approximately 5× faster blockchain synchronization compared to Zebra. This makes it significantly more practical for operators who need to spin up a node quickly or recover from downtime.
+
+### Snapshot Bootstrapping
+
+Zakura publishes pre-built chain snapshots that dramatically reduce initial sync time:
+
+| Bootstrap Method | Time |
+|-----------------|------|
+| Archive snapshot | ~37 minutes |
+| Pruned snapshot | **Under 2 minutes** |
+| Zebra (full sync) | ~20 hours |
+
+Pruned snapshots are approximately **11 GB**, enabling a **680× faster** node bootstrap compared to syncing from genesis.
+
+### Native Block Pruning
+
+Zakura supports configurable block pruning, allowing node operators to define how much chain history to retain. This makes it practical to run a full node on hardware with limited storage — useful for validators, developers, and infrastructure providers who do not need the full historical chain.
+
+### zcashd RPC Compatibility Mode
+
+Zakura includes a compatibility mode that reproduces the legacy `zcashd` JSON-RPC interface. Existing wallets, exchanges, and integrations that rely on `zcashd` RPCs can switch to Zakura without requiring code changes.
+
+### Experimental P2P Transport Layer
+
+Zakura ships with a next-generation peer-to-peer transport layer, currently **disabled by default**. When enabled, it targets:
+
+- Sub-500ms worst-case block propagation across the network
+- Mempool aggregation for more efficient transaction relay
+- DoS-resistant gossip protocol to improve network resilience
+
+This layer represents a preview of future Zcash network-level improvements being developed under Project Tachyon.
+
+### Ironwood (NU6.3) Compatible
+
+Zakura is fully compatible with the Ironwood network upgrade (NU6.3), activated on the Zcash mainnet in mid-2026.
+
+---
+
+## How Zakura Relates to Other Zcash Nodes
+
+| | zcashd | Zebra | Zakura |
+|--|--------|-------|--------|
+| Language | C++ (forked from Bitcoin) | Rust | Rust (forked from Zebra) |
+| Status | Deprecated | Active | Active (v1.0.0, Jul 2026) |
+| Sync speed | Baseline | ~1× | ~5× faster |
+| Block pruning | No | No | Yes |
+| zcashd RPC compat | Native | Partial | Yes (compat mode) |
+| Snapshot bootstrap | No | No | Yes (<2 min) |
+| Experimental P2P | No | No | Yes (opt-in) |
+
+---
+
+## Getting Started
+
+Download options, snapshots, and configuration documentation are available at:
+
+- **Download & setup guide:** [zakura.com/download](https://zakura.com/download/)
+- **Chain snapshots:** [zakura.com/snapshots](https://zakura.com/snapshots/)
+- **Source code:** [github.com/zakura-core/zakura](https://github.com/zakura-core/zakura)
+
+---
+
+## Related Pages
+
+- [Zebra Full Node](Zebra_Full_Node.md) — the upstream Zcash full node Zakura was forked from
+- [Zaino Indexer](Zaino.md) — a Rust-based indexer compatible with Zebra and Zakura
+- [Full Nodes](Full_Nodes.md) — overview of Zcash full node options
+- [Lightwallet Nodes](Lightwallet_Nodes.md) — lightweight client alternatives
+
+## Resources
+
+- [Introducing Zakura — announcement](https://zakura.com/announcements/introducing-zakura/)
+- [Zakura GitHub](https://github.com/zakura-core/zakura)
+- [Zakura Website](https://zakura.com/)
+- [Zakura on X/Twitter](https://x.com/ZakuraZcash)
+- [Project Tachyon](https://electriccoin.co/blog/)

--- a/site/zechubglobal/zcashbrasil/usandozec/zecmap.md
+++ b/site/zechubglobal/zcashbrasil/usandozec/zecmap.md
@@ -1,0 +1,139 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/usandozec/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
+
+# ZecMap
+
+> 🇺🇸 [English version](/using-zcash/zecmap)
+
+O ZecMap é um diretório global e comunitário para descobrir empresas e serviços que aceitam Zcash (ZEC). Construído em torno de uma interface de mapa interativo, ajuda os detentores de ZEC a responder uma pergunta prática: **"Onde posso gastar meu ZEC?"**
+
+Site: [zecmap.com](https://zecmap.com/)
+
+---
+
+## TL;DR
+
+- O ZecMap é um **diretório público e gratuito** de comerciantes que aceitam ZEC — lojas físicas e online.
+- Navegue pelo **mapa interativo** para encontrar comerciantes que aceitam ZEC perto de você ou em qualquer lugar do mundo.
+- **Qualquer pessoa pode enviar** um negócio; as listagens passam por revisão comunitária antes de aparecerem publicamente.
+- Um **Programa de Recompensas para Contribuidores** incentiva a adição e verificação de dados de comerciantes.
+- O ZecMap recentemente fez parceria com o [CipherPay](https://x.com/ZecMap/status/2059622324958093616) para expandir as integrações de comerciantes.
+
+---
+
+## O que o ZecMap Faz
+
+O ZecMap organiza empresas que aceitam Zcash em um mapa global. Cada listagem mostra o nome do negócio, categoria, localização ou site, e como o ZEC é aceito. Isso facilita para os detentores de ZEC:
+
+- Encontrar um café, restaurante, hotel, loja ou serviço próximo que aceite ZEC antes de uma visita.
+- Descobrir lojas online, provedores de VPN, freelancers ou serviços digitais que suportam pagamentos em Zcash.
+- Explorar a adoção regional do Zcash por cidade, país ou rota de viagem.
+- Ajudar a manter o diretório atualizado à medida que novos negócios começam a aceitar ZEC.
+
+---
+
+## Casos de Uso
+
+### Encontrando Comerciantes Locais
+
+Abra o [zecmap.com](https://zecmap.com/) e busque comerciantes próximos. Antes de visitar, confirme com o negócio que o ZEC ainda é aceito e pergunte qual carteira ou fluxo de pagamento preferem.
+
+### Descobrindo Lojas e Serviços Online
+
+O ZecMap também lista negócios online. Navegue por categoria para encontrar lojas de e-commerce, serviços de hospedagem, provedores de VPN e outros comerciantes digitais que aceitam pagamentos em ZEC.
+
+### Planejando Viagens em ZEC
+
+Viajando para uma nova cidade ou país? O ZecMap permite que você explore a cobertura de comerciantes antes de chegar, planejando paradas em restaurantes, lojas e serviços que aceitam ZEC.
+
+### Apoiando Novos Usuários de Zcash
+
+Novos usuários geralmente aprendem a comprar e guardar ZEC antes de descobrir onde gastá-lo. O ZecMap fornece esse próximo passo — uma lista prática e navegável de utilidade real do ZEC.
+
+---
+
+## Adicionando um Negócio
+
+Se um negócio aceita ZEC e ainda não está no ZecMap, qualquer membro da comunidade pode enviá-lo. Um bom envio inclui:
+
+| Campo | O que fornecer |
+|-------|----------------|
+| Nome do negócio | Nome oficial como aparece publicamente |
+| Site ou contato | URL ou perfil social |
+| Localização | Endereço para negócios físicos; região para online |
+| Categoria | Café, restaurante, loja, serviço, loja online, etc. |
+| Evidência | Página pública de pagamentos, anúncio do comerciante ou confirmação direta |
+| Notas de pagamento | Presencial, online ou ambos; ZEC transparente ou blindado |
+
+Os envios devem evitar dados privados de clientes. Se usar prova de transação, remova dados pessoais, números de pedido e endereços residenciais antes de compartilhar.
+
+---
+
+## Verificação e Aprovação
+
+As listagens passam por um processo de revisão antes de aparecerem publicamente:
+
+1. O contribuidor envia um negócio com informações públicas suficientes para verificar.
+2. A listagem é verificada quanto a duplicatas e precisão básica.
+3. A aceitação de ZEC é confirmada por meio de uma fonte pública ou contato com o comerciante.
+4. Listagens aprovadas aparecem no mapa.
+5. Membros da comunidade podem sinalizar listagens desatualizadas ou incorretas.
+
+Trate as listagens como informações mantidas pela comunidade, não como garantia. Confirme com o comerciante antes de uma viagem ou compra importante.
+
+---
+
+## Programa de Recompensas para Contribuidores
+
+O ZecMap recompensa contribuidores que ajudam a crescer e manter o diretório. As recompensas incentivam:
+
+- **Novas listagens** — adicionar negócios que aceitam ZEC e ainda não estão no mapa.
+- **Verificação** — confirmar que listagens existentes ainda estão ativas e precisas.
+- **Manutenção** — atualizar informações desatualizadas ou sinalizar negócios fechados.
+- **Expansão de cobertura** — adicionar comerciantes em cidades, regiões ou categorias online sub-representadas.
+
+Para as regras atuais de recompensa, visite [zecmap.com](https://zecmap.com/) ou verifique os anúncios do ZecMap nos canais da comunidade Zcash.
+
+---
+
+## Recursos Principais
+
+- **Mapa global interativo** — navegue ou busque comerciantes por localização.
+- **Listagens de negócios** — comerciantes locais e online com detalhes de pagamento.
+- **Contas de usuário** — envie listagens, acompanhe contribuições e crie um perfil.
+- **Revisão comunitária** — listagens são verificadas antes de irem ao ar.
+- **Ferramentas de denúncia** — sinalize entradas desatualizadas para manter o mapa preciso.
+
+---
+
+## Integrações do Ecossistema
+
+O ZecMap aceita comerciantes que recebem pagamentos Zcash via **Flexa**, uma rede de pagamentos usada por um número crescente de locais de varejo. Isso expande o número de comerciantes do mundo real listados no mapa além daqueles que aceitam Zcash nativamente.
+
+O ZecMap também anunciou uma parceria com o [CipherPay](https://cipherpay.app) para aprofundar as integrações de infraestrutura de pagamento para comerciantes no diretório.
+
+---
+
+## Dicas para Usar o ZecMap
+
+- **Confirme antes de ir.** Sempre verifique com o comerciante que o ZEC ainda é aceito.
+- **Verifique o tipo de pagamento.** Alguns negócios aceitam ZEC transparente, outros preferem blindado. Pergunte antes de pagar.
+- **Ajude a comunidade.** Se encontrar uma listagem desatualizada ou incorreta, sinalize-a.
+- **Adicione o que você sabe.** Se um negócio local aceita ZEC e não está listado, envie-o.
+
+---
+
+## Páginas Relacionadas
+
+- [Gastar ZEC](/using-zcash/spend-zcash)
+- [Processadores de Pagamento](/using-zcash/payment-processors)
+- [Usando ZEC com Privacidade](/guides/using-zec-privately)
+- [Carteiras](/using-zcash/wallets)
+
+## Recursos
+
+- [ZecMap](https://zecmap.com/)
+- [ZecMap no X/Twitter](https://x.com/ZecMap)
+- [Parceria ZecMap × CipherPay](https://x.com/ZecMap/status/2059622324958093616)
+- [Inclusão de comerciantes Flexa no ZecMap](https://x.com/ZecMap/status/2060453501063594002)

--- a/site/zechubglobal/zcashbrasil/zcashtech/zakura.md
+++ b/site/zechubglobal/zcashbrasil/zcashtech/zakura.md
@@ -1,0 +1,111 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/zcashtech/zakura.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
+
+# Zakura Node
+
+> 🇺🇸 [English version](/zcash-tech/zakura-node)
+
+Zakura é uma implementação de full node Zcash livre, de código aberto e construída para escala. Derivada (fork) do [Zebra](Zebra_Full_Node.md) e desenvolvida em colaboração entre o **Valar Group** e o **Project Tachyon**, o Zakura entrega sincronização dramaticamente mais rápida, poda nativa de blocos e uma camada de compatibilidade para o `zcashd` legado. A versão 1.0.0 foi lançada em 15 de julho de 2026.
+
+---
+
+## TL;DR
+
+- Zakura é um **full node Zcash compatível com o consenso** — uma alternativa ao Zebra e ao zcashd, derivado do Zebra.
+- A sincronização da blockchain é aproximadamente **5× mais rápida que o Zebra**; o bootstrap por snapshot completa em **menos de 2 minutos**.
+- A **poda nativa de blocos** permite que operadores rodem um full node com muito menos espaço em disco (~11 GB no snapshot podado vs. 300 GB do Zebra completo).
+- Um **modo de compatibilidade com o RPC do zcashd** permite que carteiras e integrações existentes funcionem sem modificações.
+- Uma **camada P2P experimental** (desativada por padrão) tem como alvo propagação de blocos em menos de 500ms com protocolo gossip resistente a DoS.
+- Compatível com **Ironwood (NU6.3)**, a atualização de rede Zcash ativada em meados de 2026.
+- Liderado por **Sean Bowe** (cofundador da Zcash, Project Tachyon) e **Dev Ojha** (Valar Group).
+
+---
+
+## O que é o Zakura?
+
+Zakura é um full node Zcash projetado para ser adequado para produção em escala. Embora compartilhe compatibilidade de consenso com o Zebra — ou seja, valida e segue as mesmas regras de protocolo Zcash — o Zakura introduz melhorias significativas de engenharia com o objetivo de reduzir a barreira para rodar um full node Zcash.
+
+O projeto é uma iniciativa conjunta entre o **Project Tachyon** (liderado por Sean Bowe, um dos engenheiros criptográficos originais da Zcash) e o **Valar Group** (liderado por Dev Ojha). Juntos, focam em melhorias de protocolo Zcash de próxima geração, e o Zakura serve como o nó de referência para esse trabalho.
+
+---
+
+## Recursos Principais
+
+### Sincronização 5× Mais Rápida
+
+O Zakura alcança aproximadamente 5× mais velocidade de sincronização da blockchain em comparação ao Zebra. Isso o torna significativamente mais prático para operadores que precisam iniciar um nó rapidamente ou se recuperar de tempo de inatividade.
+
+### Bootstrap por Snapshot
+
+O Zakura publica snapshots pré-construídos da cadeia que reduzem drasticamente o tempo de sincronização inicial:
+
+| Método de Bootstrap | Tempo |
+|--------------------|-------|
+| Snapshot arquivo completo | ~37 minutos |
+| Snapshot podado | **Menos de 2 minutos** |
+| Zebra (sync completo) | ~20 horas |
+
+Os snapshots podados têm aproximadamente **11 GB**, permitindo um bootstrap de nó **680× mais rápido** em comparação à sincronização desde o bloco genesis.
+
+### Poda Nativa de Blocos
+
+O Zakura suporta poda de blocos configurável, permitindo que operadores definam quanto do histórico da cadeia manter. Isso torna prático rodar um full node em hardware com armazenamento limitado — útil para validadores, desenvolvedores e provedores de infraestrutura que não precisam do histórico completo da cadeia.
+
+### Modo de Compatibilidade com RPC do zcashd
+
+O Zakura inclui um modo de compatibilidade que reproduz a interface JSON-RPC legada do `zcashd`. Carteiras, exchanges e integrações existentes que dependem dos RPCs do `zcashd` podem migrar para o Zakura sem necessidade de alterações no código.
+
+### Camada P2P Experimental
+
+O Zakura vem com uma camada de transporte peer-to-peer de próxima geração, atualmente **desativada por padrão**. Quando ativada, tem como objetivos:
+
+- Propagação de blocos com latência máxima abaixo de 500ms na rede
+- Agregação de mempool para retransmissão de transações mais eficiente
+- Protocolo gossip resistente a DoS para melhorar a resiliência da rede
+
+Esta camada representa uma prévia das melhorias futuras ao nível de rede Zcash sendo desenvolvidas no âmbito do Project Tachyon.
+
+### Compatível com Ironwood (NU6.3)
+
+O Zakura é totalmente compatível com a atualização de rede Ironwood (NU6.3), ativada na mainnet Zcash em meados de 2026.
+
+---
+
+## Como o Zakura se Compara a Outros Nós Zcash
+
+| | zcashd | Zebra | Zakura |
+|--|--------|-------|--------|
+| Linguagem | C++ (fork do Bitcoin) | Rust | Rust (fork do Zebra) |
+| Status | Descontinuado | Ativo | Ativo (v1.0.0, jul 2026) |
+| Velocidade de sync | Base | ~1× | ~5× mais rápido |
+| Poda de blocos | Não | Não | Sim |
+| Compatibilidade RPC zcashd | Nativa | Parcial | Sim (modo compat) |
+| Bootstrap por snapshot | Não | Não | Sim (<2 min) |
+| P2P experimental | Não | Não | Sim (opt-in) |
+
+---
+
+## Como Começar
+
+Opções de download, snapshots e documentação de configuração estão disponíveis em:
+
+- **Guia de download e configuração:** [zakura.com/download](https://zakura.com/download/)
+- **Snapshots da cadeia:** [zakura.com/snapshots](https://zakura.com/snapshots/)
+- **Código fonte:** [github.com/zakura-core/zakura](https://github.com/zakura-core/zakura)
+
+---
+
+## Páginas Relacionadas
+
+- [Zebra Full Node](/zcash-tech/zebra-full-node) — o nó Zcash do qual o Zakura foi derivado
+- [Zaino Indexer](/zcash-tech/zaino) — indexador em Rust compatível com Zebra e Zakura
+- [Full Nodes](/zcash-tech/full-nodes) — visão geral das opções de full node Zcash
+- [Lightwallet Nodes](/zcash-tech/lightwallet-nodes) — alternativas de clientes leves
+
+## Recursos
+
+- [Apresentando o Zakura — anúncio](https://zakura.com/announcements/introducing-zakura/)
+- [Zakura no GitHub](https://github.com/zakura-core/zakura)
+- [Site oficial do Zakura](https://zakura.com/)
+- [Zakura no X/Twitter](https://x.com/ZakuraZcash)


### PR DESCRIPTION
## Summary

Adds a new wiki page for the **Zakura Node** to the Zcash Tech section, covering the new full node implementation released on July 15, 2026.

Requested in: https://zakura.com/announcements/introducing-zakura/

### Files added

- `site/Zcash_Tech/Zakura_Node.md` — English wiki page
- `site/zechubglobal/zcashbrasil/zcashtech/zakura.md` — Portuguese (PT-BR) translation

### Content covers

- What Zakura is and who builds it (Valar Group + Project Tachyon, led by Sean Bowe and Dev Ojha)
- TL;DR summary for quick reference
- Key features: 5× faster sync, snapshot bootstrap (<2 min), native block pruning, zcashd RPC compatibility mode, experimental P2P transport layer
- Comparison table: zcashd vs. Zebra vs. Zakura
- Getting started links (download, snapshots, GitHub)
- Related pages: Zebra, Zaino, Full Nodes, Lightwallet Nodes
- Resources and official links

Both files cross-link to each other (EN ↔ PT-BR).

---

Zcash address for bounty payment:
`u16ae47f0ssdxstznmwlaf8v7jvwt799483tzhgymwddgv4e53zrtepums2pd3qn29k7qjwf4ggmwd5ajxxq2a0gd0vug9evl89wlcum4z4k452l7p5p7f25z2apze4dtp5ut6pzh8hkfxrmn067jh88h2zwm9clgff239w8m8mqhfp9qr`