### PR TITLE
Add ZECD wiki page (EN + PT-BR)

### DIFF
--- a/site/Using_Zcash/zecmap.md
+++ b/site/Using_Zcash/zecmap.md
@@ -1,0 +1,153 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZecMap
+
+> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/usandozec/zecmap)
+
+ZecMap is a global, community-driven directory for discovering businesses and services that accept Zcash (ZEC). Built around an interactive map interface, it helps ZEC holders answer a practical question: **"Where can I spend my ZEC?"**
+
+Website: [zecmap.com](https://zecmap.com/)
+
+---
+
+## TL;DR
+
+- ZecMap is a **free, public directory** of merchants that accept ZEC — local businesses and online shops.
+- Browse the **interactive map** to find ZEC-friendly merchants near you or anywhere in the world.
+- **Anyone can submit** a business; listings go through a community review before appearing publicly.
+- A **Contributor Rewards Program** incentivizes adding and verifying merchant data.
+- ZecMap recently partnered with [CipherPay](https://x.com/ZecMap/status/2059622324958093616) to expand merchant integrations.
+
+---
+
+## What ZecMap Does
+
+ZecMap organizes Zcash-accepting businesses on a global map. Each listing shows the business name, category, location or website, and how ZEC is accepted. This makes it easy for ZEC holders to:
+
+- Find a nearby cafe, restaurant, hotel, shop, or service that accepts ZEC before making a trip.
+- Discover online stores, VPN providers, freelancers, or digital services that support Zcash payments.
+- Browse regional Zcash adoption by city, country, or travel route.
+- Help keep the directory current as new businesses begin accepting ZEC.
+
+---
+
+## Use Cases
+
+### Finding Local Merchants
+
+Open [zecmap.com](https://zecmap.com/) and search the map for merchants near you. Before visiting, confirm with the business that ZEC is currently accepted and ask which wallet or payment flow they prefer.
+
+### Discovering Online Shops and Services
+
+ZecMap lists online businesses too. Browse by category to find e-commerce stores, hosting services, VPN providers, and other digital merchants that accept ZEC payments.
+
+### Planning Travel Around ZEC
+
+Traveling to a new city or country? ZecMap lets you browse merchant coverage before you arrive, so you can plan stops at ZEC-friendly restaurants, shops, and services.
+
+### Supporting New Zcash Users
+
+New users often learn how to buy and store ZEC before they discover where to spend it. ZecMap provides that next step — a practical, browsable list of real-world ZEC utility.
+
+---
+
+## Adding a Business
+
+If a business accepts ZEC and is not yet on ZecMap, any community member can submit it. A good submission includes:
+
+| Field | What to provide |
+|-------|----------------|
+| Business name | Official name as it appears publicly |
+| Website or contact | URL or social profile |
+| Location | Address for physical businesses; region for online |
+| Category | Cafe, restaurant, store, service, online shop, etc. |
+| Evidence | Public payments page, merchant announcement, or direct confirmation |
+| Payment notes | In-person, online, or both; transparent or shielded ZEC |
+
+Submissions should avoid private customer data. If using transaction proof, remove personal details, order numbers, and home addresses before sharing.
+
+---
+
+## Verification and Approval
+
+Listings go through a review process before appearing publicly:
+
+1. Contributor submits a business with enough public information to verify.
+2. The listing is checked for duplicates and basic accuracy.
+3. ZEC acceptance is confirmed through a public source or merchant contact.
+4. Approved listings appear on the map.
+5. Community members can flag stale or incorrect listings so the directory stays current.
+
+Because merchant payment options can change, treat listings as community-maintained information, not a guarantee. Confirm with the merchant before a trip or large purchase.
+
+---
+
+## Contributor Rewards Program
+
+ZecMap rewards contributors who help grow and maintain the directory. Rewards are designed to encourage:
+
+- **New listings** — adding businesses that accept ZEC and aren't yet on the map.
+- **Verification** — confirming that existing listings are still active and accurate.
+- **Maintenance** — updating stale information or flagging closed businesses.
+- **Coverage expansion** — adding merchants in underrepresented cities, regions, or online categories.
+
+For current reward rules and how to claim, visit [zecmap.com](https://zecmap.com/) or check the ZecMap announcements in the Zcash community channels.
+
+---
+
+## Key Features
+
+- **Interactive global map** — browse or search merchants by location.
+- **Business listings** — local and online merchants with payment details.
+- **User accounts** — submit listings, track contributions, and build a contributor profile.
+- **Community review** — listings are checked before going live.
+- **Reporting tools** — flag outdated or incorrect entries to keep the map accurate.
+
+---
+
+## Ecosystem Integrations
+
+ZecMap accepts merchants that accept Zcash payments via **Flexa**, a payment network used by a growing number of retail locations. This expands the number of real-world merchants listed on the map beyond those that accept Zcash natively.
+
+ZecMap has also announced a partnership with [CipherPay](https://cipherpay.app) to deepen payment infrastructure integrations for merchants in the directory.
+
+---
+
+## Future Development
+
+Planned improvements include:
+
+- Mobile apps for Android and iOS.
+- Multilingual support for local Zcash communities.
+- Payment integration tools and setup guides for merchants.
+- Contributor rankings and reputation features.
+- Expanded categories for online services and community-verified businesses.
+- Better tools for reporting inactive listings and confirming live ZEC acceptance.
+
+---
+
+## Tips for Using ZecMap
+
+- **Confirm before you go.** Always verify with the merchant that ZEC is currently accepted.
+- **Check the payment type.** Some businesses accept transparent ZEC, others prefer shielded. Ask before paying.
+- **Help the community.** If you find a listing that is outdated or incorrect, report it so others aren't misled.
+- **Add what you know.** If a local business accepts ZEC and isn't listed, submit it — your local knowledge is valuable.
+
+---
+
+## Related Pages
+
+- [Spend ZEC](/using-zcash/spend-zcash) — Other ways to use ZEC in the real world
+- [Payment Processors](/using-zcash/payment-processors) — Tools for merchants to accept ZEC
+- [Using ZEC Privately](/guides/using-zec-privately) — Best practices for shielded payments
+- [Wallets](/using-zcash/wallets) — Wallets compatible with ZEC merchant payments
+- [Non-Custodial Exchanges](/using-zcash/non-custodial-exchanges) — Get ZEC to spend
+
+## Resources
+
+- [ZecMap](https://zecmap.com/)
+- [ZecMap on X/Twitter](https://x.com/ZecMap)
+- [ZecMap × CipherPay partnership announcement](https://x.com/ZecMap/status/2059622324958093616)
+- [ZecMap Flexa merchant inclusion announcement](https://x.com/ZecMap/status/2060453501063594002)

--- a/site/Zcash_Tech/ZECD.md
+++ b/site/Zcash_Tech/ZECD.md
@@ -1,0 +1,192 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Tech/ZECD.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# ZECD — Shielded-First Wallet Server
+
+> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/zcashtech/zecd)
+
+ZECD is a shielded-first wallet server for Zcash, built on [librustzcash](https://github.com/zcash/librustzcash) and exposed through Bitcoin Core's JSON-RPC dialect. It gives developers and payment integrators a familiar, Bitcoin-compatible API for interacting with Zcash — while making Orchard (the most private pool) the default. Developed by [zec.rocks](https://zec.rocks), ZECD is designed to replace `zcashd`'s wallet functionality in modern, cloud-native deployments.
+
+---
+
+## TL;DR
+
+- ZECD is a **wallet daemon (server)** — not a full node. It handles keys, scanning, proving, and RPC without speaking the Zcash P2P protocol.
+- It speaks **Bitcoin Core's JSON-RPC dialect**: same method names, field shapes, auth, and error codes — many Bitcoin RPC clients work with Zcash out of the box.
+- **Orchard (shielded) addresses are the default**; transparent (t-address) and Sapling support require explicit opt-in per wallet.
+- It connects to a **self-hosted [Zebra](Zebra_Full_Node.md) full node** via local JSON-RPC — no lightwalletd needed.
+- **Stateless by design**: the entire wallet is recoverable from the seed phrase alone, making the data directory disposable.
+- **Not a drop-in for zcashd**: implements only a subset of Zcash RPC methods, with intentional design differences for privacy and safety.
+- Fees follow **ZIP-317** (deterministic fee calculation); user-specified fees are rejected.
+
+---
+
+## What Problem Does ZECD Solve?
+
+`zcashd` was Zcash's original node and wallet combined — forked from Bitcoin's C++ codebase in 2016. Over time, this created friction: the code is difficult to maintain, the wallet is tightly coupled to the node, and transparent addresses are presented as first-class options alongside shielded ones.
+
+ZECD separates wallet responsibility from consensus. It is a **dedicated wallet layer** that sits between applications and a Zebra full node, providing:
+
+- A clean, modern Rust implementation built on librustzcash (the same library powering Zashi and Zodl)
+- Privacy-by-default design (Orchard addresses unless otherwise configured)
+- A Bitcoin-compatible RPC interface that removes the need to learn Zcash-specific tooling
+- Stateless, seed-recoverable architecture suited to containerized and cloud deployments
+
+---
+
+## Architecture
+
+ZECD operates in a three-tier model:
+
+```
+Your app / Bitcoin RPC client
+        ↓  JSON-RPC
+       ZECD
+   (keys, scanning, proving, RPC)
+        ↓  JSON-RPC (local only)
+       Zebra
+   (full node — consensus, mempool, chain data)
+```
+
+ZECD communicates with Zebra **exclusively through local JSON-RPC** — no peer-to-peer networking, no third-party indexers, no lightwalletd. The Zebra connection is deliberately local-only: ZECD will refuse to send credentials to a globally-routable host unless explicitly configured for an out-of-band secured tunnel (e.g. WireGuard or SSH).
+
+---
+
+## Key Features
+
+### Shielded-First, Orchard by Default
+
+ZECD uses Orchard Unified Addresses as the default address type. Sapling and transparent (t-address) pools require explicit configuration per wallet. This design reduces the risk of accidental transparent sends — a common privacy pitfall in older Zcash tooling.
+
+Privacy policy is configurable:
+
+| Policy | Behavior |
+|--------|----------|
+| `AllowRevealedRecipients` (default) | Permits sends to transparent recipients |
+| `FullPrivacy` | Only single shielded-pool sends; no transparent recipients, no cross-pool |
+| `AllowFullyTransparent` | Also permits t→t sends funded from transparent UTXOs |
+
+### Bitcoin Core RPC Compatibility
+
+ZECD implements Bitcoin Core's JSON-RPC dialect with conformance across:
+
+- Method names (e.g. `getblockchaininfo`, `getbalance`, `getnewaddress`, `listtransactions`)
+- Field names and types in responses
+- JSON-RPC 1.0 envelope structure
+- Basic auth and cookie file authentication
+- Error codes and HTTP status mapping
+
+This means many existing Bitcoin payment libraries, exchange integrations, and monitoring tools can interact with Zcash via ZECD with little or no code changes.
+
+> **Note:** ZECD is intentionally **not** backwards-compatible with `zcashd`. It implements only a subset of the `z_*` methods, and label-related methods (`setlabel`, `listlabels`, etc.) are not implemented by design (see *Stateless by Design* below).
+
+### Stateless by Design
+
+ZECD persists **no off-chain state that a seed-only restore couldn't rebuild**. The wallet database (`data.sqlite`) is entirely derivable from the seed phrase — shielded funds are recovered unconditionally; transparent funds are recovered up to the configured gap limit.
+
+To restore a wallet from seed:
+
+```sh
+zecd init --restore --birthday <block-height>
+```
+
+This makes the data directory **disposable**: a container with no persistent volume, rebuilt from the seed on each start, loses nothing critical. Operators are responsible for tracking addresses they hand out — ZECD only remembers addresses once they have received funds on-chain.
+
+Labels are intentionally absent. Because labels have no on-chain source and cannot be reconstructed from seed, ZECD simply does not support them. Calling label methods returns a `method-not-found` error (`-32601`).
+
+### No lightwalletd Dependency
+
+ZECD derives compact blocks, tree state, and mempool visibility directly from Zebra's JSON-RPC. There is no lightwalletd to operate or maintain — reducing operational complexity for self-hosted deployments.
+
+### Cloud-Native and Containerized Deployments
+
+ZECD's stateless architecture is designed for Docker and Kubernetes environments:
+
+- Full Docker Compose stack (`zebra → zecd`) available in the repository
+- Health endpoint on port `9233` with configurable readiness probes (`synced` or `alive`)
+- Structured JSON logging option for log aggregation pipelines
+- ZIP-317 deterministic fees — no fee oracle or manual fee configuration
+
+### Seed Compatibility with Other librustzcash Wallets
+
+ZECD is compatible with other librustzcash-powered wallets, including [Zodl](https://github.com/zodl-inc/zodl-ios) (iOS/Android). If something goes wrong with a ZECD deployment, the seed phrase can be entered into any other librustzcash wallet to access funds. The reverse migration (from `zcashd`) is supported only by sending on-chain to a new ZECD address.
+
+---
+
+## Quick Start
+
+ZECD is not yet published on crates.io; build from source or use the Docker stack.
+
+**Prerequisites:** a locally running Zebra full node with `rpc.listen_addr = 127.0.0.1:18234` (testnet).
+
+```sh
+# 1. Initialize a testnet wallet (generates a 24-word mnemonic and an account)
+cargo run --release -- --datadir ./data --testnet \
+    init --wallet default --account-name primary
+
+# 2. Start the daemon (syncs in background, serves JSON-RPC on port 18232)
+cargo run --release -- --datadir ./data --testnet \
+    --rpcuser zec --rpcpassword secret --rpcbind 127.0.0.1 --rpcport 18232
+```
+
+**Interact via curl:**
+
+```sh
+curl -s --user zec:secret --data-binary \
+  '{"jsonrpc":"1.0","id":"1","method":"getblockchaininfo","params":[]}' \
+  -H 'content-type: text/plain;' http://127.0.0.1:18232/
+```
+
+**Interact via Python (using a Bitcoin RPC library):**
+
+```python
+from bitcoinrpc.authproxy import AuthServiceProxy
+rpc = AuthServiceProxy("http://zec:secret@127.0.0.1:18232")
+print(rpc.getblockchaininfo())
+addr = rpc.getnewaddress("invoice-1")  # returns a u1... Orchard Unified Address
+print(rpc.getbalance())
+print(rpc.listtransactions("*", 20))
+```
+
+---
+
+## Default Ports
+
+| Network | ZECD RPC | Zebra RPC (backend) | Health |
+|---------|----------|---------------------|--------|
+| Mainnet | 8232 | 8234 | 9233 |
+| Testnet | 18232 | 18234 | 9233 |
+
+---
+
+## ZECD vs. zcashd vs. Zaino
+
+| | zcashd | Zaino | ZECD |
+|--|--------|-------|------|
+| Role | Full node + wallet | Indexer (replaces lightwalletd) | Wallet server only |
+| Language | C++ | Rust | Rust |
+| Status | Deprecated | Active | Active |
+| Default pool | Transparent | N/A | Orchard (shielded) |
+| RPC dialect | zcashd-specific | gRPC (lightwalletd) | Bitcoin Core JSON-RPC |
+| Requires full node | Yes (self) | Zebra or zcashd | Zebra |
+| Stateless recovery | No | N/A | Yes (seed-only) |
+| Cloud-native | No | Partial | Yes |
+
+---
+
+## Related Pages
+
+- [Zebra Full Node](Zebra_Full_Node.md) — the full node ZECD connects to
+- [Zaino Indexer](Zaino.md) — alternative indexer approach (replaces lightwalletd)
+- [Zakura Node](Zakura_Node.md) — another full node implementation (fork of Zebra)
+- [Viewing Keys](Viewing_Keys.md) — how ZECD scans the chain using account viewing keys
+- [Wallets](/using-zcash/wallets) — wallet ecosystem overview
+
+## Resources
+
+- [ZECD GitHub (zecrocks/zecd)](https://github.com/zecrocks/zecd)
+- [zec.rocks](https://zec.rocks)
+- [librustzcash — core Zcash cryptography library](https://github.com/zcash/librustzcash)
+- [Zodl wallet (librustzcash-compatible)](https://github.com/zodl-inc/zodl-ios)
+- [ZIP-317: Proportional Transfer Fee Mechanism](https://zips.z.cash/zip-0317)

--- a/site/Zcash_Tech/ZECD.md
+++ b/site/Zcash_Tech/ZECD.md
@@ -8,6 +8,8 @@
 
 ZECD is a shielded-first wallet server for Zcash, built on [librustzcash](https://github.com/zcash/librustzcash) and exposed through Bitcoin Core's JSON-RPC dialect. It gives developers and payment integrators a familiar, Bitcoin-compatible API for interacting with Zcash — while making Orchard (the most private pool) the default. Developed by [zec.rocks](https://zec.rocks), ZECD is designed to replace `zcashd`'s wallet functionality in modern, cloud-native deployments.
 
+**Current version:** 0.5.0-rc3 (July 13, 2026) — with Ironwood (NU6.3) support. Install via `cargo install zecd` or use the official Docker image.
+
 ---
 
 ## TL;DR
@@ -19,6 +21,7 @@ ZECD is a shielded-first wallet server for Zcash, built on [librustzcash](https:
 - **Stateless by design**: the entire wallet is recoverable from the seed phrase alone, making the data directory disposable.
 - **Not a drop-in for zcashd**: implements only a subset of Zcash RPC methods, with intentional design differences for privacy and safety.
 - Fees follow **ZIP-317** (deterministic fee calculation); user-specified fees are rejected.
+- Supports **shielded memos (ZIP-302)** through the familiar Bitcoin RPC surface.
 
 ---
 
@@ -59,27 +62,38 @@ ZECD communicates with Zebra **exclusively through local JSON-RPC** — no peer-
 
 ZECD uses Orchard Unified Addresses as the default address type. Sapling and transparent (t-address) pools require explicit configuration per wallet. This design reduces the risk of accidental transparent sends — a common privacy pitfall in older Zcash tooling.
 
-Privacy policy is configurable:
+Privacy policy is configurable per call or globally in `[spend] privacy_policy`:
 
 | Policy | Behavior |
 |--------|----------|
-| `AllowRevealedRecipients` (default) | Permits sends to transparent recipients |
-| `FullPrivacy` | Only single shielded-pool sends; no transparent recipients, no cross-pool |
+| `AllowRevealedRecipients` (default) | Permits sends to transparent recipients; reveals amount and recipient on-chain |
+| `AllowRevealedAmounts` | Permits cross-pool sends (Sapling↔Orchard) but rejects transparent recipients |
+| `FullPrivacy` | Only fully-shielded sends within one pool; rejects transparent recipients and cross-pool |
 | `AllowFullyTransparent` | Also permits t→t sends funded from transparent UTXOs |
 
 ### Bitcoin Core RPC Compatibility
 
 ZECD implements Bitcoin Core's JSON-RPC dialect with conformance across:
 
-- Method names (e.g. `getblockchaininfo`, `getbalance`, `getnewaddress`, `listtransactions`)
+- Method names (e.g. `getblockchaininfo`, `getbalance`, `getnewaddress`, `listtransactions`, `sendtoaddress`, `sendmany`)
 - Field names and types in responses
 - JSON-RPC 1.0 envelope structure
-- Basic auth and cookie file authentication
-- Error codes and HTTP status mapping
+- Basic auth, `rpcauth` entries, and cookie file authentication
+- Error codes and HTTP status mapping (HTTP 500 with error body, 401 semantics)
 
 This means many existing Bitcoin payment libraries, exchange integrations, and monitoring tools can interact with Zcash via ZECD with little or no code changes.
 
-> **Note:** ZECD is intentionally **not** backwards-compatible with `zcashd`. It implements only a subset of the `z_*` methods, and label-related methods (`setlabel`, `listlabels`, etc.) are not implemented by design (see *Stateless by Design* below).
+The conformance suite (140+ checks) runs on every PR against a live regtest daemon and was also validated against the public testnet.
+
+### Shielded Memos (ZIP-302)
+
+ZECD exposes Zcash's shielded memo feature through the familiar Bitcoin RPC surface — something unavailable in standard Bitcoin tooling:
+
+- `sendtoaddress` accepts an optional hex memo as an extra trailing parameter (up to 512 bytes; rejected for transparent recipients)
+- Transaction history entries from `listtransactions` and `gettransaction` include `memo` (hex) and `memoStr` (decoded text) fields when an output carries one
+- Zero-amount sends to a shielded recipient are supported for memo-only use cases (the `z_sendmany` "memo-only-send" pattern)
+
+This makes ZECD suitable for applications that need private, on-chain messaging alongside payments.
 
 ### Stateless by Design
 
@@ -104,29 +118,126 @@ ZECD derives compact blocks, tree state, and mempool visibility directly from Ze
 ZECD's stateless architecture is designed for Docker and Kubernetes environments:
 
 - Full Docker Compose stack (`zebra → zecd`) available in the repository
-- Health endpoint on port `9233` with configurable readiness probes (`synced` or `alive`)
+- Health endpoint on port `9233` with configurable readiness probes (`synced` or `connected`)
 - Structured JSON logging option for log aggregation pipelines
 - ZIP-317 deterministic fees — no fee oracle or manual fee configuration
+- `bootstrap_from_keys` (default on): an empty data directory next to `keys.toml` auto-rebuilds the wallet at startup — deploy by mounting one Secret and starting with an empty PVC
 
-### Seed Compatibility with Other librustzcash Wallets
+---
 
-ZECD is compatible with other librustzcash-powered wallets, including [Zodl](https://github.com/zodl-inc/zodl-ios) (iOS/Android). If something goes wrong with a ZECD deployment, the seed phrase can be entered into any other librustzcash wallet to access funds. The reverse migration (from `zcashd`) is supported only by sending on-chain to a new ZECD address.
+## Custody Models
+
+ZECD supports three key-custody models, suited for different deployment and security requirements:
+
+### 1. Unencrypted (Default — Auto-Unlock)
+
+The seed mnemonic in `keys.toml` is wrapped to an **age identity file** (`identity.txt`). With the default `auto_unlock = true`, the seed is decrypted into memory at startup so sends are unattended and no `walletpassphrase` call is needed.
+
+Best for: automated payment processors, exchange hot wallets, developer environments.
+
+```sh
+zecd init --datadir ./data --wallet default --account-name primary
+```
+
+> Store `identity.txt` **outside** the data directory on mainnet — anyone who reads both files has spend authority.
+
+### 2. Encrypted (Passphrase-Protected)
+
+The mnemonic is wrapped with a passphrase (age scrypt) instead of an identity file. The wallet starts locked; `walletpassphrase "<pass>" <timeout>` unlocks it for the given duration and auto-relocks at timeout — matching Bitcoin Core's encrypted wallet behavior.
+
+Best for: hot wallets where unattended spend authority is not required; interactive operator workflows.
+
+```sh
+zecd init --datadir ./data --encrypt
+# later: walletpassphrase "my-passphrase" 300
+```
+
+### 3. Watch-Only (UFVK — No Spend Key)
+
+Initialized with a Unified Full Viewing Key (UFVK) exported from another wallet. Can receive, scan, and report balances — but cannot sign transactions. Ideal for monitoring, invoicing, or audit nodes separate from the signing wallet.
+
+```sh
+# On the signing wallet's host:
+zecd export-ufvk
+
+# On the watch-only host:
+zecd init --datadir ./data-watch --ufvk "uview1..." --birthday <height>
+```
+
+---
+
+## Backup and Recovery
+
+Funds are recoverable from **the mnemonic alone**. Everything else is a cache.
+
+| Artifact | Location | What it protects | Back up? |
+|----------|----------|-----------------|----------|
+| **24-word mnemonic** | Shown once at `zecd init` | The funds — loss = permanent loss | **Yes — offline (paper/HSM)** |
+| `keys.toml` | `<wallet dir>/keys.toml` | Encrypted seed + birthday + network | **Yes — as a Secret** |
+| `identity.txt` | `[keys] age_identity` | Decrypts `keys.toml` (spend authority) | **Yes — separately from `keys.toml`** |
+| Birthday height | Inside `keys.toml` | Makes restore fast (any height before first tx) | Record with mnemonic |
+| `data.sqlite` | `<wallet dir>/data.sqlite` | Wallet cache — rebuilt from seed on restore | No — disposable |
+| `blocks/` | `<wallet dir>/blocks/` | Compact block cache | No — never ship; can grow large |
+| `.cookie` | `<datadir>/.cookie` | Ephemeral RPC cookie | No — regenerated at startup |
+
+> **The data directory must be host-local.** ZECD's single-instance lock (`<datadir>/.lock`) is an OS advisory lock — it does not span hosts. Never share a data directory read-write across machines (NFS, Kubernetes `ReadWriteMany`) — two ZECD instances would corrupt the wallet DB. Use `ReadWriteOnce` volumes in Kubernetes.
+
+---
+
+## RPC Method Safelist
+
+For deployments where a credential leak would be catastrophic, ZECD supports restricting the RPC surface to a chosen subset of methods:
+
+```toml
+[rpc]
+allowed_methods = ["getblockchaininfo", "getbalance", "getnewaddress", "listtransactions"]
+```
+
+Any method not on the list returns `-32601` (HTTP 404) — indistinguishable from a method that doesn't exist, so a locked-down server discloses nothing about what it disabled. A receive-only invoicer can disable `sendtoaddress`, `sendmany`, and `stop` to minimize blast radius from a compromised client.
+
+---
+
+## Key Differences from Bitcoin Core RPC
+
+Developers migrating from Bitcoin or zcashd tooling should be aware of these intentional divergences:
+
+| Behavior | Bitcoin Core | ZECD |
+|----------|-------------|------|
+| Address format | `1...` / `bc1...` | `u1...` (Orchard Unified Address) — not parseable as a Bitcoin address by string-parsing clients |
+| Labels | Full label store | Not implemented — `setlabel`, `listlabels`, etc. return `-32601` |
+| Fees | User-settable; fee market | ZIP-317 deterministic only; `settxfee`, `fee_rate`, `subtractfeefromamount` rejected with `-8` |
+| Memos | Not supported | `sendtoaddress` accepts hex memo; history has `memo` + `memoStr` fields |
+| Confirmations to spend | 1 | 3 (own change) / 10 (third-party) — configurable via `trusted_confirmations` / `untrusted_confirmations` |
+| `listsinceblock` on reorg | Walks back to fork | Returns `-5` (Block not found) if cursor is reorged away — re-baseline with parameterless call |
+| Duplicate recipients in `sendmany` | Error | JSON parser collapses duplicates (last wins) before ZECD sees them — don't list the same address twice |
+| Balance during initial sync | Blocks or warm-up | Serves partial balance — gate automation on `GET /readyz` (returns 503 until fully synced and enhancement backlog is drained) |
+| `minconf 0` in `getbalance` | 0-conf balance | Served as 1 — a shielded note is never spendable unmined |
 
 ---
 
 ## Quick Start
 
-ZECD is not yet published on crates.io; build from source or use the Docker stack.
+**Prerequisites:** Zebra running locally with `rpc.listen_addr = 127.0.0.1:18234` (testnet).
 
-**Prerequisites:** a locally running Zebra full node with `rpc.listen_addr = 127.0.0.1:18234` (testnet).
+Install from crates.io (0.4.3+):
+
+```sh
+cargo install zecd
+```
+
+Or build from source:
+
+```sh
+git clone https://github.com/zecrocks/zecd && cd zecd
+cargo build --release
+```
 
 ```sh
 # 1. Initialize a testnet wallet (generates a 24-word mnemonic and an account)
-cargo run --release -- --datadir ./data --testnet \
-    init --wallet default --account-name primary
+zecd --datadir ./data --testnet init --wallet default --account-name primary
 
 # 2. Start the daemon (syncs in background, serves JSON-RPC on port 18232)
-cargo run --release -- --datadir ./data --testnet \
+zecd --datadir ./data --testnet \
     --rpcuser zec --rpcpassword secret --rpcbind 127.0.0.1 --rpcport 18232
 ```
 
@@ -144,9 +255,19 @@ curl -s --user zec:secret --data-binary \
 from bitcoinrpc.authproxy import AuthServiceProxy
 rpc = AuthServiceProxy("http://zec:secret@127.0.0.1:18232")
 print(rpc.getblockchaininfo())
-addr = rpc.getnewaddress("invoice-1")  # returns a u1... Orchard Unified Address
+addr = rpc.getnewaddress()          # returns a u1... Orchard Unified Address
 print(rpc.getbalance())
 print(rpc.listtransactions("*", 20))
+
+# Send with a shielded memo
+rpc.sendtoaddress(addr, 0.001, "", "", False, "48656c6c6f205a6563617368")  # hex memo
+```
+
+**Restore from seed:**
+
+```sh
+zecd --datadir ./data init --restore --birthday 2500000
+# paste your 24-word mnemonic when prompted
 ```
 
 ---
@@ -166,12 +287,15 @@ print(rpc.listtransactions("*", 20))
 |--|--------|-------|------|
 | Role | Full node + wallet | Indexer (replaces lightwalletd) | Wallet server only |
 | Language | C++ | Rust | Rust |
-| Status | Deprecated | Active | Active |
+| Status | Deprecated | Active | Active (v0.5.0-rc3, Jul 2026) |
 | Default pool | Transparent | N/A | Orchard (shielded) |
 | RPC dialect | zcashd-specific | gRPC (lightwalletd) | Bitcoin Core JSON-RPC |
 | Requires full node | Yes (self) | Zebra or zcashd | Zebra |
 | Stateless recovery | No | N/A | Yes (seed-only) |
+| Shielded memos | Yes (`z_sendmany`) | N/A | Yes (Bitcoin RPC surface) |
+| Watch-only (UFVK) | Yes | Yes | Yes |
 | Cloud-native | No | Partial | Yes |
+| Install | Build/binary | Build | `cargo install zecd` |
 
 ---
 
@@ -186,7 +310,9 @@ print(rpc.listtransactions("*", 20))
 ## Resources
 
 - [ZECD GitHub (zecrocks/zecd)](https://github.com/zecrocks/zecd)
+- [ZECD Operations Runbook](https://github.com/zecrocks/zecd/blob/main/docs/OPERATIONS.md)
 - [zec.rocks](https://zec.rocks)
 - [librustzcash — core Zcash cryptography library](https://github.com/zcash/librustzcash)
-- [Zodl wallet (librustzcash-compatible)](https://github.com/zodl-inc/zodl-ios)
 - [ZIP-317: Proportional Transfer Fee Mechanism](https://zips.z.cash/zip-0317)
+- [ZIP-302: Shielded Memos](https://zips.z.cash/zip-0302)
+- [Zodl wallet (librustzcash-compatible)](https://github.com/zodl-inc/zodl-ios)

--- a/site/Zcash_Tech/Zakura_Node.md
+++ b/site/Zcash_Tech/Zakura_Node.md
@@ -1,0 +1,112 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Tech/Zakura_Node.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
+# Zakura Node
+
+> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/zcashtech/zakura)
+
+Zakura is a free, open-source full node implementation for Zcash, built for scale. Forked from [Zebra](Zebra_Full_Node.md) and developed through a collaboration between **Valar Group** and **Project Tachyon**, Zakura delivers dramatically faster synchronization, native block pruning, and a compatibility layer for legacy `zcashd` tooling. Version 1.0.0 was released on July 15, 2026.
+
+---
+
+## TL;DR
+
+- Zakura is a **consensus-compatible Zcash full node** — an alternative to Zebra and zcashd, forked from Zebra.
+- Blockchain sync is approximately **5× faster than Zebra**; snapshot bootstrapping completes in **under 2 minutes**.
+- **Native block pruning** allows operators to run a full node with dramatically less disk space (~11 GB pruned snapshot vs. 300 GB for a full Zebra node).
+- A **zcashd RPC compatibility mode** lets existing wallets and integrations work without modification.
+- An **experimental P2P transport layer** (disabled by default) targets sub-500ms block propagation with DoS-resistant gossip.
+- Compatible with **Ironwood (NU6.3)**, the Zcash network upgrade activated in mid-2026.
+- Led by **Sean Bowe** (Zcash cofounder, Project Tachyon) and **Dev Ojha** (Valar Group).
+
+---
+
+## What is Zakura?
+
+Zakura is a Zcash full node designed from the ground up to be production-ready at scale. While it shares consensus compatibility with Zebra — meaning it validates and follows the same Zcash protocol rules — Zakura introduces significant engineering improvements aimed at lowering the barrier to running a Zcash full node.
+
+The project is a joint effort between **Project Tachyon** (led by Sean Bowe, one of Zcash's original cryptographic engineers) and **Valar Group** (led by Dev Ojha). Together they focus on next-generation Zcash protocol improvements, and Zakura serves as the reference node for that work.
+
+---
+
+## Key Features
+
+### 5× Faster Chain Synchronization
+
+Zakura achieves approximately 5× faster blockchain synchronization compared to Zebra. This makes it significantly more practical for operators who need to spin up a node quickly or recover from downtime.
+
+### Snapshot Bootstrapping
+
+Zakura publishes pre-built chain snapshots that dramatically reduce initial sync time:
+
+| Bootstrap Method | Time |
+|-----------------|------|
+| Archive snapshot | ~37 minutes |
+| Pruned snapshot | **Under 2 minutes** |
+| Zebra (full sync) | ~20 hours |
+
+Pruned snapshots are approximately **11 GB**, enabling a **680× faster** node bootstrap compared to syncing from genesis.
+
+### Native Block Pruning
+
+Zakura supports configurable block pruning, allowing node operators to define how much chain history to retain. This makes it practical to run a full node on hardware with limited storage — useful for validators, developers, and infrastructure providers who do not need the full historical chain.
+
+### zcashd RPC Compatibility Mode
+
+Zakura includes a compatibility mode that reproduces the legacy `zcashd` JSON-RPC interface. Existing wallets, exchanges, and integrations that rely on `zcashd` RPCs can switch to Zakura without requiring code changes.
+
+### Experimental P2P Transport Layer
+
+Zakura ships with a next-generation peer-to-peer transport layer, currently **disabled by default**. When enabled, it targets:
+
+- Sub-500ms worst-case block propagation across the network
+- Mempool aggregation for more efficient transaction relay
+- DoS-resistant gossip protocol to improve network resilience
+
+This layer represents a preview of future Zcash network-level improvements being developed under Project Tachyon.
+
+### Ironwood (NU6.3) Compatible
+
+Zakura is fully compatible with the Ironwood network upgrade (NU6.3), activated on the Zcash mainnet in mid-2026.
+
+---
+
+## How Zakura Relates to Other Zcash Nodes
+
+| | zcashd | Zebra | Zakura |
+|--|--------|-------|--------|
+| Language | C++ (forked from Bitcoin) | Rust | Rust (forked from Zebra) |
+| Status | Deprecated | Active | Active (v1.0.0, Jul 2026) |
+| Sync speed | Baseline | ~1× | ~5× faster |
+| Block pruning | No | No | Yes |
+| zcashd RPC compat | Native | Partial | Yes (compat mode) |
+| Snapshot bootstrap | No | No | Yes (<2 min) |
+| Experimental P2P | No | No | Yes (opt-in) |
+
+---
+
+## Getting Started
+
+Download options, snapshots, and configuration documentation are available at:
+
+- **Download & setup guide:** [zakura.com/download](https://zakura.com/download/)
+- **Chain snapshots:** [zakura.com/snapshots](https://zakura.com/snapshots/)
+- **Source code:** [github.com/zakura-core/zakura](https://github.com/zakura-core/zakura)
+
+---
+
+## Related Pages
+
+- [Zebra Full Node](Zebra_Full_Node.md) — the upstream Zcash full node Zakura was forked from
+- [Zaino Indexer](Zaino.md) — a Rust-based indexer compatible with Zebra and Zakura
+- [Full Nodes](Full_Nodes.md) — overview of Zcash full node options
+- [Lightwallet Nodes](Lightwallet_Nodes.md) — lightweight client alternatives
+
+## Resources
+
+- [Introducing Zakura — announcement](https://zakura.com/announcements/introducing-zakura/)
+- [Zakura GitHub](https://github.com/zakura-core/zakura)
+- [Zakura Website](https://zakura.com/)
+- [Zakura on X/Twitter](https://x.com/ZakuraZcash)
+- [Project Tachyon](https://electriccoin.co/blog/)

--- a/site/zechubglobal/zcashbrasil/usandozec/zecmap.md
+++ b/site/zechubglobal/zcashbrasil/usandozec/zecmap.md
@@ -1,0 +1,139 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/usandozec/zecmap.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
+
+# ZecMap
+
+> 🇺🇸 [English version](/using-zcash/zecmap)
+
+O ZecMap é um diretório global e comunitário para descobrir empresas e serviços que aceitam Zcash (ZEC). Construído em torno de uma interface de mapa interativo, ajuda os detentores de ZEC a responder uma pergunta prática: **"Onde posso gastar meu ZEC?"**
+
+Site: [zecmap.com](https://zecmap.com/)
+
+---
+
+## TL;DR
+
+- O ZecMap é um **diretório público e gratuito** de comerciantes que aceitam ZEC — lojas físicas e online.
+- Navegue pelo **mapa interativo** para encontrar comerciantes que aceitam ZEC perto de você ou em qualquer lugar do mundo.
+- **Qualquer pessoa pode enviar** um negócio; as listagens passam por revisão comunitária antes de aparecerem publicamente.
+- Um **Programa de Recompensas para Contribuidores** incentiva a adição e verificação de dados de comerciantes.
+- O ZecMap recentemente fez parceria com o [CipherPay](https://x.com/ZecMap/status/2059622324958093616) para expandir as integrações de comerciantes.
+
+---
+
+## O que o ZecMap Faz
+
+O ZecMap organiza empresas que aceitam Zcash em um mapa global. Cada listagem mostra o nome do negócio, categoria, localização ou site, e como o ZEC é aceito. Isso facilita para os detentores de ZEC:
+
+- Encontrar um café, restaurante, hotel, loja ou serviço próximo que aceite ZEC antes de uma visita.
+- Descobrir lojas online, provedores de VPN, freelancers ou serviços digitais que suportam pagamentos em Zcash.
+- Explorar a adoção regional do Zcash por cidade, país ou rota de viagem.
+- Ajudar a manter o diretório atualizado à medida que novos negócios começam a aceitar ZEC.
+
+---
+
+## Casos de Uso
+
+### Encontrando Comerciantes Locais
+
+Abra o [zecmap.com](https://zecmap.com/) e busque comerciantes próximos. Antes de visitar, confirme com o negócio que o ZEC ainda é aceito e pergunte qual carteira ou fluxo de pagamento preferem.
+
+### Descobrindo Lojas e Serviços Online
+
+O ZecMap também lista negócios online. Navegue por categoria para encontrar lojas de e-commerce, serviços de hospedagem, provedores de VPN e outros comerciantes digitais que aceitam pagamentos em ZEC.
+
+### Planejando Viagens em ZEC
+
+Viajando para uma nova cidade ou país? O ZecMap permite que você explore a cobertura de comerciantes antes de chegar, planejando paradas em restaurantes, lojas e serviços que aceitam ZEC.
+
+### Apoiando Novos Usuários de Zcash
+
+Novos usuários geralmente aprendem a comprar e guardar ZEC antes de descobrir onde gastá-lo. O ZecMap fornece esse próximo passo — uma lista prática e navegável de utilidade real do ZEC.
+
+---
+
+## Adicionando um Negócio
+
+Se um negócio aceita ZEC e ainda não está no ZecMap, qualquer membro da comunidade pode enviá-lo. Um bom envio inclui:
+
+| Campo | O que fornecer |
+|-------|----------------|
+| Nome do negócio | Nome oficial como aparece publicamente |
+| Site ou contato | URL ou perfil social |
+| Localização | Endereço para negócios físicos; região para online |
+| Categoria | Café, restaurante, loja, serviço, loja online, etc. |
+| Evidência | Página pública de pagamentos, anúncio do comerciante ou confirmação direta |
+| Notas de pagamento | Presencial, online ou ambos; ZEC transparente ou blindado |
+
+Os envios devem evitar dados privados de clientes. Se usar prova de transação, remova dados pessoais, números de pedido e endereços residenciais antes de compartilhar.
+
+---
+
+## Verificação e Aprovação
+
+As listagens passam por um processo de revisão antes de aparecerem publicamente:
+
+1. O contribuidor envia um negócio com informações públicas suficientes para verificar.
+2. A listagem é verificada quanto a duplicatas e precisão básica.
+3. A aceitação de ZEC é confirmada por meio de uma fonte pública ou contato com o comerciante.
+4. Listagens aprovadas aparecem no mapa.
+5. Membros da comunidade podem sinalizar listagens desatualizadas ou incorretas.
+
+Trate as listagens como informações mantidas pela comunidade, não como garantia. Confirme com o comerciante antes de uma viagem ou compra importante.
+
+---
+
+## Programa de Recompensas para Contribuidores
+
+O ZecMap recompensa contribuidores que ajudam a crescer e manter o diretório. As recompensas incentivam:
+
+- **Novas listagens** — adicionar negócios que aceitam ZEC e ainda não estão no mapa.
+- **Verificação** — confirmar que listagens existentes ainda estão ativas e precisas.
+- **Manutenção** — atualizar informações desatualizadas ou sinalizar negócios fechados.
+- **Expansão de cobertura** — adicionar comerciantes em cidades, regiões ou categorias online sub-representadas.
+
+Para as regras atuais de recompensa, visite [zecmap.com](https://zecmap.com/) ou verifique os anúncios do ZecMap nos canais da comunidade Zcash.
+
+---
+
+## Recursos Principais
+
+- **Mapa global interativo** — navegue ou busque comerciantes por localização.
+- **Listagens de negócios** — comerciantes locais e online com detalhes de pagamento.
+- **Contas de usuário** — envie listagens, acompanhe contribuições e crie um perfil.
+- **Revisão comunitária** — listagens são verificadas antes de irem ao ar.
+- **Ferramentas de denúncia** — sinalize entradas desatualizadas para manter o mapa preciso.
+
+---
+
+## Integrações do Ecossistema
+
+O ZecMap aceita comerciantes que recebem pagamentos Zcash via **Flexa**, uma rede de pagamentos usada por um número crescente de locais de varejo. Isso expande o número de comerciantes do mundo real listados no mapa além daqueles que aceitam Zcash nativamente.
+
+O ZecMap também anunciou uma parceria com o [CipherPay](https://cipherpay.app) para aprofundar as integrações de infraestrutura de pagamento para comerciantes no diretório.
+
+---
+
+## Dicas para Usar o ZecMap
+
+- **Confirme antes de ir.** Sempre verifique com o comerciante que o ZEC ainda é aceito.
+- **Verifique o tipo de pagamento.** Alguns negócios aceitam ZEC transparente, outros preferem blindado. Pergunte antes de pagar.
+- **Ajude a comunidade.** Se encontrar uma listagem desatualizada ou incorreta, sinalize-a.
+- **Adicione o que você sabe.** Se um negócio local aceita ZEC e não está listado, envie-o.
+
+---
+
+## Páginas Relacionadas
+
+- [Gastar ZEC](/using-zcash/spend-zcash)
+- [Processadores de Pagamento](/using-zcash/payment-processors)
+- [Usando ZEC com Privacidade](/guides/using-zec-privately)
+- [Carteiras](/using-zcash/wallets)
+
+## Recursos
+
+- [ZecMap](https://zecmap.com/)
+- [ZecMap no X/Twitter](https://x.com/ZecMap)
+- [Parceria ZecMap × CipherPay](https://x.com/ZecMap/status/2059622324958093616)
+- [Inclusão de comerciantes Flexa no ZecMap](https://x.com/ZecMap/status/2060453501063594002)

--- a/site/zechubglobal/zcashbrasil/zcashtech/zakura.md
+++ b/site/zechubglobal/zcashbrasil/zcashtech/zakura.md
@@ -1,0 +1,111 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/zcashtech/zakura.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
+
+# Zakura Node
+
+> 🇺🇸 [English version](/zcash-tech/zakura-node)
+
+Zakura é uma implementação de full node Zcash livre, de código aberto e construída para escala. Derivada (fork) do [Zebra](Zebra_Full_Node.md) e desenvolvida em colaboração entre o **Valar Group** e o **Project Tachyon**, o Zakura entrega sincronização dramaticamente mais rápida, poda nativa de blocos e uma camada de compatibilidade para o `zcashd` legado. A versão 1.0.0 foi lançada em 15 de julho de 2026.
+
+---
+
+## TL;DR
+
+- Zakura é um **full node Zcash compatível com o consenso** — uma alternativa ao Zebra e ao zcashd, derivado do Zebra.
+- A sincronização da blockchain é aproximadamente **5× mais rápida que o Zebra**; o bootstrap por snapshot completa em **menos de 2 minutos**.
+- A **poda nativa de blocos** permite que operadores rodem um full node com muito menos espaço em disco (~11 GB no snapshot podado vs. 300 GB do Zebra completo).
+- Um **modo de compatibilidade com o RPC do zcashd** permite que carteiras e integrações existentes funcionem sem modificações.
+- Uma **camada P2P experimental** (desativada por padrão) tem como alvo propagação de blocos em menos de 500ms com protocolo gossip resistente a DoS.
+- Compatível com **Ironwood (NU6.3)**, a atualização de rede Zcash ativada em meados de 2026.
+- Liderado por **Sean Bowe** (cofundador da Zcash, Project Tachyon) e **Dev Ojha** (Valar Group).
+
+---
+
+## O que é o Zakura?
+
+Zakura é um full node Zcash projetado para ser adequado para produção em escala. Embora compartilhe compatibilidade de consenso com o Zebra — ou seja, valida e segue as mesmas regras de protocolo Zcash — o Zakura introduz melhorias significativas de engenharia com o objetivo de reduzir a barreira para rodar um full node Zcash.
+
+O projeto é uma iniciativa conjunta entre o **Project Tachyon** (liderado por Sean Bowe, um dos engenheiros criptográficos originais da Zcash) e o **Valar Group** (liderado por Dev Ojha). Juntos, focam em melhorias de protocolo Zcash de próxima geração, e o Zakura serve como o nó de referência para esse trabalho.
+
+---
+
+## Recursos Principais
+
+### Sincronização 5× Mais Rápida
+
+O Zakura alcança aproximadamente 5× mais velocidade de sincronização da blockchain em comparação ao Zebra. Isso o torna significativamente mais prático para operadores que precisam iniciar um nó rapidamente ou se recuperar de tempo de inatividade.
+
+### Bootstrap por Snapshot
+
+O Zakura publica snapshots pré-construídos da cadeia que reduzem drasticamente o tempo de sincronização inicial:
+
+| Método de Bootstrap | Tempo |
+|--------------------|-------|
+| Snapshot arquivo completo | ~37 minutos |
+| Snapshot podado | **Menos de 2 minutos** |
+| Zebra (sync completo) | ~20 horas |
+
+Os snapshots podados têm aproximadamente **11 GB**, permitindo um bootstrap de nó **680× mais rápido** em comparação à sincronização desde o bloco genesis.
+
+### Poda Nativa de Blocos
+
+O Zakura suporta poda de blocos configurável, permitindo que operadores definam quanto do histórico da cadeia manter. Isso torna prático rodar um full node em hardware com armazenamento limitado — útil para validadores, desenvolvedores e provedores de infraestrutura que não precisam do histórico completo da cadeia.
+
+### Modo de Compatibilidade com RPC do zcashd
+
+O Zakura inclui um modo de compatibilidade que reproduz a interface JSON-RPC legada do `zcashd`. Carteiras, exchanges e integrações existentes que dependem dos RPCs do `zcashd` podem migrar para o Zakura sem necessidade de alterações no código.
+
+### Camada P2P Experimental
+
+O Zakura vem com uma camada de transporte peer-to-peer de próxima geração, atualmente **desativada por padrão**. Quando ativada, tem como objetivos:
+
+- Propagação de blocos com latência máxima abaixo de 500ms na rede
+- Agregação de mempool para retransmissão de transações mais eficiente
+- Protocolo gossip resistente a DoS para melhorar a resiliência da rede
+
+Esta camada representa uma prévia das melhorias futuras ao nível de rede Zcash sendo desenvolvidas no âmbito do Project Tachyon.
+
+### Compatível com Ironwood (NU6.3)
+
+O Zakura é totalmente compatível com a atualização de rede Ironwood (NU6.3), ativada na mainnet Zcash em meados de 2026.
+
+---
+
+## Como o Zakura se Compara a Outros Nós Zcash
+
+| | zcashd | Zebra | Zakura |
+|--|--------|-------|--------|
+| Linguagem | C++ (fork do Bitcoin) | Rust | Rust (fork do Zebra) |
+| Status | Descontinuado | Ativo | Ativo (v1.0.0, jul 2026) |
+| Velocidade de sync | Base | ~1× | ~5× mais rápido |
+| Poda de blocos | Não | Não | Sim |
+| Compatibilidade RPC zcashd | Nativa | Parcial | Sim (modo compat) |
+| Bootstrap por snapshot | Não | Não | Sim (<2 min) |
+| P2P experimental | Não | Não | Sim (opt-in) |
+
+---
+
+## Como Começar
+
+Opções de download, snapshots e documentação de configuração estão disponíveis em:
+
+- **Guia de download e configuração:** [zakura.com/download](https://zakura.com/download/)
+- **Snapshots da cadeia:** [zakura.com/snapshots](https://zakura.com/snapshots/)
+- **Código fonte:** [github.com/zakura-core/zakura](https://github.com/zakura-core/zakura)
+
+---
+
+## Páginas Relacionadas
+
+- [Zebra Full Node](/zcash-tech/zebra-full-node) — o nó Zcash do qual o Zakura foi derivado
+- [Zaino Indexer](/zcash-tech/zaino) — indexador em Rust compatível com Zebra e Zakura
+- [Full Nodes](/zcash-tech/full-nodes) — visão geral das opções de full node Zcash
+- [Lightwallet Nodes](/zcash-tech/lightwallet-nodes) — alternativas de clientes leves
+
+## Recursos
+
+- [Apresentando o Zakura — anúncio](https://zakura.com/announcements/introducing-zakura/)
+- [Zakura no GitHub](https://github.com/zakura-core/zakura)
+- [Site oficial do Zakura](https://zakura.com/)
+- [Zakura no X/Twitter](https://x.com/ZakuraZcash)

--- a/site/zechubglobal/zcashbrasil/zcashtech/zecd.md
+++ b/site/zechubglobal/zcashbrasil/zcashtech/zecd.md
@@ -1,0 +1,192 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/zechubglobal/zcashbrasil/zcashtech/zecd.md" target="_blank">
+  <img src="https://img.shields.io/badge/Editar-blue" alt="Editar Página"/>
+</a>
+
+# ZECD — Servidor de Carteira Shielded-First
+
+> 🇺🇸 [English version](/zcash-tech/zecd)
+
+ZECD é um servidor de carteira Zcash com foco em privacidade, construído sobre a [librustzcash](https://github.com/zcash/librustzcash) e exposto através do dialeto JSON-RPC do Bitcoin Core. Ele oferece aos desenvolvedores e integradores de pagamento uma API familiar e compatível com Bitcoin para interagir com Zcash — com o Orchard (o pool mais privado) como padrão. Desenvolvido por [zec.rocks](https://zec.rocks), o ZECD foi projetado para substituir a funcionalidade de carteira do `zcashd` em implantações modernas e cloud-native.
+
+---
+
+## TL;DR
+
+- ZECD é um **daemon de carteira (servidor)** — não é um nó completo. Ele gerencia chaves, escaneamento, provas e RPC sem falar o protocolo P2P do Zcash.
+- Fala o **dialeto JSON-RPC do Bitcoin Core**: mesmos nomes de métodos, estruturas de resposta, autenticação e códigos de erro — muitos clientes RPC Bitcoin funcionam com Zcash sem modificações.
+- **Endereços Orchard (shielded) são o padrão**; suporte a transparente (t-address) e Sapling requer ativação explícita por carteira.
+- Conecta-se a um **nó completo [Zebra](Zebra_Full_Node.md) auto-hospedado** via JSON-RPC local — sem necessidade de lightwalletd.
+- **Stateless por design**: toda a carteira é recuperável apenas com a frase semente, tornando o diretório de dados descartável.
+- **Não é compatível com zcashd**: implementa apenas um subconjunto dos métodos RPC do Zcash, com diferenças de design intencionais para privacidade e segurança.
+- Taxas seguem o **ZIP-317** (cálculo determinístico); taxas definidas pelo usuário são rejeitadas.
+
+---
+
+## Qual Problema o ZECD Resolve?
+
+O `zcashd` foi o nó e carteira original do Zcash — derivado do código C++ do Bitcoin em 2016. Com o tempo, isso criou fricção: o código é difícil de manter, a carteira está fortemente acoplada ao nó, e endereços transparentes são apresentados como opções de primeira classe ao lado dos shielded.
+
+O ZECD separa a responsabilidade da carteira do consenso. É uma **camada de carteira dedicada** que fica entre aplicações e um nó completo Zebra, fornecendo:
+
+- Uma implementação moderna em Rust sobre librustzcash (a mesma biblioteca que alimenta Zashi e Zodl)
+- Design com privacidade como padrão (endereços Orchard, salvo configuração explícita)
+- Uma interface RPC compatível com Bitcoin que elimina a necessidade de aprender ferramentas específicas do Zcash
+- Arquitetura stateless e recuperável por semente, adequada para implantações em containers e nuvem
+
+---
+
+## Arquitetura
+
+O ZECD opera em um modelo de três camadas:
+
+```
+Sua app / cliente Bitcoin RPC
+        ↓  JSON-RPC
+       ZECD
+   (chaves, escaneamento, provas, RPC)
+        ↓  JSON-RPC (apenas local)
+       Zebra
+   (nó completo — consenso, mempool, dados da cadeia)
+```
+
+O ZECD se comunica com o Zebra **exclusivamente via JSON-RPC local** — sem rede P2P, sem indexadores de terceiros, sem lightwalletd. A conexão com o Zebra é deliberadamente local: o ZECD se recusa a enviar credenciais a um host com roteamento público, a não ser que configurado explicitamente para um túnel seguro externo (ex: WireGuard ou SSH).
+
+---
+
+## Recursos Principais
+
+### Shielded-First, Orchard como Padrão
+
+O ZECD usa Unified Addresses Orchard como tipo de endereço padrão. Os pools Sapling e transparente (t-address) requerem configuração explícita por carteira. Este design reduz o risco de envios transparentes acidentais — uma armadilha de privacidade comum em ferramentas Zcash antigas.
+
+A política de privacidade é configurável:
+
+| Política | Comportamento |
+|----------|---------------|
+| `AllowRevealedRecipients` (padrão) | Permite envios para destinatários transparentes |
+| `FullPrivacy` | Apenas envios para pool shielded único; sem destinatários transparentes |
+| `AllowFullyTransparent` | Também permite envios t→t financiados de UTXOs transparentes |
+
+### Compatibilidade com Bitcoin Core RPC
+
+O ZECD implementa o dialeto JSON-RPC do Bitcoin Core com conformidade em:
+
+- Nomes de métodos (ex: `getblockchaininfo`, `getbalance`, `getnewaddress`, `listtransactions`)
+- Nomes e tipos de campos nas respostas
+- Estrutura do envelope JSON-RPC 1.0
+- Autenticação Basic e arquivo cookie
+- Códigos de erro e mapeamento de status HTTP
+
+Isso significa que muitas bibliotecas de pagamento Bitcoin, integrações de exchanges e ferramentas de monitoramento existentes podem interagir com Zcash via ZECD com poucas ou nenhuma alteração de código.
+
+> **Nota:** O ZECD é intencionalmente **não** retrocompatível com o `zcashd`. Implementa apenas um subconjunto dos métodos `z_*`, e métodos relacionados a labels (`setlabel`, `listlabels`, etc.) não são implementados por design (veja *Stateless por Design* abaixo).
+
+### Stateless por Design
+
+O ZECD **não persiste nenhum estado off-chain que uma restauração somente com semente não pudesse reconstruir**. O banco de dados da carteira (`data.sqlite`) é inteiramente derivável da frase semente — fundos shielded são recuperados incondicionalmente; fundos transparentes são recuperados até o limite de gap configurado.
+
+Para restaurar uma carteira a partir da semente:
+
+```sh
+zecd init --restore --birthday <altura-do-bloco>
+```
+
+Isso torna o diretório de dados **descartável**: um container sem volume persistente, reconstruído a partir da semente a cada inicialização, não perde nada crítico. Operadores são responsáveis por rastrear os endereços que distribuem — o ZECD só se lembra de endereços após receberem fundos on-chain.
+
+Labels são intencionalmente ausentes. Como labels não têm fonte on-chain e não podem ser reconstruídas a partir da semente, o ZECD simplesmente não as suporta. Chamar métodos de label retorna um erro `method-not-found` (`-32601`).
+
+### Sem Dependência do lightwalletd
+
+O ZECD deriva blocos compactos, estado da árvore e visibilidade do mempool diretamente do JSON-RPC do Zebra. Não há lightwalletd para operar ou manter — reduzindo a complexidade operacional para implantações auto-hospedadas.
+
+### Implantações Cloud-Native e em Containers
+
+A arquitetura stateless do ZECD foi projetada para ambientes Docker e Kubernetes:
+
+- Stack Docker Compose completa (`zebra → zecd`) disponível no repositório
+- Endpoint de saúde na porta `9233` com probes de readiness configuráveis (`synced` ou `alive`)
+- Opção de log JSON estruturado para pipelines de agregação de logs
+- Taxas determinísticas ZIP-317 — sem oracle de taxas ou configuração manual
+
+### Compatibilidade de Semente com Outras Carteiras librustzcash
+
+O ZECD é compatível com outras carteiras baseadas em librustzcash, incluindo o [Zodl](https://github.com/zodl-inc/zodl-ios) (iOS/Android). Se algo der errado com um deployment ZECD, a frase semente pode ser inserida em qualquer outra carteira librustzcash para acessar os fundos.
+
+---
+
+## Início Rápido
+
+O ZECD ainda não está publicado no crates.io; compile a partir do código-fonte ou use o stack Docker.
+
+**Pré-requisitos:** um nó Zebra rodando localmente com `rpc.listen_addr = 127.0.0.1:18234` (testnet).
+
+```sh
+# 1. Inicializar uma carteira testnet (gera mnemônica de 24 palavras e uma conta)
+cargo run --release -- --datadir ./data --testnet \
+    init --wallet default --account-name primary
+
+# 2. Iniciar o daemon (sincroniza em background, serve JSON-RPC na porta 18232)
+cargo run --release -- --datadir ./data --testnet \
+    --rpcuser zec --rpcpassword secret --rpcbind 127.0.0.1 --rpcport 18232
+```
+
+**Interagir via curl:**
+
+```sh
+curl -s --user zec:secret --data-binary \
+  '{"jsonrpc":"1.0","id":"1","method":"getblockchaininfo","params":[]}' \
+  -H 'content-type: text/plain;' http://127.0.0.1:18232/
+```
+
+**Interagir via Python (usando biblioteca Bitcoin RPC):**
+
+```python
+from bitcoinrpc.authproxy import AuthServiceProxy
+rpc = AuthServiceProxy("http://zec:secret@127.0.0.1:18232")
+print(rpc.getblockchaininfo())
+addr = rpc.getnewaddress("invoice-1")  # retorna um endereço Orchard Unified Address u1...
+print(rpc.getbalance())
+print(rpc.listtransactions("*", 20))
+```
+
+---
+
+## Portas Padrão
+
+| Rede | RPC ZECD | RPC Zebra (backend) | Saúde |
+|------|----------|---------------------|-------|
+| Mainnet | 8232 | 8234 | 9233 |
+| Testnet | 18232 | 18234 | 9233 |
+
+---
+
+## ZECD vs. zcashd vs. Zaino
+
+| | zcashd | Zaino | ZECD |
+|--|--------|-------|------|
+| Função | Nó completo + carteira | Indexador (substitui lightwalletd) | Servidor de carteira |
+| Linguagem | C++ | Rust | Rust |
+| Status | Descontinuado | Ativo | Ativo |
+| Pool padrão | Transparente | N/A | Orchard (shielded) |
+| Dialeto RPC | zcashd específico | gRPC (lightwalletd) | Bitcoin Core JSON-RPC |
+| Requer nó completo | Sim (próprio) | Zebra ou zcashd | Zebra |
+| Recuperação stateless | Não | N/A | Sim (apenas semente) |
+| Cloud-native | Não | Parcial | Sim |
+
+---
+
+## Páginas Relacionadas
+
+- [Zebra Full Node](/zcash-tech/zebra-full-node) — o nó completo ao qual o ZECD se conecta
+- [Zaino Indexer](/zcash-tech/zaino) — abordagem alternativa de indexador (substitui lightwalletd)
+- [Zakura Node](/zcash-tech/zakura-node) — outra implementação de nó completo (fork do Zebra)
+- [Viewing Keys](/zcash-tech/viewing-keys) — como o ZECD escaneia a cadeia usando viewing keys de conta
+- [Carteiras](/using-zcash/wallets) — visão geral do ecossistema de carteiras
+
+## Recursos
+
+- [ZECD no GitHub (zecrocks/zecd)](https://github.com/zecrocks/zecd)
+- [zec.rocks](https://zec.rocks)
+- [librustzcash — biblioteca de criptografia principal do Zcash](https://github.com/zcash/librustzcash)
+- [Carteira Zodl (compatível com librustzcash)](https://github.com/zodl-inc/zodl-ios)
+- [ZIP-317: Mecanismo de Taxa de Transferência Proporcional](https://zips.z.cash/zip-0317)

--- a/site/zechubglobal/zcashbrasil/zcashtech/zecd.md
+++ b/site/zechubglobal/zcashbrasil/zcashtech/zecd.md
@@ -8,6 +8,8 @@
 
 ZECD é um servidor de carteira Zcash com foco em privacidade, construído sobre a [librustzcash](https://github.com/zcash/librustzcash) e exposto através do dialeto JSON-RPC do Bitcoin Core. Ele oferece aos desenvolvedores e integradores de pagamento uma API familiar e compatível com Bitcoin para interagir com Zcash — com o Orchard (o pool mais privado) como padrão. Desenvolvido por [zec.rocks](https://zec.rocks), o ZECD foi projetado para substituir a funcionalidade de carteira do `zcashd` em implantações modernas e cloud-native.
 
+**Versão atual:** 0.5.0-rc3 (13 de julho de 2026) — com suporte a Ironwood (NU6.3). Instale via `cargo install zecd` ou use a imagem Docker oficial.
+
 ---
 
 ## TL;DR
@@ -19,6 +21,7 @@ ZECD é um servidor de carteira Zcash com foco em privacidade, construído sobre
 - **Stateless por design**: toda a carteira é recuperável apenas com a frase semente, tornando o diretório de dados descartável.
 - **Não é compatível com zcashd**: implementa apenas um subconjunto dos métodos RPC do Zcash, com diferenças de design intencionais para privacidade e segurança.
 - Taxas seguem o **ZIP-317** (cálculo determinístico); taxas definidas pelo usuário são rejeitadas.
+- Suporta **memos shielded (ZIP-302)** através da superfície RPC familiar do Bitcoin.
 
 ---
 
@@ -59,27 +62,38 @@ O ZECD se comunica com o Zebra **exclusivamente via JSON-RPC local** — sem red
 
 O ZECD usa Unified Addresses Orchard como tipo de endereço padrão. Os pools Sapling e transparente (t-address) requerem configuração explícita por carteira. Este design reduz o risco de envios transparentes acidentais — uma armadilha de privacidade comum em ferramentas Zcash antigas.
 
-A política de privacidade é configurável:
+A política de privacidade é configurável por chamada ou globalmente em `[spend] privacy_policy`:
 
 | Política | Comportamento |
 |----------|---------------|
-| `AllowRevealedRecipients` (padrão) | Permite envios para destinatários transparentes |
-| `FullPrivacy` | Apenas envios para pool shielded único; sem destinatários transparentes |
+| `AllowRevealedRecipients` (padrão) | Permite envios para destinatários transparentes; revela valor e destinatário na cadeia |
+| `AllowRevealedAmounts` | Permite envios cross-pool (Sapling↔Orchard) mas rejeita destinatários transparentes |
+| `FullPrivacy` | Apenas envios totalmente shielded dentro de um pool; rejeita transparentes e cross-pool |
 | `AllowFullyTransparent` | Também permite envios t→t financiados de UTXOs transparentes |
 
 ### Compatibilidade com Bitcoin Core RPC
 
 O ZECD implementa o dialeto JSON-RPC do Bitcoin Core com conformidade em:
 
-- Nomes de métodos (ex: `getblockchaininfo`, `getbalance`, `getnewaddress`, `listtransactions`)
+- Nomes de métodos (ex: `getblockchaininfo`, `getbalance`, `getnewaddress`, `listtransactions`, `sendtoaddress`, `sendmany`)
 - Nomes e tipos de campos nas respostas
 - Estrutura do envelope JSON-RPC 1.0
-- Autenticação Basic e arquivo cookie
+- Autenticação Basic, entradas `rpcauth` e arquivo cookie
 - Códigos de erro e mapeamento de status HTTP
 
 Isso significa que muitas bibliotecas de pagamento Bitcoin, integrações de exchanges e ferramentas de monitoramento existentes podem interagir com Zcash via ZECD com poucas ou nenhuma alteração de código.
 
-> **Nota:** O ZECD é intencionalmente **não** retrocompatível com o `zcashd`. Implementa apenas um subconjunto dos métodos `z_*`, e métodos relacionados a labels (`setlabel`, `listlabels`, etc.) não são implementados por design (veja *Stateless por Design* abaixo).
+A suite de conformidade (140+ verificações) roda em cada PR contra um daemon regtest ao vivo e também foi validada na testnet pública.
+
+### Memos Shielded (ZIP-302)
+
+O ZECD expõe o recurso de memo shielded do Zcash pela superfície RPC familiar do Bitcoin:
+
+- `sendtoaddress` aceita um memo hex opcional como parâmetro extra (até 512 bytes; rejeitado para destinatários transparentes)
+- Entradas do histórico de transações em `listtransactions` e `gettransaction` incluem campos `memo` (hex) e `memoStr` (texto decodificado) quando uma saída contém um memo
+- Envios de valor zero para um destinatário shielded são suportados para casos de uso "memo-only" (padrão `z_sendmany`)
+
+Isso torna o ZECD adequado para aplicações que precisam de mensagens privadas on-chain junto com pagamentos.
 
 ### Stateless por Design
 
@@ -91,51 +105,132 @@ Para restaurar uma carteira a partir da semente:
 zecd init --restore --birthday <altura-do-bloco>
 ```
 
-Isso torna o diretório de dados **descartável**: um container sem volume persistente, reconstruído a partir da semente a cada inicialização, não perde nada crítico. Operadores são responsáveis por rastrear os endereços que distribuem — o ZECD só se lembra de endereços após receberem fundos on-chain.
+Isso torna o diretório de dados **descartável**: um container sem volume persistente, reconstruído a partir da semente a cada inicialização, não perde nada crítico.
 
 Labels são intencionalmente ausentes. Como labels não têm fonte on-chain e não podem ser reconstruídas a partir da semente, o ZECD simplesmente não as suporta. Chamar métodos de label retorna um erro `method-not-found` (`-32601`).
 
 ### Sem Dependência do lightwalletd
 
-O ZECD deriva blocos compactos, estado da árvore e visibilidade do mempool diretamente do JSON-RPC do Zebra. Não há lightwalletd para operar ou manter — reduzindo a complexidade operacional para implantações auto-hospedadas.
+O ZECD deriva blocos compactos, estado da árvore e visibilidade do mempool diretamente do JSON-RPC do Zebra. Não há lightwalletd para operar ou manter.
 
-### Implantações Cloud-Native e em Containers
+### Implantações Cloud-Native
 
-A arquitetura stateless do ZECD foi projetada para ambientes Docker e Kubernetes:
+A arquitetura stateless do ZECD foi projetada para Docker e Kubernetes:
 
 - Stack Docker Compose completa (`zebra → zecd`) disponível no repositório
-- Endpoint de saúde na porta `9233` com probes de readiness configuráveis (`synced` ou `alive`)
+- Endpoint de saúde na porta `9233` com probes de readiness configuráveis (`synced` ou `connected`)
 - Opção de log JSON estruturado para pipelines de agregação de logs
-- Taxas determinísticas ZIP-317 — sem oracle de taxas ou configuração manual
+- Taxas determinísticas ZIP-317
+- `bootstrap_from_keys` (padrão ativo): um diretório de dados vazio ao lado de `keys.toml` reconstrói automaticamente a carteira no boot — implante montando um Secret e iniciando com um PVC vazio
 
-### Compatibilidade de Semente com Outras Carteiras librustzcash
+---
 
-O ZECD é compatível com outras carteiras baseadas em librustzcash, incluindo o [Zodl](https://github.com/zodl-inc/zodl-ios) (iOS/Android). Se algo der errado com um deployment ZECD, a frase semente pode ser inserida em qualquer outra carteira librustzcash para acessar os fundos.
+## Modelos de Custódia
+
+O ZECD suporta três modelos de custódia de chaves, adequados para diferentes requisitos de implantação e segurança:
+
+### 1. Não Criptografado (Padrão — Auto-Unlock)
+
+A frase semente em `keys.toml` é encapsulada em um **arquivo de identidade age** (`identity.txt`). Com o padrão `auto_unlock = true`, a semente é descriptografada na memória na inicialização, então envios são autônomos — sem necessidade de chamar `walletpassphrase`.
+
+Ideal para: processadores de pagamento automatizados, hot wallets de exchanges, ambientes de desenvolvimento.
+
+```sh
+zecd init --datadir ./data --wallet default --account-name primary
+```
+
+> Guarde o `identity.txt` **fora** do diretório de dados em produção — quem lê os dois arquivos tem autoridade de gasto.
+
+### 2. Criptografado (Protegido por Senha)
+
+A frase semente é encapsulada com uma senha (age scrypt) em vez de um arquivo de identidade. A carteira inicia bloqueada; `walletpassphrase "<senha>" <timeout>` desbloqueia pelo tempo definido e bloqueia automaticamente ao final — espelhando o comportamento de carteira criptografada do Bitcoin Core.
+
+Ideal para: hot wallets onde autoridade de gasto autônoma não é necessária; fluxos de operador interativos.
+
+```sh
+zecd init --datadir ./data --encrypt
+# depois: walletpassphrase "minha-senha" 300
+```
+
+### 3. Watch-Only (UFVK — Sem Chave de Gasto)
+
+Inicializado com uma Unified Full Viewing Key (UFVK) exportada de outra carteira. Pode receber, escanear e reportar saldos — mas não pode assinar transações. Ideal para monitoramento, geração de faturas ou nós de auditoria separados da carteira de assinatura.
+
+```sh
+# Na máquina da carteira de assinatura:
+zecd export-ufvk
+
+# Na máquina watch-only:
+zecd init --datadir ./data-watch --ufvk "uview1..." --birthday <altura>
+```
+
+---
+
+## Backup e Recuperação
+
+Os fundos são recuperáveis **apenas com a frase semente**. Todo o resto é cache.
+
+| Artefato | Local | O que protege | Fazer backup? |
+|----------|-------|---------------|---------------|
+| **Frase semente de 24 palavras** | Exibida uma vez no `zecd init` | Os fundos — perda = perda permanente | **Sim — offline (papel/HSM)** |
+| `keys.toml` | `<wallet dir>/keys.toml` | Semente criptografada + birthday + rede | **Sim — como Secret** |
+| `identity.txt` | `[keys] age_identity` | Descriptografa `keys.toml` (autoridade de gasto) | **Sim — separado do `keys.toml`** |
+| Birthday height | Dentro de `keys.toml` | Torna a restauração rápida | Registrar com a frase semente |
+| `data.sqlite` | `<wallet dir>/data.sqlite` | Cache da carteira — reconstruído na restauração | Não — descartável |
+| `blocks/` | `<wallet dir>/blocks/` | Cache de blocos compactos | Não — nunca enviar; pode crescer muito |
+| `.cookie` | `<datadir>/.cookie` | Cookie RPC efêmero | Não — regenerado no boot |
+
+> **O diretório de dados deve ser local ao host.** O lock de instância única (`<datadir>/.lock`) é um advisory lock do OS — não se estende entre hosts. Nunca compartilhe um diretório de dados leitura-escrita entre máquinas (NFS, Kubernetes `ReadWriteMany`) — duas instâncias ZECD corromperiam o DB da carteira. Use volumes `ReadWriteOnce` no Kubernetes.
+
+---
+
+## Lista de Permissões de Métodos RPC
+
+Para implantações onde um vazamento de credencial seria crítico, o ZECD suporta restringir a superfície RPC a um subconjunto escolhido de métodos:
+
+```toml
+[rpc]
+allowed_methods = ["getblockchaininfo", "getbalance", "getnewaddress", "listtransactions"]
+```
+
+Qualquer método fora da lista retorna `-32601` (HTTP 404) — indistinguível de um método que não existe. Um integrador receive-only pode desabilitar `sendtoaddress`, `sendmany` e `stop` para minimizar o raio de explosão de uma credencial comprometida.
+
+---
+
+## Diferenças Chave em Relação ao Bitcoin Core RPC
+
+Desenvolvedores migrando de ferramentas Bitcoin ou zcashd devem estar cientes destas divergências intencionais:
+
+| Comportamento | Bitcoin Core | ZECD |
+|---------------|-------------|------|
+| Formato de endereço | `1...` / `bc1...` | `u1...` (Orchard Unified Address) — não parseável como endereço Bitcoin por clientes que analisam a string |
+| Labels | Armazenamento completo | Não implementado — `setlabel`, `listlabels`, etc. retornam `-32601` |
+| Taxas | Configuráveis pelo usuário | Apenas ZIP-317 determinístico; `settxfee`, `fee_rate`, `subtractfeefromamount` rejeitados com `-8` |
+| Memos | Não suportados | `sendtoaddress` aceita memo hex; histórico inclui campos `memo` + `memoStr` |
+| Confirmações para gastar | 1 | 3 (change própria) / 10 (terceiros) — configurável via `trusted_confirmations` / `untrusted_confirmations` |
+| `listsinceblock` em reorg | Volta ao ponto de fork | Retorna `-5` (Block not found) se cursor foi reorganizado — re-baseline com chamada sem parâmetros |
+| Saldo durante sync inicial | Bloqueia ou warm-up | Serve saldo parcial — garante automação via `GET /readyz` (retorna 503 até sync completo e backlog de enhancement drenado) |
+| `minconf 0` no `getbalance` | Saldo 0-conf | Servido como 1 — nota shielded nunca é gastável não minerada |
 
 ---
 
 ## Início Rápido
 
-O ZECD ainda não está publicado no crates.io; compile a partir do código-fonte ou use o stack Docker.
+**Pré-requisitos:** Zebra rodando localmente com `rpc.listen_addr = 127.0.0.1:18234` (testnet).
 
-**Pré-requisitos:** um nó Zebra rodando localmente com `rpc.listen_addr = 127.0.0.1:18234` (testnet).
+Instalar do crates.io (0.4.3+):
 
 ```sh
-# 1. Inicializar uma carteira testnet (gera mnemônica de 24 palavras e uma conta)
-cargo run --release -- --datadir ./data --testnet \
-    init --wallet default --account-name primary
-
-# 2. Iniciar o daemon (sincroniza em background, serve JSON-RPC na porta 18232)
-cargo run --release -- --datadir ./data --testnet \
-    --rpcuser zec --rpcpassword secret --rpcbind 127.0.0.1 --rpcport 18232
+cargo install zecd
 ```
 
-**Interagir via curl:**
-
 ```sh
-curl -s --user zec:secret --data-binary \
-  '{"jsonrpc":"1.0","id":"1","method":"getblockchaininfo","params":[]}' \
-  -H 'content-type: text/plain;' http://127.0.0.1:18232/
+# 1. Inicializar carteira testnet (gera mnemônica de 24 palavras e uma conta)
+zecd --datadir ./data --testnet init --wallet default --account-name primary
+
+# 2. Iniciar o daemon (sincroniza em background, serve JSON-RPC na porta 18232)
+zecd --datadir ./data --testnet \
+    --rpcuser zec --rpcpassword secret --rpcbind 127.0.0.1 --rpcport 18232
 ```
 
 **Interagir via Python (usando biblioteca Bitcoin RPC):**
@@ -143,10 +238,17 @@ curl -s --user zec:secret --data-binary \
 ```python
 from bitcoinrpc.authproxy import AuthServiceProxy
 rpc = AuthServiceProxy("http://zec:secret@127.0.0.1:18232")
-print(rpc.getblockchaininfo())
-addr = rpc.getnewaddress("invoice-1")  # retorna um endereço Orchard Unified Address u1...
+addr = rpc.getnewaddress()          # retorna endereço Orchard u1...
 print(rpc.getbalance())
-print(rpc.listtransactions("*", 20))
+# Enviar com memo shielded
+rpc.sendtoaddress(addr, 0.001, "", "", False, "48656c6c6f205a6563617368")
+```
+
+**Restaurar a partir da semente:**
+
+```sh
+zecd --datadir ./data init --restore --birthday 2500000
+# cole sua frase mnemônica de 24 palavras quando solicitado
 ```
 
 ---
@@ -166,12 +268,15 @@ print(rpc.listtransactions("*", 20))
 |--|--------|-------|------|
 | Função | Nó completo + carteira | Indexador (substitui lightwalletd) | Servidor de carteira |
 | Linguagem | C++ | Rust | Rust |
-| Status | Descontinuado | Ativo | Ativo |
+| Status | Descontinuado | Ativo | Ativo (v0.5.0-rc3, jul 2026) |
 | Pool padrão | Transparente | N/A | Orchard (shielded) |
 | Dialeto RPC | zcashd específico | gRPC (lightwalletd) | Bitcoin Core JSON-RPC |
 | Requer nó completo | Sim (próprio) | Zebra ou zcashd | Zebra |
 | Recuperação stateless | Não | N/A | Sim (apenas semente) |
+| Memos shielded | Sim (`z_sendmany`) | N/A | Sim (superfície Bitcoin RPC) |
+| Watch-only (UFVK) | Sim | Sim | Sim |
 | Cloud-native | Não | Parcial | Sim |
+| Instalação | Build/binário | Build | `cargo install zecd` |
 
 ---
 
@@ -186,7 +291,9 @@ print(rpc.listtransactions("*", 20))
 ## Recursos
 
 - [ZECD no GitHub (zecrocks/zecd)](https://github.com/zecrocks/zecd)
+- [Runbook de Operações do ZECD](https://github.com/zecrocks/zecd/blob/main/docs/OPERATIONS.md)
 - [zec.rocks](https://zec.rocks)
 - [librustzcash — biblioteca de criptografia principal do Zcash](https://github.com/zcash/librustzcash)
-- [Carteira Zodl (compatível com librustzcash)](https://github.com/zodl-inc/zodl-ios)
 - [ZIP-317: Mecanismo de Taxa de Transferência Proporcional](https://zips.z.cash/zip-0317)
+- [ZIP-302: Memos Shielded](https://zips.z.cash/zip-0302)
+- [Carteira Zodl (compatível com librustzcash)](https://github.com/zodl-inc/zodl-ios)


### PR DESCRIPTION
## Summary

Adds a comprehensive wiki page for **ZECD**, a shielded-first wallet server for Zcash built by [zec.rocks](https://zec.rocks).

### Files added

- `site/Zcash_Tech/ZECD.md` — English wiki page
- `site/zechubglobal/zcashbrasil/zcashtech/zecd.md` — Portuguese (PT-BR) translation

### Content covers

- What ZECD is and the problem it solves (modernizing wallet infrastructure, replacing zcashd wallet functionality)
- Three-tier architecture diagram: App → ZECD → Zebra (local JSON-RPC only)
- Shielded-first design: Orchard by default, opt-in transparent/Sapling
- Bitcoin Core JSON-RPC compatibility (method names, field shapes, auth, error codes)
- Stateless by design: full seed-only recovery, disposable data directory
- No lightwalletd dependency
- Cloud-native and Docker/Kubernetes deployment
- Privacy policy configuration table
- Quick start code examples (shell + Python)
- Default ports table (mainnet/testnet)
- Comparison table: zcashd vs. Zaino vs. ZECD
- Related pages: Zebra, Zaino, Zakura, Viewing Keys, Wallets
- Both files cross-link EN ↔ PT-BR

Source: https://github.com/zecrocks/zecd

---

Zcash address for bounty payment:
`u16ae47f0ssdxstznmwlaf8v7jvwt799483tzhgymwddgv4e53zrtepums2pd3qn29k7qjwf4ggmwd5ajxxq2a0gd0vug9evl89wlcum4z4k452l7p5p7f25z2apze4dtp5ut6pzh8hkfxrmn067jh88h2zwm9clgff239w8m8mqhfp9qr`