### PR TITLE
Update and standardize Pepper Sync page

### DIFF
--- a/site/Zcash_Tech/Pepper_Sync.md
+++ b/site/Zcash_Tech/Pepper_Sync.md
@@ -1,16 +1,29 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Tech/Pepper_Sync.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
+
 # Zingo 2.0 - Pepper Sync
 
-## INTRODUCTION
+## TL;DR
+
+* Pepper Sync is the synchronization engine introduced in Zingo! 2.0, the open-source Zcash wallet built by Zingo Labs.
+* It uses non-linear synchronization instead of scanning the chain in large sequential chunks, so your balance and transactions appear far sooner.
+* Progress is saved continuously. If the connection drops or the app closes, syncing resumes from where it stopped rather than restarting.
+* You can spend before synchronization has finished.
+* Shielded transactions remain private throughout the whole process.
+
+## Core Explanation
+
 Zingo 2.0 is the latest version of the Zingo! wallet, a lightweight, open-source wallet built for the Zcash community. The star of this release is Pepper Sync, a major upgrade that completely rethinks how wallets connect with the blockchain.
 
-In the past, syncing could feel painfully slow, error-prone, and resource heavy sometimes forcing users to restart from scratch. Pepper Sync changes all that. It makes syncing faster, smoother, more reliable, and less demanding on your device, while fully preserving the privacy of shielded transactions.
+In the past, syncing could feel painfully slow, error-prone, and resource-heavy, sometimes forcing users to restart from scratch. Pepper Sync changes all that. It makes syncing faster, smoother, more reliable, and less demanding on your device, while fully preserving the privacy of shielded transactions.
 
 Whether you're a brand-new user testing Zcash for the first time, or a long-time community member managing multiple shielded wallets, Pepper Sync makes the experience far more practical and enjoyable.
 
----
+### Core features of Pepper Sync
 
-## CORE FEATURES OF PEPPER SYNC
 Pepper Sync introduces several improvements:
+
 - Much Faster Syncing - Your wallet is ready in minutes, not hours.
 - Smart Updates - Data is processed in smaller chunks, avoiding full rescans.
 - Resilient to Interruptions - If your connection drops, syncing resumes where it left off.
@@ -18,70 +31,35 @@ Pepper Sync introduces several improvements:
 - Clearer Feedback - Real-time progress updates reduce confusion.
 - Privacy-Preserving - Shielded transactions remain private throughout the process.
 
----
+### What's better than before
 
-## WHAT'S BETTER THAN BEFORE
 Older versions of Zingo often frustrated users with long syncing times, unclear error handling, and heavy resource usage. Pepper Sync fixes these common issues:
 
