### PR TITLE
Add Ironwood readiness status to wallet entries

### DIFF
--- a/site/Using_Zcash/Wallets.md
+++ b/site/Using_Zcash/Wallets.md
@@ -5,6 +5,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Hardware
 - Pools: Transparent | Sapling | Orchard
 - Features: Address Book | CrossPay | Near Intents | Flexa Payments | MultiSignature | Payment Request | Shielded Memo | Spend before Sync | TEX Address | Tor Support | F-droid
+- Ironwood: Ready
 
 ---
 
@@ -15,6 +16,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Hardware
 - Pools: Transparent | Sapling | Orchard
 - Features: Address Book | Cold Storage | Diversified Address | Payment Request | Pool Transfer | Shielded Memo | TEX Address | Voting | WarpSync
+- Ironwood: Not Ready
 
 ---
 
@@ -35,6 +37,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address
 - Pools: Transparent | Sapling | Orchard
 - Features: Address Book | Financial Insights | Payment Request | PepperSync | Shielded Memo | Testnet Support
+- Ironwood: Ready
 
 ---
 
@@ -55,6 +58,7 @@
 - Wallet Support: Seed Phrase | Unified Address
 - Pools: Transparent | Sapling | Orchard
 - Features: DEX Swaps | Multi Coin | Spend before Sync
+- Ironwood: In Progress
 
 ---
 
@@ -75,6 +79,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Hardware
 - Pools: Transparent | Sapling | Orchard
 - Features: Address Rotation | Broad Key Support | Encrypted Exports | FROST Multisig | Multi-Account Sync | Shielded Memo | Testnet Support
+- Ironwood: Ready
 
 ---
 
@@ -105,6 +110,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Full Node
 - Pools: Transparent | Sapling | Orchard
 - Features: Command Line Interface | PepperSync | Shielded Memo | Testnet Support 
+- Ironwood: In Progress
 
 ---
 
@@ -115,6 +121,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Full Node
 - Pools: Transparent | Sapling | Orchard
 - Features: Alpha Release | JSON-RPC Interface | Shielded Memo | Testnet Support
+- Ironwood: Ready
 
 ---
 
@@ -125,6 +132,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Full Node
 - Pools: Transparent | Sapling | Orchard
 - Features: Command Line Interface | Diversified Address | Shielded Memo | Testnet Support
+- Ironwood: Not Ready
 
 ---
 
@@ -205,6 +213,7 @@
 - Wallet Support: Hardware | Unified Address
 - Pools: Transparent | Sapling | Orchard
 - Features: Multi Coin
+- Ironwood: Ready
 
 ---
 
@@ -215,6 +224,7 @@
 - Wallet Support: Hardware
 - Pools: Transparent 
 - Features: Multi Coin
+- Ironwood: In Progress
 
 ---
 
@@ -254,6 +264,7 @@
 - Wallet Support: Seed Phrase | Unified Address | Hardware
 - Pools: Transparent | Sapling | Orchard
 - Features: Automatic Shielding | Shielded Memo | Testnet Support | FROST Multisig
+- Ironwood: In Progress
 
 ---
 
@@ -263,6 +274,7 @@
 - Operating System: Browser
 - Pools: Shielded | Transparent
 - Features: Browser Extension | Shielded Transactions | Cross-chain Swaps | Lending & Borrowing | DApp Connections | Rhea
+- Ironwood: Ready
 
 ---
 
@@ -293,6 +305,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Private Key | Spending Key | Wallet Backup / Key Export | Full Node Wallet 
 - Pools: Transparent | Sapling | Orchard | Sprout
 - Features: Encrypted Memo | Wallet Backup (wallet data) | RPC Interface | Shielded Memo | Private Key Management
+- Ironwood: Ready
 
 ---
 
@@ -313,6 +326,7 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Spending Key | HD Wallet | Private Key Management 
 - Pools: Transparent | Sapling | Orchard 
 - Features: Address Book | Tor Support | I2P Support | Zebra/Zebrad Integration | Transaction History | Transaction Export | Local Witness Derivation | Dynamic Fee (ZIP-317) | NU6.2 Compatibility | NU6.3 Migration Support | Shielded Memo
