### PR TITLE
Add Zcash Ecosystem Digest | July 25th

### DIFF
--- a/newsletter/Digest 07-25-26.md
+++ b/newsletter/Digest 07-25-26.md
@@ -1,0 +1,385 @@
+# Zcash Ecosystem Digest | July 25th
+
+Dive into the Zebra 6.2.1 and 6.1.0 Security Releases, Zebra 6.2.0 Adds zcashd-Compat Mode, NU6.3 "Ironwood" Mainnet Activation Set for July 28th, Zakura Full Node Announced by Valar Group and Project Tachyon, Zcash Foundation Welcomes Zakura, zcashd Reaches End of Life at Block 3,417,100, ZODL Ships Ironwood Migration with "Migrate Privately", Shielded Labs Zero Adds Full Ironwood Support, Zcon7 Applications Open for Cancún, ZecHub Hackathon 3.0 with 33 New Projects, ZCG Meeting Minutes for July 6th and July 20th, Closing the ZCG Vulnerability Bounty Program, Zcash Türkiye ZecMap Merchant Directory, LiveZEC Shielded Tipping for Streamers, Sovright Argos Recovers Abandoned ZEC, 80% of ZEC Emissions Now Mined, and Boston Zcash Ironwood Launch Meetup with Zooko
+
+Curated by [DanielDerefaka](https://github.com/DanielDerefaka)
+
+## Shielded Labs, ZODL, Zcash Foundation, and Zcash Updates 🛠️
+
+[Zebra 6.2.1 Release: Two Security Hardening Improvements, No Resync Needed - @ZcashFoundation](https://zfnd.org/zebra-6-2-1-release/)
+
+[Zebra 6.2.1 Release Announcement on the Forum - @ZcashFoundation](https://forum.zcashcommunity.com/t/zebra-6-2-1-release/56780)
+
+[Zebra 6.2.1 is Out: Chain Synchronization and Mempool Verification Hardening - @zfnd.org](https://bsky.app/profile/zfnd.org/post/3mrd2lyn2rg2y)
+
+[Zebra v6.2.0 Adds Experimental zcashd-Compat Mode for Exchanges - @ZcashFoundation](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.0)
+
+[Zebra 6.1.0 Release: Adds getstandardfee RPC and Fixes Four Security Issues - @ZcashFoundation](https://zfnd.org/zebra-6-1-0-release/)
+
+[Zebra 6.1.0 Release Thread - @ZcashFoundation](https://forum.zcashcommunity.com/t/zebra-6-1-0-release/56714)
+
+[Zebra, Zakura, and the Road Through NU6.3 - @ZcashFoundation](https://zfnd.org/zebra-zakura-and-the-road-through-nu6-3/)
+
+[Zcash Foundation Welcomes Zakura, the New Full Node Built From the Zebra Codebase - @zfnd.org](https://bsky.app/profile/zfnd.org/post/3mqs7tkj32x2a)
+
+[Zebra, Zakura and the Road Through NU6.3 - Forum Discussion - @ZcashFoundation](https://forum.zcashcommunity.com/t/zebra-zakura-and-the-road-through-nu6-3/56703)
+
+[Zebra 6.0.0 Release: Stable NU6.3 "Ironwood" Support with New Shielded Pool and v6 Transactions - @ZcashFoundation](https://zfnd.org/zebra-6-0-0-release/)
+
+[Zebra 6.0.0 Release Thread - @ZcashFoundation](https://forum.zcashcommunity.com/t/zebra-6-0-0-release/56607)
+
+[ZF Engineering Update - 29th June to 12th July 2026 - @ZcashFoundation](https://forum.zcashcommunity.com/t/zf-engineering-update-29th-june-to-12th-july-2026/56667)
+
+[ZF Engineering Update: Zebra v6.0.0 Ships With Full NU6.3 Ironwood Support - @zfnd.org](https://bsky.app/profile/zfnd.org/post/3mqmlxtkmxl2n)
+
+[Accepting Applications for Zcon7: October 27–29, 2026 in Cancún, Mexico - @ZcashFoundation](https://forum.zcashcommunity.com/t/accepting-applications-for-zcon7-october-27-29-2026-in-cancun-mexico/56175)
+
+[Ironwood Update for Users - @zooko](https://forum.zcashcommunity.com/t/ironwood-update-for-users/56721)
+
+[Ironwood is Active on testnet.zec.rocks - @emersonian](https://forum.zcashcommunity.com/t/ironwood-is-active-on-testnet-zec-rocks/56557)
+
+[Zcash Z3 Updates (formerly Zcashd Deprecation) - @pacu](https://forum.zcashcommunity.com/t/zcash-z3-updates-formerly-zcashd-deprecation/48965)
+
+[Shielded Labs Zero v21: Peers Submitting Invalid Shielded Proofs Are Now Banned - @ShieldedLabs](https://github.com/ShieldedLabs/zero/releases)
+
+[Crosslink Monolith Season 2 Version 9 - Bugfixes Release - @ShieldedLabs](https://github.com/ShieldedLabs/crosslink_monolith/releases/tag/s2v9)
+
+[Crosslink: Incentivized Feature Net - @aquietinvestor](https://forum.zcashcommunity.com/t/crosslink-incentivized-feature-net/55210)
+
+[Zodl Android 3.7.2 Release: Streamlined Swap and Pay Asset List - @zodl_app](https://github.com/zodl-inc/zodl-android/releases/tag/3.7.2-2009)
+
+[Zodl 3.7.0: Improved Transaction Reliability - @zodl_app](https://zodl.com/zodl-3-7-0-improved-transaction-reliability/)
+
+[ZODL Makes Ironwood Migration Simple: Choose "Migrate Privately" for Standardized Amounts and Scheduling - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mr6dkzjllk25)
+
+[ZODL Statement on zcashd: Service Ends July 18th as the Ecosystem Moves to Rust-Based Clients - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mqmjlocd4m2s)
+
+[Zebra 6.1.0 Now Available: A Security Release Fixing Four Issues With No Consensus Changes - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mr4lljudo22u)
+
+[Ironwood Mainnet Activation Height Is Set and All Major Organizations Have Committed to NU6.3 - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mqmyph7v5e2s)
+
+[80% of ZEC Emissions Have Now Been Mined - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mr64tvscm72r)
+
+[NU6.2 Updated Wallets List - @Autotunafish](https://forum.zcashcommunity.com/t/nu6-2-updated-wallets-list/56011)
+
+[Zallet RPC Quick Reference - @dismad](https://forum.zcashcommunity.com/t/zallet-rpc-quick-reference/56761)
+
+[Zainod Release Announcements - @zancas](https://forum.zcashcommunity.com/t/zainod-release-announcements/55845)
+
+[New Version of Zingo-PC - @zancas](https://forum.zcashcommunity.com/t/new-version-of-zingo-pc/45359)
+
+---
+
+## Zcash Community Grants 🏛️
+
+[Zcash Community Grants (ZCG) Meeting Minutes 7/20/2026 - @ZCG](https://forum.zcashcommunity.com/t/zcash-community-grants-zcg-meeting-minutes-7-20-2026/56763)
+
+[Zcash Community Grants (ZCG) Meeting Minutes 7/6/2026 - @ZCG](https://forum.zcashcommunity.com/t/zcash-community-grants-zcg-meeting-minutes-7-6-2026/56577)
+
+[Closing the ZCG Vulnerability Bounty Program - @ZCG](https://forum.zcashcommunity.com/t/closing-the-zcg-vulnerability-bounty-program/55855)
+
+[June ZCG Election: Nomination Period Closed, Questions for Candidates and New Format Announcement - @FPF](https://forum.zcashcommunity.com/t/june-zcg-election-nomination-period-closed-need-questions-for-candidates-new-format-announcement/56102)
+
+[ZCG Communication Guidelines - @aquietinvestor](https://forum.zcashcommunity.com/t/zcg-communication-guidelines/44284)
+
+[Paul Brigner for ZCG (June 2026) - @paulbrigner](https://forum.zcashcommunity.com/t/paul-brigner-for-zcg-june-2026/55738)
+
+[Request for Specific Feedback on Rejected Grant Application #352 (Pure Go Zcash Parser) - @cexpepe](https://forum.zcashcommunity.com/t/request-for-specific-feedback-on-rejected-grant-application-352-pure-go-zcash-parser/56776)
+
+[Grant Application: Pure Go Zero-Dependency Zcash Transaction Blob Parser - @cexpepe](https://forum.zcashcommunity.com/t/grant-application-pure-go-zero-dependency-zcash-transaction-blob-parser/56637)
+
+[Grant Application: Zk-CosmWasm, a Programmable Selective Disclosure WebAssembly Smart Contract VM - @hard-nett](https://forum.zcashcommunity.com/t/grant-application-zk-cosmwasm-a-programmable-selective-disclosure-webassembly-smart-contract-virtual-machine/54211)
+
+[Grant Application - Zcash Indexer Observatory - @oabagit](https://forum.zcashcommunity.com/t/grant-application-zcash-indexer-observatory/56506)
+
+[Grant Application - Zcash Explained: Educational Media Series by BlockDesk News - @BlockDeskNews](https://forum.zcashcommunity.com/t/grant-application-zcash-explained-educational-media-series-by-blockdesk-news/56563)
+
+[Grant Application - Batch-vs-Single Verification Equivalence: Continuous Soundness Fuzzing for Zcash - @robustfengbin](https://forum.zcashcommunity.com/t/grant-application-batch-vs-single-verification-equivalence-continuous-soundness-fuzzing-for-zcash-shielded-verification-incl-ironwood/56308)
+
+[Grant Application - Zcash Light Client Privacy Transport Library - @Crackdevs](https://forum.zcashcommunity.com/t/grant-application-zcash-light-client-privacy-transport-library/56592)
+
+[Grant Application - Turnstile Migration Integration Kit - @soloking](https://forum.zcashcommunity.com/t/grant-application-turnstile-migration-integration-kit/56700)
+
+[Grant Application - Chadwick Bailey - @chadwickmbailey](https://forum.zcashcommunity.com/t/grant-application-chadwick-bailey/56627)
+
+[FROST Shielded Multi-Sig SDK: Easy Threshold Custody for Zcash Wallets - @mahmudsudo](https://forum.zcashcommunity.com/t/frost-shielded-multi-sig-sdk-easy-threshold-custody-for-zcash-wallets-grant-application/56608)
+
+[Grant Application - Zebra Mempool Adversarial Resilience Suite - @deucali0n10](https://forum.zcashcommunity.com/t/grant-application-zebra-mempool-adversarial-resilience-suite/56740)
+
+[Grant Application - ZECsy Team Marketing at Cypherpunk Week in Amsterdam - @readymouse](https://forum.zcashcommunity.com/t/grant-application-zecsy-team-marketing-at-cypherpunk-week-in-amsterdam/56509)
+
+[Grant Application - Offensive Security #340 - @phill](https://forum.zcashcommunity.com/t/grant-application-offensive-security-340/56474)
+
+[Grant Application - Zcash in the Privacy Stack (#339) - @proofstreet](https://forum.zcashcommunity.com/t/grant-application-zcash-in-the-privacy-stack-339/56456)
+
+[Grant Application: ZecDev Launchpad - One-Command Zebra Devnet and Reusable CI - @DappsoverApps](https://forum.zcashcommunity.com/t/grant-application-zecdev-launchpad-one-command-zebra-devnet-reusable-ci/52472)
+
+[Grant Application: Tensor-Core Accelerated Proving for Orchard/Ironwood - @strahncryptography](https://forum.zcashcommunity.com/t/grant-application-tensor-core-accelerated-proving-for-orchard-ironwood/56664)
+
+[Grant Application - Constant-Time Hardening and Explicit Timing Semantics for Zcash Rust Cryptography - @fdecroix](https://forum.zcashcommunity.com/t/grant-application-constant-time-hardening-and-explicit-timing-semantics-for-zcash-rust-cryptography/56503)
+
+[Grant Application – Educating Communities by Educating Their Leaders (ZCLN) - @CryptoEpoch](https://forum.zcashcommunity.com/t/grant-application-educating-communities-by-educating-their-leaders-zcln/56673)
+
+[Grant Application - Grassroots Marketing Team at DWeb Camp - @readymouse](https://forum.zcashcommunity.com/t/grant-application-grassroots-marketing-team-at-dweb-camp/55472)
+
+[Zcash Community Media Infrastructure and Support | Zk Av Club 2026 - @ryan.taylor](https://forum.zcashcommunity.com/t/zcash-community-media-infrastructure-support-zk-av-club-2026/53913)
+
+[Zcash Türkiye RLAY HUB Event Grant - @Batuhan](https://forum.zcashcommunity.com/t/zcash-turkiye-rlay-hub-event/56562)
+
+[Zcash Türkiye 2026 Q3-Q4 and 2027 Proposal - @Batuhan](https://forum.zcashcommunity.com/t/zcash-turkiye-2026-q3-4-2027-q1-2-3-4/56274)
+
+[Zcash Arabia (June to September 2026) - @ZArabia](https://forum.zcashcommunity.com/t/zcash-arabia-june-to-september-2026/56580)
+
+[Zchat - Shielded Messenger Retroactive Grant - @decentrathai](https://forum.zcashcommunity.com/t/zchat-shielded-messenger-retroactive-grant/54543)
+
+[Grant Update: Zcash Ecosystem Security Lead - @Liz315](https://forum.zcashcommunity.com/t/grant-update-zcash-ecosystem-security-lead/47541)
+
+[Questions Before I Apply: Independent Security Review of red·bridge Architecture - @soloking](https://forum.zcashcommunity.com/t/questions-before-i-apply-independent-security-review-of-red-bridge-architecture/56775)
+
+[Threshold (FROST) Custody for Shielded ZEC: Design Check Before a ZCG Application - @aryaethn](https://forum.zcashcommunity.com/t/threshold-frost-custody-for-shielded-zec-design-check-before-a-zcg-application/56660)
+
+[ZecHub DAO — Proposal A149: Phase 1 Progress Report - @bloxster](https://forum.zcashcommunity.com/t/zechub-dao-proposal-a149-phase-1-progress-report/56030)
+
+[ZecHub 2026 - @squirrel](https://forum.zcashcommunity.com/t/zechub-2026/53686)
+
+---
+
+## Community Projects 🌐
+
+[Zcash Shielded News | Vol.28 - @ZecHub](https://zechub.substack.com/p/zcash-shielded-news-vol28-2fd)
+
+[Zcash Shielded News | Vol.27 - @ZecHub](https://zechub.substack.com/p/zcash-shielded-news-vol27)
+
+[Zcash Ecosystem Digest | July 19th - @ZecHub](https://zechub.substack.com/p/zcash-ecosystem-digest-july-19th)
+
+[Zcash Ecosystem Digest | July 12th - @ZecHub](https://zechub.substack.com/p/zcash-ecosystem-digest-july-12th)
+
+[ZecHub Updates | July 21, 2026 - @ZecHub](https://zechub.substack.com/p/zechub-updates-july-21-2026)
+
+[ZecHub Hackathon 3.0 Is Live! - @dismad](https://forum.zcashcommunity.com/t/zechub-hackathon-3-0-is-live/55831)
+
+[33 Brand New Zcash Hackathon Projects Are Ready for Your Feedback - @zechub.bsky.social](https://bsky.app/profile/zechub.bsky.social/post/3mqpbw3glks2m)
+
+[Road to Ironwood Part 2: The Orchard to Ironwood Turnstile Mechanism Explained - @zechub.bsky.social](https://bsky.app/profile/zechub.bsky.social/post/3mr6f4x5mqc2w)
+
+[Catch Up on the Latest ZecHub Sync Meeting Notes - @zechub.bsky.social](https://bsky.app/profile/zechub.bsky.social/post/3mrct3lhx5c2l)
+
+[Zcash Ecosystem Digest July 19th: Zakura Full Node, Zebra 6.1.0, zcashd Sunset, DWeb Camp - @zechub.bsky.social](https://bsky.app/profile/zechub.bsky.social/post/3mr3rahsmd22o)
+
+[Zcash Ecosystem Digest July 12th: NU6.3 Ironwood Activation Set for July 28th - @zechub.bsky.social](https://bsky.app/profile/zechub.bsky.social/post/3mqi5sfs4kc2e)
+
+[Introducing Zakura: A New Open Source Full Node Implementation Built to Scale, by Project Tachyon and Valar Group - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mrd5ruxfuc2s)
+
+[Abandoned ZEC: Recover Stranded Funds With Sovright's Free Argos Tool - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mrb43y25xg2j)
+
+[The ZecMap Manifesto: Register Your Business to Tell the World You Accept ZEC - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mratzp5fmz2j)
+
+[F-Droid Users Can Get New Zodl Releases Faster by Adding the Official Repository - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mrand3zfcr2r)
+
+[ZecMap: How to Register Your Business or Professional Profile to Accept ZEC - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mqs3rqpxbk2a)
+
+[Zcash Ecosystem Digest in Spanish - July 19th Edition - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mr6ikyehiu2j)
+
+[Zcash Shielded News Vol.27 in Spanish - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mr3gf7aplc24)
+
+[LeoDex Launches Full Zcash Support on leodex.io, the First Web App of Its Kind - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mr3mexmdqo2m)
+
+[Noir Wallet Is Now Available on the Zcash Global Discord for Support and Release News - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mqp7apx4xs22)
+
+[Dynamic Fees Are Now Available in Noir Wallet for Priority Delivery - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mqmqccmeeb23)
+
+[Spanish Language Tasks Are Now Open on the ZecHub Dework Board - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mqku3iy5sb2e)
+
+[Wallets, Explorers, Payment Processors, Maps and DEXs: Nobody Asked Permission, a Parallel Economy Is Built - @zcashesp.bsky.social](https://bsky.app/profile/zcashesp.bsky.social/post/3mqps4dv6sh2n)
+
+[Ironwood in Zcash: What It Means for Ordinary Users and How to Prepare - @zcashesp](https://zcashesp.com/ironwood-zcash-consideraciones-usuarios-comunes/)
+
+[Zcash Ecosystem Summary in Spanish - July 19th - @zcashesp](https://zcashesp.com/resumen-del-ecosistema-zcash-julio-19/)
+
+[Zcash Shielded News Volume 27 in Spanish - @zcashesp](https://zcashesp.com/zcash-shielded-news-volumen-27-2/)
+
+[Zcast Live #13: Zcash in the Real World - @ZcastEsp](https://www.youtube.com/watch?v=SaD-tVMDrfo)
+
+[The Spanish-Speaking Zcash Community Now Has Its Own Node - @gordonesTV](https://forum.zcashcommunity.com/t/the-spanish-speaking-zcash-community-now-has-its-own-node/55530)
+
+[The Spanish Zcash Community Node Is Live at panel.zcashesp.com - @zcastesp.bsky.social](https://bsky.app/profile/zcastesp.bsky.social/post/3mqenlyqm6i22)
+
+[Zcast and Zcash Meet the Ethereum Community in Barcelona - @zcastesp.bsky.social](https://bsky.app/profile/zcastesp.bsky.social/post/3mqqnz6srw726)
+
+[Another Way to Support the Z-Aid for Venezuela Campaign - @zcastesp.bsky.social](https://bsky.app/profile/zcastesp.bsky.social/post/3mqqpvgemz52y)
+
+[This Is the Z-Aid for Venezuela Campaign - @zcastesp.bsky.social](https://bsky.app/profile/zcastesp.bsky.social/post/3mqnymdcbfy2f)
+
+[Zcash for Venezuela! - @gordonesTV](https://forum.zcashcommunity.com/t/zcash-for-venezuela/56445)
+
+[Zcast, the Zcash Podcast in Spanish - A New Phase - @gordonesTV](https://forum.zcashcommunity.com/t/zcast-the-zcash-podcast-in-spanish-a-new-phase/54291)
+
+[Club Zcash Barcelona, the Journey Begins! - @gordonesTV](https://forum.zcashcommunity.com/t/club-zcash-barcelona-the-journey-begins/51247)
+
+[Welcome to the Zero-Knowledge Chess Club! - @gordonesTV](https://forum.zcashcommunity.com/t/welcome-to-the-zero-knowledge-chess-club/56475)
+
+[Zcash Club Querétaro-Mexico: Advancing Financial Privacy in Mexico - @palmar](https://forum.zcashcommunity.com/t/zcash-club-queretaro-mexico-advancing-financial-privacy-in-mexico/55764)
+
+[Nobody Validates For You: Full Nodes as an Analogy for Independent Human Verification - @zcashbrazil](https://zcashbrazil.substack.com/p/ninguem-valida-por-voce)
+
+[Shielded Magazine #27: Zakura Node, Zodl Ironwood Migration Paths, NU6.3 Activation and zcashd EOL - @zcashbrazil](https://zcashbrazil.substack.com/p/shielded-magazine-27)
+
+[Running the Old Version: A Reflection on Cycles, Courage and Refining Yourself - @zcashbrazil](https://zcashbrazil.substack.com/p/rodando-a-versao-antiga)
+
+[Legal Tech and Web3: The New Paths of Law - @ZcashBrasil](https://www.youtube.com/watch?v=tQUjXpv_Ims)
+
+[Protocol Study #6: Proving Without Revealing, zk-SNARKs in Zcash - @ZcashBrasil](https://www.youtube.com/watch?v=rcCHNY6A6zo)
+
+[Zakura Node and Tachyon | Zec Insider - @ZcashBrasil](https://www.youtube.com/watch?v=18pKZ63mm9E)
+
+[Milca0 Explains How to Connect Projects, Creators and Communities - @ZcashBrasil](https://www.youtube.com/watch?v=pyGwR4woPbc)
+
+[Zcash Türkiye Monthly Report, 19 June to 19 July 2026: ZecMap Growth and Flexa Merchant Talks - @Batuhan](https://forum.zcashcommunity.com/t/zcash-turkiye-2026-q3-4-2027-q1-2-3-4/56274/5)
+
+[The End of an Era: zcashd Has Retired - @ZcashTurkiye](https://www.youtube.com/shorts/9THjoqZ7Z4U)
+
+[Zakura v1.0.0: Zcash's Next Generation Full Node - @ZcashTurkiye](https://www.youtube.com/shorts/xQIvdkbdKRU)
+
+[Zaino 0.5.1 Is Now Available - @ZcashTurkiye](https://www.youtube.com/shorts/OHSbxc1fqrE)
+
+[ZECMAP – A Global Map for Businesses That Accept Zcash - @Batuhan](https://forum.zcashcommunity.com/t/zecmap-a-global-map-for-businesses-that-accept-zcash/55686)
+
+[Zec App Is Coming Soon! - @Batuhan](https://forum.zcashcommunity.com/t/zec-app-is-coming-soon/56605)
+
+[Shielded Wall Is Now Live — The Anonymous Confession Platform - @Batuhan](https://forum.zcashcommunity.com/t/shielded-wall-is-now-live-the-anonymous-confession-platform/56716)
+
+[Weekly Zcash Ecosystem Digest in Yoruba - July 19th Edition - @ZcashNigeria](https://zechubnigeria.substack.com/p/iwe-iroyin-ose-ose-lori-zcash-ati-80e)
+
+[Weekly Zcash Ecosystem Digest in Yoruba - July 12th Edition - @ZcashNigeria](https://zechubnigeria.substack.com/p/iwe-iroyin-ose-ose-lori-zcash-ati-be2)
+
+[Bringing Zcash to Web3Lagos 2026 - @Dre_Nesthub](https://forum.zcashcommunity.com/t/bringing-zcash-to-web3lagos-2026/56588)
+
+[Zcash Developer Sprint - @Dre_Nesthub](https://forum.zcashcommunity.com/t/zcash-developer-sprint/56582)
+
+[What If Buying Zcash Was as Easy as Buying Airtime? - @clemencedouglas](https://forum.zcashcommunity.com/t/what-if-buying-zcash-was-as-easy-as-buying-airtime/56593)
+
+[Obscura Labs: An Independent Non-US Organisation - @lisa001](https://forum.zcashcommunity.com/t/obscura-labs-an-independent-non-us-organisation/56325)
+
+[Zcash Ecosystem Summary in Swahili - July 12th Edition - @ZcashEastAfrica](https://zcasheastafrica.substack.com/p/muhtasari-wa-mfumo-wa-ikolojia-wa-902)
+
+[We Will Win: Recap of the ZODL Summit in Prague - @ruZcash](https://pro.zcash.ru/my-pobedim-sammit-zodl-2026)
+
+[Thank You, zcashd. Moving Forward - @ruZcash](https://pro.zcash.ru/zcashd-zavershil-rabotu)
+
+[Zakura: The New Zcash Node and Installation Guide - @ruZcash](https://pro.zcash.ru/zcash-zakura)
+
+[The Economics of Freedom - @ruZcash](https://pro.zcash.ru/ekonomika-svobody)
+
+[The Mechanism of Freedom Must Be Built - @ruZcash](https://pro.zcash.ru/mehanizm-svobody-nuzhno-postroit)
+
+[Zcash: Hard Money for a Confidential World - @ruZcash](https://pro.zcash.ru/zcash-tvyordye-dengi-dlya-konfidenczialnogo-mira)
+
+[Why Zcash Is Needed Right Now - @ruZcash](https://pro.zcash.ru/pochemu-imenno-sejchas-vremya-zcash)
+
+[Russian Language Zcash Blog at pro.zcash.ru - @artkor](https://forum.zcashcommunity.com/t/pro-zcash-ru/38485)
+
+[Learn to Use ZODL — ZK AV Club Community Workshop - @ZkAv_Club](https://www.youtube.com/watch?v=CsjI388pKt0)
+
+[New Community Workshop: Learn How to Use Zodl to Send, Receive and Protect Your ZEC - @zkavclub.bsky.social](https://bsky.app/profile/zkavclub.bsky.social/post/3mramyyvhb225)
+
+[First Public Workshop Program Update from the ZK AV Club - @zkavclub.bsky.social](https://bsky.app/profile/zkavclub.bsky.social/post/3mr5f3wfi3c2k)
+
+[ZK AV Club Community Workshops Are Scheduled Through December 2026 - @zkavclub.bsky.social](https://bsky.app/profile/zkavclub.bsky.social/post/3mqjo4e7z5s2d)
+
+[Last Day to Enter the Zcash Playlist Challenge - @zkavclub.bsky.social](https://bsky.app/profile/zkavclub.bsky.social/post/3mqozebr6ds2a)
+
+[Zcash Playlist Challenge: 25 Most Important Zcon Presentations - @ryan.taylor](https://forum.zcashcommunity.com/t/zcash-playlist-challenge-25-most-important-zcon-presentations/55914)
+
+[Boston Zcash Meetup – July 28 – Ironwood Launch Event featuring Zooko - @BostonZcash](https://forum.zcashcommunity.com/t/boston-zcash-meetup-july-28-ironwood-launch-event-ft-zooko/56748)
+
+[LiveZEC: ZEC Shielded Tipping for Streamers - @PacDc](https://forum.zcashcommunity.com/t/livezec-zec-shielded-tipping-for-streamers/56747)
+
+[The Sovright Relay: Live Now - @TheBootstrapOrg](https://forum.zcashcommunity.com/t/the-sovright-relay-live-now/56769)
+
+[Announcing the Zcash X Monitor, a New Feature for the PGPZ Community - @paulbrigner](https://forum.zcashcommunity.com/t/announcing-the-zcash-x-monitor-a-new-feature-for-the-pgpz-community/56760)
+
+[PGPZ Community Weekly Policy Memos - @paulbrigner](https://forum.zcashcommunity.com/t/pgpz-community-weekly-policy-memos/56324)
+
+[Lightwalletd-rs: A Rust Implementation of Lightwalletd for Light Wallets - @Joaco](https://forum.zcashcommunity.com/t/lightwalletd-rs-a-rust-implementation-of-lightwalletd-for-light-wallets/56779)
+
+[CipherScan 2026 - Privacy Intelligence for Zcash - @Kenbak](https://forum.zcashcommunity.com/t/cipherscan-2026-privacy-intelligence-for-zcash/54151)
+
+[Ztrash - Disposable Email Powered by Zcash - @NoFace](https://forum.zcashcommunity.com/t/ztrash-disposable-email/56720)
+
+[VeilNFC – Private NFC Collectibles on Zcash - @carbanak](https://forum.zcashcommunity.com/t/veilnfc-private-nfc-collectibles-on-zcash/56764)
+
+[What If Private Messaging Was Completely Future-Proof? Introducing Ursa Chat - @dbsc](https://forum.zcashcommunity.com/t/what-if-private-messaging-was-completely-future-proof-introducing-ursa-chat/56670)
+
+[Introducing Gleyo, A ZEC-Native Quest and Community Growth Platform - @gilmore](https://forum.zcashcommunity.com/t/introducing-gleyo-a-zec-native-quest-community-growth-platform-zechub-hackathon-3-0/56672)
+
+[Gleyo, Post Hackathon Update - @gilmore](https://forum.zcashcommunity.com/t/gleyo-post-hackathon-update/56723)
+
+[Introducing the Noir Desktop App - @noir_wallet](https://forum.zcashcommunity.com/t/introduce-noir-desktop-app/56702)
+
+[Vizor Wallet Has Launched, But We Need Your Help - @dogemos](https://forum.zcashcommunity.com/t/vizor-wallet-has-launched-but-we-need-your-help/55719)
+
+[Zkool - The Successor to Ywallet - @hanh](https://forum.zcashcommunity.com/t/zkool-the-successor-to-ywallet/51139)
+
+[NozyWallet Ironwood (NU6.3): Migration Case Breakdown and v2.4.0 CLI Release - @Lowo88](https://forum.zcashcommunity.com/t/nozywallet-ironwood-nu6-3-migration-case-breakdown-and-v2-4-0-cli-release/56568)
+
+[Safer Ironwood Migration IP From NozyWallet - @Lowo88](https://forum.zcashcommunity.com/t/safer-ironwood-migration-ip-from-nozywallet/56609)
+
+[MonteZecret: A Desktop Wallet for Zcash Written in Rust - @topcrypto](https://forum.zcashcommunity.com/t/montezecret-a-desktop-wallet-for-zcash-in-rust-instead-of-tweets/56164)
+
+[A Flutter SDK for Zcash: FFI Over librustzcash With a Drop-In Shielded Wallet UI - @kamba888](https://forum.zcashcommunity.com/t/a-flutter-sdk-for-zcash-ffi-over-librustzcash-with-a-drop-in-shielded-wallet-ui/56639)
+
+[Gem Wallet Integration With Zcash - @Anzus_GemWallet](https://forum.zcashcommunity.com/t/gem-wallet-integration-with-zcash/53206)
+
+[Hello From KeepKey to the Zcash Community - @KeepKey](https://forum.zcashcommunity.com/t/zcash-community-hello-from-keepkey/55711)
+
+[Double Speedup Over State of the Art for Batched Same-Base MSM for Halo2 on Apple Silicon - @strahncryptography](https://forum.zcashcommunity.com/t/we-just-achieved-a-double-speedup-over-the-sota-pasta-curves-for-batched-same-base-msm-for-halo2-on-apple-silicon/56724)
+
+[Apple Silicon Zero-Knowledge Proving: Mobile Halo2 and Tachyon Acceleration - @strahncryptography](https://forum.zcashcommunity.com/t/apple-silicon-zero-knowledge-proving-mobile-halo2-and-tachyon-acceleration-on-m-series-and-a-series-chips/56725)
+
+[Openzcash.org | Public Transparency - @Michae2xl](https://forum.zcashcommunity.com/t/openzcash-org-public-transparency/56404)
+
+[Protocol Study Series: 12-Session Guided Reading of the Zcash Protocol Specification - @shieldedmark](https://forum.zcashcommunity.com/t/protocol-study-series-12-session-guided-reading-of-the-zcash-protocol-specification-starting-april-21/55350)
+
+[Building Zcash Products End-to-End - @gustavovalverde](https://forum.zcashcommunity.com/t/building-zcash-products-end-to-end/56647)
+
+[Mastering Zcash Video Series - @maxdesalle](https://forum.zcashcommunity.com/t/mastering-zcash-video-series/55204)
+
+[Zcash Protocol Reviewed with Mythos - @aquietinvestor](https://forum.zcashcommunity.com/t/zcash-protocol-reviewed-with-mythos/56183)
+
+[Donut Shop Owners Don't Need Zcash - @the_zero](https://forum.zcashcommunity.com/t/donut-shop-owners-dont-need-zcash/56471)
+
+[Is Anyone Actually Using Viewing Keys for Business Accounting? - @ZKZeek](https://forum.zcashcommunity.com/t/is-anyone-actually-using-viewing-keys-for-business-accounting/56300)
+
+[Decentralized Multi-Operator Light Client Infrastructure Optimized for Zakura - @jatinsahijwani](https://forum.zcashcommunity.com/t/idea-detailed-roadmap-decentralized-multi-operator-light-client-infrastructure-optimized-for-zakura-seeking-community-feedback-before-mvp/56727)
+
+[CodeZ: Just Another Source Code Mirror - @jenkin](https://forum.zcashcommunity.com/t/codez-just-another-source-code-mirror/54977)
+
+[Educating Communities by Educating Their Leaders - @CryptoEpoch](https://forum.zcashcommunity.com/t/educating-communities-by-educating-their-leaders/56321)
+
+[Zodl Everything, Captain - @Zebraman](https://forum.zcashcommunity.com/t/zodl-everything-captain/56598)
+
+[Positive Zcash News Aggregation Thread - @Zebraman](https://forum.zcashcommunity.com/t/positive-zcash-news-aggregation-thread/54674)
+
+---
+
+## Meme of the week 😊
+
+[Zcash Irondevs: A Gift to the Heroic Zcash Developers - @jenkin](https://forum.zcashcommunity.com/t/contest-presenting-zcash-irondevs-a-gift-to-the-heroic-zcash-developers/56666)
+
+---
+
+# Video Of the week
+
+[Road to Ironwood Part 2: The Orchard to Ironwood Turnstile Mechanism - @ZecHub](https://bsky.app/profile/zechub.bsky.social/post/3mr6f4x5mqc2w)
+
+[Zcast Live #13 - Zcash in the Real World - @ZcastEsp](https://www.youtube.com/watch?v=SaD-tVMDrfo)
+
+---
+
+## Jobs in the Ecosystem
+
+[Careers On ZODL - @zodl_app](https://zodl.com/careers/)
+
+[Dework tasks posted every Monday - ZecHub](https://app.dework.xyz/zechub-2424)
+
+[ZecHub Hackathon 3.0 - Build and Earn - @ZecHub](https://zechub.wiki/hackathon)


### PR DESCRIPTION
Adds newsletter/Digest 07-25-26.md, covering July 11 to 23. It picks up where the July 11th digest stopped.

The sections are the usual ones: Shielded Labs / ZODL / Zcash Foundation updates, Zcash Community Grants, Community Projects, Meme of the week, Video of the week and Jobs.

Main items this week are Zebra 6.0.0 through 6.2.1, the Zakura full node announcement and the Foundation's response to it, Ironwood mainnet activation being set for July 28, zcashd reaching end of life, and Zcon7 applications opening.

Community Projects has 107 links. Communities covered include Zcash en Español, Zcash Brazil, Zcash Türkiye, Zcash Nigeria, Zcash East Africa, ruZcash, ZK AV Club, Zcast, Zcash Arabia, Zcash Club Querétaro, Club Zcash Barcelona, Boston Zcash and ZecHub.

I ran a check over every link in the file and all 179 of them return 200. The descriptions were written from the actual content behind each link so they match. Posts in Spanish, Portuguese, Russian, Turkish, Yoruba and Swahili have English descriptions so the digest is easy to translate into other languages.

One gap: I couldn't find anything published between July 11 and 23 from Zcash Ukraine, Zcash Korea or genzcash. Their Substack and forum accounts have been quiet and their activity looks like it's on X only, so they aren't in this one. If someone can point me at links for them I'll add them.