-<div className="overflow-x-auto my-8">
-  <table className="w-full min-w-[640px] max-w-[950px] mx-auto border-collapse shadow-xl rounded-2xl overflow-hidden dark:shadow-2xl">
-    <thead>
-      <tr>
-        <th className="bg-emerald-400 dark:bg-emerald-700 text-white px-4 py-4 sm:px-6 sm:py-5 text-left font-bold text-base sm:text-lg tracking-tight">Feature</th>
-        <th className="bg-emerald-400 dark:bg-emerald-700 text-white px-4 py-4 sm:px-6 sm:py-5 text-left font-bold text-base sm:text-lg tracking-tight">Previous Zingo Versions</th>
-        <th className="bg-emerald-400 dark:bg-emerald-700 text-white px-4 py-4 sm:px-6 sm:py-5 text-left font-bold text-base sm:text-lg tracking-tight">Zingo 2.0 with Pepper Sync</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr className="bg-slate-50 hover:bg-slate-100 dark:bg-slate-800 dark:hover:bg-slate-700">
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 font-semibold text-slate-800 dark:text-slate-200">Sync Speed</td>
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300">Slower, especially on first setup</td>
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 bg-emerald-50 dark:bg-emerald-950 font-medium text-emerald-800 dark:text-emerald-300">Much faster initial and ongoing sync</td>
-      </tr>
-      <tr className="hover:bg-slate-100 dark:hover:bg-slate-700">
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 font-semibold text-slate-800 dark:text-slate-200">Error Handling</td>
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300">Occasional stalls and unclear failures</td>
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 bg-emerald-50 dark:bg-emerald-950 font-medium text-emerald-800 dark:text-emerald-300">Improved stability with automatic recovery</td>
-      </tr>
-      <tr className="bg-slate-50 hover:bg-slate-100 dark:bg-slate-800 dark:hover:bg-slate-700">
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 font-semibold text-slate-800 dark:text-slate-200">User Experience</td>
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300">Sync felt "opaque" to newcomers</td>
-        <td className="px-4 py-4 sm:px-6 sm:py-5 border-b border-slate-200 dark:border-slate-700 bg-emerald-50 dark:bg-emerald-950 font-medium text-emerald-800 dark:text-emerald-300">Transparent, with clearer status and updates</td>
-      </tr>
-      <tr className="hover:bg-slate-100 dark:hover:bg-slate-700">
-        <td className="px-4 py-4 sm:px-6 sm:py-5 font-semibold text-slate-800 dark:text-slate-200">Device Performance</td>
-        <td className="px-4 py-4 sm:px-6 sm:py-5 text-slate-700 dark:text-slate-300">High CPU/memory usage</td>
-        <td className="px-4 py-4 sm:px-6 sm:py-5 bg-emerald-50 dark:bg-emerald-950 font-medium text-emerald-800 dark:text-emerald-300">Optimized for smooth resource use</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+| Feature            | Previous Zingo Versions                | Zingo 2.0 with Pepper Sync                   |
+| ------------------ | -------------------------------------- | -------------------------------------------- |
+| Sync Speed         | Slower, especially on first setup      | Much faster initial and ongoing sync         |
+| Error Handling     | Occasional stalls and unclear failures | Improved stability with automatic recovery   |
+| User Experience    | Sync felt "opaque" to newcomers        | Transparent, with clearer status and updates |
+| Device Performance | High CPU/memory usage                  | Optimized for smooth resource use            |
 
 In short: syncing is now faster, more reliable, and easier to understand.
 
----
+## Visual / Analogy
 
-## WHO BENEFITS FROM PEPPER SYNC?
-- New Users - Can set up wallets quickly without being discouraged by delays.
-- Daily Users - Reliable syncing makes shielded payments practical for everyday use.
-- Developers & Testers - Shorter sync times mean faster testing cycles.
-- Mobile & Light Devices - Zingo now runs efficiently even on resource-limited hardware.
+Think of an older wallet sync like reading a very long book from page one, out loud, before you are allowed to say anything about it. Stop halfway, and you start again from page one. Pepper Sync reads the same book, but it keeps a bookmark, reads the chapters that matter to you first, and lets you talk about the story before you have finished the last page.
 
----
+The bookmark is the important part. Every previous version treated an interrupted sync as wasted work; Pepper Sync treats it as a pause.
 
-## WHY IT MATTERS FOR ZCASH
-Zcash is built around shielded transactions, one of the most powerful privacy tools in cryptocurrency. But privacy is only useful if it's accessible.
+### Visual guides
 
