### PR TITLE
Zcash Ecosystem Digest | August 1st

### DIFF
--- a/newsletter/Digest 08-01-2026.md
+++ b/newsletter/Digest 08-01-2026.md
@@ -1,0 +1,83 @@
+# Zcash Ecosystem Digest | August 1st
+
+This week: Ironwood (NU6.3) activated on mainnet on July 28th, closing the vulnerable Orchard pool and opening a new shielded pool; ZODL and Zakura both shipped compatibility updates for the migration; new grant applications came in from Zcash Ghana and for Web3Lagos 2026; and Fortitude Crypto announced both a new 12 MW mining facility and a 9,000-unit Antminer Z15 Pro purchase.
+
+Curated by Harrie
+
+## Shielded Labs, ZODL, Zcash Foundation Updates 🛠️
+
+[ZF Engineering Update: July 13th - 26th, 2026 - @ZcashFoundation](https://forum.zcashcommunity.com/t/zf-engineering-update-13th-july-26th-july-2026/56845)
+
+[Ironwood is Here! Updated Wallets, Libraries (July 30) - Zcash Community Forum](https://forum.zcashcommunity.com/t/ironwood-is-here-updated-wallets-libraries-july-28/56557)
+
+[Ironwood is live on Zcash: NU6.3 activated at block 3,428,143 - @zodl_co](https://x.com/zodl_co/status/2082106258740420648)
+
+[Ironwood for Zodl users: update to v3.8.0, Keystone firmware v3.0.2 required - @zodl_app](https://x.com/zodl_app/status/2082108853592744301)
+
+[Zakura Release 1.0.5: mitigates a testnet issue affecting both Zakura and Zebra - @ZakuraZcash](https://x.com/ZakuraZcash/status/2081958808033931651)
+
+---
+
+## Zcash Community Grants 🏛️
+
+[Zcash Community Grants (ZCG) Meeting Minutes 7/20/2026](https://forum.zcashcommunity.com/t/zcash-community-grants-zcg-meeting-minutes-7-20-2026/56763)
+
+[Zcash Ghana Grant Application (July 2026 - September 2026)](https://forum.zcashcommunity.com/t/zcash-ghana-july-2026-september-2026/56214)
+
+[Grant Proposal: Bringing Zcash to Web3Lagos 2026](https://forum.zcashcommunity.com/t/bringing-zcash-to-web3lagos-2026/56588)
+
+[Zebra node 6.2.3 update is here - @ZcashCommGrants](https://x.com/ZcashCommGrants/status/2082051678329561590)
+
+---
+
+## Community Projects 🌐
+
+[Fortitude Crypto: construction complete, power flowing to Grand Island, Nebraska 12 MW facility - @ZecHub](https://x.com/ZecHub/status/2082444843230376159)
+
+[Zebra Talks: The Day After, with @castacrypto (Portuguese) - @zcashbrazil](https://x.com/zcashbrazil/status/2082603475926458668)
+
+[Fortitude signs a definitive agreement with Bitmain for 9,000 Antminer Z15 Pro units (~7.56 GSol/s of added Equihash hashrate) (translated from Russian) - @ruZCASH](https://x.com/ruZCASH/status/2082834304539807793)
+
+[Live workshop: how to use ZODL to manage, protect, and transact your digital assets - @ZkAv_Club](https://x.com/ZkAv_Club/status/2082845901702213959)
+
+[Mert explains why crypto without privacy isn't crypto - @genzcash](https://x.com/genzcash/status/2082247526883995719)
+
+[Zcash Ghana: Our First Year Journey (June 2025 - June 2026)](https://forum.zcashcommunity.com/t/zcash-ghana-our-first-year-journey-june-2025-june-2026/56792)
+
+[Zcash East Africa Update (June-July 2026)](https://forum.zcashcommunity.com/t/zcash-east-africa-june-july-2026/56405)
+
+[ZecHub DAO: 2026 Zcash Korea Ambassador Proposal (Approved)](https://forum.zcashcommunity.com/t/zechub-dao-2026-zcash-korea-ambassador-proposal-approved/56458)
+
+[This week's newsletter is now available in Yoruba, translated by @etukudo68370 - @ZcashNigeria](https://x.com/ZcashNigeria/status/2082352336903475509)
+
+[Zcast Live #14: Digital Hygiene to Protect Your Finances (Spanish) - @ZcastEsp](https://x.com/ZcastEsp/status/2082180359899496515)
+
+[Understanding Ironwood: Zcash's New Chapter (Turkish explainer thread) - @ZcashTR](https://x.com/ZcashTR/status/2082846937846300765)
+
+[Less than 48 hours until Ironwood: formal verification, quantum recoverability, and dozens of codebase audits (translated from Korean) - @zcashkorea](https://x.com/zcashkorea/status/2081372746588868711)
+
+[Ironwood y la verificabilidad del suministro: what the upgrade means for supply verification (Spanish-language coverage) - Crypto Economy ESP](https://crypto-economy.com/es/ironwood-y-la-verificabilidad-del-suministro-el-momento-de-zcash/)
+
+[Global Ambassador Elzz: June 2026 Report](https://forum.zcashcommunity.com/t/global-ambassador-elzz-june-2026-report/56482)
+
+[ZecHub Updates | July 21, 2026](https://zechub.substack.com/p/zechub-updates-july-21-2026)
+
+[Ten Years of Zcash: an animated co-authorship map of the developers who built Zcash, entered in the Zcash Irondevs contest - @Giri-Aayush](https://forum.zcashcommunity.com/t/contest-presenting-zcash-irondevs-a-gift-to-the-heroic-zcash-developers/56666)
+
+---
+
+## Meme of the week 😊
+
+[Stay Shielded: celebrating the Ironwood launch - @hardaeborla](https://x.com/hardaeborla/status/2082391931615658387?s=20)
+
+---
+
+## Jobs in the Ecosystem
+
+[ZecHub Bounty Board (Dework)](https://app.dework.xyz/zechub-2424)
+
+[ZODL Careers: open roles including Principal Engineer R&D and Analytics & Optimization Specialist](https://zodl.com/careers/)
+
+[ZkAv Club: Zcash Community Media Infrastructure & Support opportunities](https://forum.zcashcommunity.com/t/zcash-community-media-infrastructure-support-zk-av-club-2026/53913)
+
+---


### PR DESCRIPTION
Weekly digest for August 1st, the week Ironwood (NU6.3) went live on mainnet.

I opened and read every link myself, nothing came from a search snippet. Covers Brazil, Turkey, Korea, Nigeria, Ghana, East Africa, ruZcash, genzcash, ZkAv Club, and Zcast, plus the standard ZODL/Foundation, Grants, Meme, and Jobs sections. Portuguese, Russian, Yoruba, Turkish, and Korean posts are translated to English.

Two flags for review: Zcash Español's X account is suspended, so I used Spanish-language press coverage instead. Zcash Ukraine's account hasn't posted since February, so there's no current-week link for them, I didn't want to fake one.