### PR TITLE
Add zcashd deprecation note to the Raspberry Pi 4 full-node guide

### DIFF
--- a/site/guides/Raspberry_Pi_4_Full_Node.md
+++ b/site/guides/Raspberry_Pi_4_Full_Node.md
@@ -8,6 +8,8 @@
 
 The purpose of this guide is to help educate Zcashers who are interested in running a full node on a low-powered Raspberry Pi 4.
 
+> **Note:** zcashd is being [deprecated](https://z.cash/support/zcashd-deprecation/) in favour of [Zebra](https://github.com/ZcashFoundation/zebra) (`zebrad`) for the node and [Zallet](https://github.com/zcash/zallet) for the wallet. This guide is kept as a legacy reference for existing zcashd setups; for a new full node, use Zebra and follow the [Migration Guide: zcashd to Zebrad/Zallet](https://zechub.wiki/migration-guide-zcashd-to-zebrad-zallet).
+
 <img src="https://user-images.githubusercontent.com/81990132/197372541-dcd886ab-a3d0-4614-b490-0294ddf3ffae.png" alt="zcashd" width="700" height="700"/>
 
 


### PR DESCRIPTION
Hey @dismad 👋

Following up on #1880 with the fix. This adds a short deprecation note to the top of the Raspberry Pi 4 full-node guide, so anyone landing on it sees that zcashd is on its way out before they start compiling.

It's intentionally light-touch: just the note, with the existing zcashd steps left in place as a legacy reference. The wording and links mirror what's already on the Full Nodes and Full Node Tutorials pages, so it stays consistent with how the rest of the wiki handles this.

I also double-checked that all four links resolve (the deprecation announcement, Zebra, Zallet, and the migration guide).

Closes #1880

Thanks for the quick turnaround on the issue!