+- Ironwood: Ready
 
 ---
 

--- a/site/Using_Zcash/Wallets.md
+++ b/site/Using_Zcash/Wallets.md
@@ -58,7 +58,7 @@
 - Wallet Support: Seed Phrase | Unified Address
 - Pools: Transparent | Sapling | Orchard
 - Features: DEX Swaps | Multi Coin | Spend before Sync
-- Ironwood: In Progress
+- Ironwood: Ready
 
 ---
 
@@ -90,7 +90,8 @@
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address
 - Pools: Transparent | Sapling | Orchard
 - Features: Address Book | Address Rotation | Automatic Shielding | DEX Swaps | Multi Coin | Shielded Memo | Tor Support
-
+- Ironwood: Ready
+  
 ---
 
 ## [Zenith](https://code.vergara.tech/Vergara_Tech/zenith)
@@ -264,7 +265,7 @@
 - Wallet Support: Seed Phrase | Unified Address | Hardware
 - Pools: Transparent | Sapling | Orchard
 - Features: Automatic Shielding | Shielded Memo | Testnet Support | FROST Multisig
-- Ironwood: In Progress
+- Ironwood: Ready
 
 ---
 
@@ -295,7 +296,8 @@
 - Wallet Support: Unified Address 
 - Pools: Transparent | Sapling | Orchard
 - Features: End-to-end encrypted Messenger | NEAR Intents | P2P.me Offramp | Beta
-
+- Ironwood: Ready
+  
 ---
 
 ## [Zecd](https://zecd.org/quickstart.html)
@@ -336,5 +338,5 @@
 - Operating System: Android | Windows | Linux (CLI and MCP Server) | iOS | macOS
 - Wallet Support: Seed Phrase | Viewing Key | Unified Address | Multi Account Wallet | Self-Custody Wallet | Private Key Management | Agent Wallet Support
 - Pools: Transparent | Sapling | Orchard 
-- Features: NEAR Intents | Payment Requests | Shielded Memo | Shielded Transaction Default | Testnet Support | Cross-chain Swap | CipherPay Checkout | Viewing Key Export | AI Agent Integration | MCP Server | CLI Wallet | Human-in-the-loop Approval | FROST | Beta | TestFlight
-
+- Features: NEAR Intents | Payment Requests | Shielded Memo | Shielded Transaction Default | Testnet | Cross-chain Swap | CipherPay | Viewing Key | AI Agent | MCP Server | CLI Wallet | FROST | Beta 
+- Ironwood: In Progress


### PR DESCRIPTION
Adds an "- Ironwood:" status line to 14 wallet entries in Wallets.md, for the readiness indicator on the wiki wallets page (companion PR: https://github.com/ZecHub/zechub-wiki/pull/690).

Statuses were taken from the "Ironwood Software and Activation" checklist on the forum (updated July 27) and each wallet's own release announcements, not guessed:

- Ready: ZODL (v3.8.0), Zingo! (2.0.21 with migration path), Zkool (v6.24.0+ with migration modes), Zallet (v0.1.0-beta.1), Zecd, Keystone (day one firmware), Noir wallet (v0.1.26), Nozy Wallet (v2.4.0)
- In Progress: Unstoppable (dev confirmed work underway), Zingo-CLI (team finishing zingolib now), Ledger (signing code merged July 27, app release not confirmed yet), Vizor (migration flow PR open)
- Not Ready: Ywallet (developer confirmed no NU6.3 support), Zcashd (end of life July 18 at block 3417100)

The other 19 wallets have no public Ironwood statement I could find, so they get no line and no badge rather than a guess. Easy to add later as wallets announce - it's one line per wallet.

Main sources: https://forum.zcashcommunity.com/t/ironwood-software-and-activation-updated-july-27/56557 and https://forum.zcashcommunity.com/t/ironwood-update-for-users/56721