-Pepper Sync helps by:
-- Lowering barriers to entry - New users can get started quickly.
-- Supporting everyday usability - Shielded addresses become easier to trust.
-- Encouraging ecosystem growth - A better wallet experience drives more adoption, apps, and services.
+- Detailed Flow - Shows the full process. ![Detailed Flow](https://github.com/user-attachments/assets/119c13ec-76be-42bd-b558-762d09275a1b)
 
-By improving the wallet experience, Pepper Sync strengthens the entire Zcash ecosystem.
+- Simplified Flow - Quick view for everyday users. ![Simplified Flow](https://github.com/user-attachments/assets/9b612cbd-f24d-4472-9b87-0f2c908bb368)
 
----
+## Deep Dive
 
-## HOW PEPPER SYNC WORKS (SIMPLE VIEW)
+### How Pepper Sync works (simple view)
+
 Instead of rescanning the blockchain in huge, clunky chunks, Pepper Sync works in small, manageable steps—always saving your place as it goes.
 
 1. Connect - Wallet checks in with the network.
@@ -92,50 +70,85 @@ Instead of rescanning the blockchain in huge, clunky chunks, Pepper Sync works i
 6. Save Progress - Stops and resumes seamlessly.
 7. Finish - Wallet is ready to transact.
 
-### VISUAL GUIDES:
-- Detailed Flow - Shows the full process. ![Detailed Flow](https://github.com/user-attachments/assets/119c13ec-76be-42bd-b558-762d09275a1b)
+## Practical Implications
 
-- Simplified Flow - Quick view for everyday users. ![Simplified Flow](https://github.com/user-attachments/assets/9b612cbd-f24d-4472-9b87-0f2c908bb368)
+### Who benefits from Pepper Sync?
 
----
+- New Users - Can set up wallets quickly without being discouraged by delays.
+- Daily Users - Reliable syncing makes shielded payments practical for everyday use.
+- Developers & Testers - Shorter sync times mean faster testing cycles.
+- Mobile & Light Devices - Zingo now runs efficiently even on resource-limited hardware.
 
-## GETTING STARTED: ONBOARDING WITH ZINGO 2.0
-1. Download the Wallet - Get the right version from the Zingo GitHub releases page[](https://github.com/zingolabs/zingolib?utm_source=chatgpt.com)
-2. Set Up Your Wallet - Create a new one or restore from an existing seed phrase. Zingo 2.0 with Zingo Labs[](https://www.youtube.com/watch?v=FREwMzf_LlM)
-3. Let Pepper Sync Run - Watch the progress indicators as your wallet updates. Pepper Sync Run[](https://x.com/ZingoLabs/status/1961871338441724191)
+### Why it matters for Zcash
+
+Zcash is built around shielded transactions, one of the most powerful privacy tools in cryptocurrency. But privacy is only useful if it's accessible.
+
+Pepper Sync helps by:
+
+- Lowering barriers to entry - New users can get started quickly.
+- Supporting everyday usability - Shielded addresses become easier to trust.
+- Encouraging ecosystem growth - A better wallet experience drives more adoption, apps, and services.
+
+By improving the wallet experience, Pepper Sync strengthens the entire Zcash ecosystem.
+
+### Getting started: onboarding with Zingo 2.0
+
+1. Download the Wallet - Get the right version from the [Zingo GitHub releases page](https://github.com/zingolabs/zingolib)
+2. Set Up Your Wallet - Create a new one or restore from an existing seed phrase. [Zingo 2.0 with Zingo Labs](https://www.youtube.com/watch?v=FREwMzf_LlM)
+3. Let Pepper Sync Run - Watch the progress indicators as your wallet updates. [Pepper Sync Run](https://x.com/ZingoLabs/status/1961871338441724191)
 4. Start Using Zcash - Send and receive shielded ZEC as soon as syncing completes.
 5. Relax About Interruptions - If the app closes or connection drops, Pepper Sync resumes automatically.
 
----
+## Common Mistakes
 
-## FAQ - COMMON QUESTIONS
-**Q: Do I have to rescan every time I open the wallet?**  
+**Treating Pepper Sync as a wallet in its own right**. Pepper Sync is the synchronization engine inside the Zingo! wallet, not a separate application. You install Zingo; Pepper Sync is what runs underneath it.
+
+**Assuming faster syncing means weaker privacy**. The speed comes from how block data is fetched, ordered, and cached, not from revealing more information. Shielded transactions stay private throughout.
+
+**Assuming you must be fully synced before you can spend**. Spending before synchronization completes is one of the headline features of Pepper Sync, so you do not have to wait for the wallet to reach the chain tip.
+
+## FAQ - Common questions
+
+**Q: Do I have to rescan every time I open the wallet?**
+
 A: No. Pepper Sync saves progress, so you only update from the last point.
 
-**Q: What happens if my internet disconnects?**  
+**Q: What happens if my internet disconnects?**
+
 A: Sync pauses and continues later without restarting.
 
-**Q: Is my privacy safe while syncing?**  
+**Q: Is my privacy safe while syncing?**
+
 A: Yes. Shielded transactions remain fully private.
 
-**Q: How long does the first sync take?**  
+**Q: How long does the first sync take?**
+
 A: Usually minutes instead of hours, depending on your device and internet.
 
-**Q: Can I use the wallet before syncing finishes?**  
-A: You'll need to be synced to the chain tip, but Pepper Sync gets you there much faster.
+**Q: Can I use the wallet before syncing finishes?**
 
----
+A: Yes. Pepper Sync supports spending before synchronization has completed, so you do not need to wait for the wallet to reach the chain tip.
 
-## RESOURCES & REFERENCES
-- Zingo! GitHub Repository[](https://github.com/zingolabs/zingolib?utm_source=chatgpt.com)
-- Zcash Community Forum[](https://forum.zcashcommunity.com/?utm_source=chatgpt.com)
-- Official Announcements - Zingo Labs Twitter[](https://twitter.com/ZingoLabs?utm_source=chatgpt.com)
+## Conclusion
 
----
-
-## CONCLUSION
 With Zingo 2.0 Pepper Sync, syncing is no longer the biggest pain point of shielded wallets. It's now fast, stable, and user-friendly, lowering the barrier for newcomers and making everyday use far more practical.
 
 For users, it means less waiting and more privacy. For developers, it means a stronger foundation to build on. For the Zcash ecosystem, it's another step toward making shielded transactions accessible to everyone.
 
-Zingo 2.0 with Pepper Sync isn't just an upgrade, it's a leap forward for private, usable crypto.
+Zingo 2.0 with Pepper Sync isn't just an upgrade; it's a leap forward for private, usable crypto.
+
+## Related Pages
+
+- [Zcash Wallet Syncing](/zcash-tech/zcash-wallet-syncing) — how wallet synchronization works across the Zcash ecosystem.
+- [Lightwallet Nodes](/zcash-tech/lightwallet-nodes) — the infrastructure a light wallet such as Zingo syncs against.
+- [Zaino](/zcash-tech/zaino) — the indexer developed by the Zingo team.
+- [Wallets](/wallets) — the full directory of Zcash wallets and their features.
+
+## Further Learning
+
+- [Zingo! GitHub Repository](https://github.com/zingolabs/zingolib)
+- [Zcash Community Forum](https://forum.zcashcommunity.com/)
+- Official Announcements - [Zingo Labs Twitter](https://twitter.com/ZingoLabs)
+
+___
+___


### PR DESCRIPTION
Applies the ZecHub content template to site/Zcash_Tech/Pepper_Sync.md, matching
the structure of the recently merged FROST.md and Zcash_Wallet_Syncing.md.

Structure: Title → TL;DR → Core Explanation → Visual / Analogy → Deep Dive →
Practical Implications → Common Mistakes → FAQ → Conclusion → Related Pages →
Further Learning.

Preserved: all original prose, the comparison table, the 7-step flow, the FAQ,
the conclusion and both diagrams. Sections reordered, not rewritten.

Markup fixes:
- 6 links had empty anchor text — "label[](url)" — so nothing was clickable.
  Rewrapped around the existing label text; no wording changed.
- Removed 4 "?utm_source=chatgpt.com" tracking parameters.

One factual correction: the FAQ stated that a user must be synced to the chain
tip before spending. Spending before sync completes is a headline Pepper Sync
feature. Sources:
- https://forum.zcashcommunity.com/t/zingo-2-0-sync-with-max-zing/51652/4
- https://zingolabs.github.io/zingo/
- Zingo! listing on the App Store
The wiki's own Wallets page already lists "Spend before Sync" for Zingo.


CI note: the protected-terms check will flag this PR as well — the new
Related Pages section introduces "Zaino", and 18 translations of this page
exist without it. Same situation and same resolution options as #1883.