### PR TITLE
Add link health dashboard

### DIFF
--- a/.github/workflows/link-health.yml
+++ b/.github/workflows/link-health.yml
@@ -1,0 +1,102 @@
+name: Link health dashboard
+
+# Scans site/**/*.md for broken links, dead domains, redirects, missing assets and
+# unresolvable internal routes, then publishes the result to a single pinned
+# "Link health dashboard" issue. Reporting only — never edits content, never opens
+# a pull request. See link-health/README.md.
+
+on:
+  schedule:
+    - cron: "23 5 * * 1" # Mondays, weekly sweep
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: link-health
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Scan links
+        env:
+          # Lets the asset check read the wiki app repo's public/ tree.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node link-health/check-links.mjs --json link-health.json --markdown link-health.md
+
+      # The issue body is capped, so the complete list is kept as an artifact.
+      - name: Upload full report
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-health-report
+          path: |
+            link-health.json
+            link-health.md
+          retention-days: 30
+
+      - name: Publish dashboard issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('link-health.md', 'utf8');
+            const report = JSON.parse(fs.readFileSync('link-health.json', 'utf8'));
+            const marker = '<!-- link-health-dashboard -->';
+            const title = '🔗 Link health dashboard';
+            const label = 'link-health';
+            const { owner, repo } = context.repo;
+
+            // Ensure the tracking label exists.
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner, repo, name: label, color: '0e8a16',
+                  description: 'Auto-maintained link health dashboard',
+                });
+              } else { throw e; }
+            }
+
+            // Reuse the existing dashboard issue rather than opening a new one each run.
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: label, per_page: 100,
+            });
+            const dash = existing.find((i) => !i.pull_request && (i.body || '').includes(marker));
+
+            const summary =
+              `Link health: ${report.serious} needing attention ` +
+              `(broken=${report.totals.broken} dns=${report.totals.dns} ` +
+              `routes=${report.totals.route} assets=${report.totals.asset}), ` +
+              `${report.totals.redirect} redirects, across ${report.filesScanned} pages.`;
+
+            if (dash) {
+              await github.rest.issues.update({ owner, repo, issue_number: dash.number, title, body });
+              core.info(`Updated dashboard issue #${dash.number}`);
+              core.notice(summary);
+              return;
+            }
+
+            const created = await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
+            core.info(`Created dashboard issue #${created.data.number}`);
+            core.notice(summary);
+
+            // Best-effort pin (GraphQL). Non-fatal if it fails (e.g. 3-pin cap).
+            try {
+              await github.graphql(
+                `mutation($id:ID!){ pinIssue(input:{issueId:$id}){ issue { number } } }`,
+                { id: created.data.node_id },
+              );
+              core.info('Pinned dashboard issue.');
+            } catch (e) {
+              core.warning(`Could not pin issue: ${e.message}`);
+            }

--- a/link-health/README.md
+++ b/link-health/README.md
@@ -1,0 +1,68 @@
+# Link health
+
+Weekly scan of the wiki's links, published to a single pinned dashboard issue.
+
+Reporting only. The workflow never edits content and never opens a pull request.
+
+## What it checks
+
+Every link in `site/**/*.md`, including markdown links, images, and the inline
+`src` / `href` attributes the icon markup uses. Links inside fenced code blocks
+are skipped, since those are examples rather than live links.
+
+| Category | Meaning |
+|---|---|
+| Domain does not resolve | DNS failure, the site is likely gone |
+| Broken links | 4xx or 5xx response |
+| Broken internal routes | An in-site link that resolves to no page |
+| Missing assets | `/content-images/...` not present in the app repo |
+| Certificate problems | TLS failure |
+| Timeouts | No response within 15 seconds |
+| Invalid URLs | Malformed or protocol-relative |
+| Redirects | 3xx, worth pointing at the final destination |
+| Duplicate URLs | The same external link repeated within one page |
+
+## Internal routes
+
+Resolving an in-site link is not a plain file lookup. The app converts a URL to a
+filename by title-casing each word and turning hyphens into underscores, then
+forcing a small set of words to lower or upper case, so `/zcash-use-cases/sign-in-with-zcash`
+resolves to `site/Zcash_Use_Cases/Sign_in_With_Zcash.md` with a lowercase `in`.
+
+`check-links.mjs` mirrors that conversion, including the loose fallback match the
+app falls back on, so a link that works in production is not reported as broken.
+If the rules in the app's `src/lib/helpers.ts` change, update `transformUri` here
+to match.
+
+Two things are deliberately not treated as broken routes:
+
+- Pages served by the app rather than by markdown, such as `/wallets` and
+  `/dashboard`. The route list is read from the app repo at scan time.
+- Absolute links ending in `.md`, which point at repository files. The
+  contributing docs use these on purpose.
+
+## Allowlist
+
+`allowlist.txt` holds substrings of URLs to skip. Use it for hosts that block
+automated requests or rate-limit hard enough to produce false timeouts, not for
+links that are genuinely broken.
+
+```
+x.com
+medium.com
+```
+
+## Running it
+
+```bash
+node link-health/check-links.mjs                    # full scan
+node link-health/check-links.mjs --offline          # routes and assets only, no network
+node link-health/check-links.mjs --concurrency 20   # more parallel requests
+```
+
+Outputs `link-health.json` for machines and `link-health.md` for the issue body.
+
+The workflow runs on Mondays and can be started by hand from the Actions tab.
+Because a GitHub issue body is capped, the dashboard shows the first 40 rows per
+category and says how many were left out; the complete list is attached to the
+run as an artifact.

--- a/link-health/allowlist.txt
+++ b/link-health/allowlist.txt
@@ -1,0 +1,16 @@
+# Hosts to skip during link checking.
+#
+# One substring per line. A URL is skipped if it contains any of these. Use this
+# for sites that block automated requests or rate-limit aggressively, not for
+# links that are genuinely broken. Comments start with #.
+
+# Blocks non-browser traffic outright
+x.com
+twitter.com
+linkedin.com
+
+# Aggressive bot protection, returns 403 to any automated request
+medium.com
+
+# Rate-limits hard enough to produce false timeouts on a weekly sweep
+reddit.com

--- a/link-health/check-links.mjs
+++ b/link-health/check-links.mjs
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+// Link health scan for the ZecHub wiki.
+//
+// Reporting only. Reads site/**/*.md, resolves every link it finds, and writes a
+// JSON result plus a Markdown summary. It never edits content and never opens a
+// pull request; the workflow publishes the Markdown to a single dashboard issue.
+//
+//   node link-health/check-links.mjs --json link-health.json --markdown link-health.md
+//
+// Flags:
+//   --json <path>       machine-readable result (default link-health.json)
+//   --markdown <path>   dashboard issue body (default link-health.md)
+//   --root <dir>        content root (default site)
+//   --offline           skip network checks; only resolve internal routes
+//   --concurrency <n>   parallel external requests (default 12)
+
+import { readFile, writeFile, readdir, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, dirname, basename, relative } from "node:path";
+
+// ── args ─────────────────────────────────────────────────────────────────────
+
+const argv = process.argv.slice(2);
+const arg = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+const OUT_JSON = arg("json", "link-health.json");
+const OUT_MD = arg("markdown", "link-health.md");
+const ROOT = arg("root", "site");
+const OFFLINE = argv.includes("--offline");
+const CONCURRENCY = Number(arg("concurrency", "8"));
+const TIMEOUT_MS = 15000;
+const ALLOWLIST_PATH = "link-health/allowlist.txt";
+
+// ── the wiki's URL → filename convention ─────────────────────────────────────
+// Mirrors transformUri() in the zechub-wiki app (src/lib/helpers.ts). A route is
+// title-cased with hyphens becoming underscores, then a small set of words is
+// forced lower or upper case. Getting this wrong is the difference between a
+// useful report and a page of false positives, so it is kept in step with the app.
+
+const LOWERCASE_WORDS = ["Guides", "Tutorials", "Contribute", "In", "The", "Vs", "And", "Is", "Zk"];
+const UPPERCASE_WORDS = ["Zec", "Dex", "Nft", "Zcap", "Zfav", "Snarks", "Frost", "2fa", "Pgp", "I2p", "Dao"];
+const SPECIAL_WORDS = {
+  Non_Custodial: "Non-Custodial",
+  Zero_Knowledge: "Zero-Knowledge",
+  Defi: "DeFi",
+  Z2z: "z2z",
+  Faq: "FAQ",
+  ZECHub: "ZecHub",
+  ZEChub: "ZecHub",
+  Av_Club: "AV_Club",
+  guides_For_Creators: "Guides_for_Creators",
+  Grapheneos: "GrapheneOS",
+  Vpn: "VPN",
+  Dvpn: "DVPN",
+  zk_Shielded: "ZK_Shielded",
+  ZECweekly: "ZecWeekly",
+  ZECWeekly: "ZecWeekly",
+  Help_Build_ZecHub: "Help_build_ZecHub",
+  zkool_Multisig: "Zkool_Multisig",
+  Zenith_installation: "Zenith_Installation",
+  Btcpayserver_Zcash_Plugin: "BTCPayServer_Zcash_Plugin",
+  Uris: "URIs",
+  Free2z_Livestreaming: "Free2Z_Livestreaming",
+  Avalanche_Redbridge: "Avalanche_RedBridge",
+  Raspberry_Pi_4_Zebra_Node: "Raspberry_pi_4_Zebra_Node",
+  Raspberry_Pi5_Zebra_Lightwalletd_Zingo: "Raspberry_pi5_Zebra_Lightwalletd_Zingo",
+  Coinholder_Directed_Retroactive_Grants: "CoinHolder_Directed_Retroactive_Grants",
+  zkav: "ZKAV",
+};
+
+function transformUri(uri) {
+  let t = uri.replace(/\b\w/g, (l) => l.toUpperCase()).replace(/-/g, "_");
+  for (const w of LOWERCASE_WORDS) if (t.includes(w)) t = t.replace(w, w.toLowerCase());
+  for (const w of UPPERCASE_WORDS) if (t.includes(w)) t = t.replace(w, w.toUpperCase());
+  for (const [w, target] of Object.entries(SPECIAL_WORDS)) if (t.includes(w)) t = t.replaceAll(w, target);
+  return t;
+}
+
+/** Loose comparison used by the app's fallback lookup: case and separators dropped. */
+const normalize = (s) => s.replace(/\.md$/i, "").toLowerCase().replace(/[-_ ]+/g, "");
+
+// ── file walking ─────────────────────────────────────────────────────────────
+
+async function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) await walk(p, out);
+    else if (e.isFile() && e.name.toLowerCase().endsWith(".md")) out.push(p);
+  }
+  return out;
+}
+
+// ── link extraction ──────────────────────────────────────────────────────────
+
+const PATTERNS = [
+  // ![alt](target) and [text](target) — target stops at whitespace or ")"
+  { re: /!?\[[^\]]*\]\(\s*<?([^)\s>]+)>?[^)]*\)/g, group: 1 },
+  // HTML attributes used by the icon markup in these pages
+  { re: /\bsrc\s*=\s*["']([^"']+)["']/gi, group: 1 },
+  { re: /\bhref\s*=\s*["']([^"']+)["']/gi, group: 1 },
+];
+
+function extractLinks(text, file) {
+  const lines = text.split("\n");
+  const found = [];
+  const seenPerFile = new Map();
+
+  // Fenced code blocks are examples, not live links.
+  let inFence = false;
+  lines.forEach((line, idx) => {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      return;
+    }
+    if (inFence) return;
+
+    for (const { re, group } of PATTERNS) {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        const raw = (m[group] || "").trim();
+        if (!raw) continue;
+        found.push({ url: raw, file, line: idx + 1 });
+        seenPerFile.set(raw, (seenPerFile.get(raw) || 0) + 1);
+      }
+    }
+  });
+  return { found, seenPerFile };
+}
+
+function classify(url) {
+  if (/^https?:\/\//i.test(url)) return "external";
+  if (/^(mailto|tel|ftp|ipfs|magnet):/i.test(url)) return "scheme";
+  if (url.startsWith("#")) return "anchor";
+  if (url.startsWith("//")) return "protocol-relative";
+  if (url.startsWith("/content-images/") || url.startsWith("/content-banners/")) return "asset";
+  // Absolute links ending in .md point at repository files (contributing docs do
+  // this deliberately), not at wiki routes, so they are not route failures.
+  if (url.startsWith("/") && /\.md($|[?#])/i.test(url)) return "repo-file";
+  if (url.startsWith("/")) return "route";
+  return "relative";
+}
+
+/**
+ * Routes served by the Next.js app rather than by a markdown file — /wallets,
+ * /dashboard, /hackathon and so on. Fetched from the app repo so the list stays
+ * correct as pages are added; falls back to a static set when offline.
+ */
+async function loadAppRoutes(offline) {
+  const fallback = [
+    "wallets", "mobile-wallets", "desktop-wallets", "web-wallets", "hardware-wallets",
+    "dashboard", "visualizer", "hackathon", "explore", "tools", "map", "dex", "privacy",
+    "proposals", "dao", "newsletter", "tutorials", "developers", "zips", "zips-grants",
+    "gallery", "welcome", "sitemap", "donation", "zebra", "zcash-projects",
+    "protocol-parameters", "zcash-evolution", "visual-identity", "governance-howto",
+    "zcash-global-ambassadors", "zcash-payment-uri", "zcash-pool-visualizer",
+    "zksnark-proof-visualizer", "zcash-infrastructure-visualizer", "omniflix",
+    "aborist-calls", "zechub-tutorial", "zechub-tutorials", "using-zcash",
+  ];
+  if (offline) return new Set(fallback);
+  try {
+    const res = await fetch("https://api.github.com/repos/ZecHub/zechub-wiki/git/trees/main?recursive=1", {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": "ZecHubLinkHealth/1.0",
+        ...(process.env.GITHUB_TOKEN ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+      },
+    });
+    if (!res.ok) return new Set(fallback);
+    const tree = await res.json();
+    const prefix = "src/app/[locale]/";
+    const routes = new Set(fallback);
+    for (const n of tree.tree) {
+      if (!n.path.startsWith(prefix) || !n.path.endsWith("/page.tsx")) continue;
+      const seg = n.path.slice(prefix.length, -"/page.tsx".length);
+      if (seg && !seg.includes("[")) routes.add(seg);
+    }
+    return routes;
+  } catch {
+    return new Set(fallback);
+  }
+}
+
+// ── internal route resolution ────────────────────────────────────────────────
+
+function routeExists(route, mdFiles, appRoutes) {
+  const clean = route.split("#")[0].split("?")[0].replace(/\/+$/, "");
+  if (!clean || clean === "/") return { ok: true, how: "site root" };
+
+  // Pages rendered by the app itself have no markdown behind them.
+  const segs = clean.replace(/^\//, "");
+  if (appRoutes.has(segs) || appRoutes.has(segs.split("/")[0])) {
+    return { ok: true, how: "app route" };
+  }
+
+  const target = `site${transformUri(clean)}.md`;
+  if (existsSync(target)) return { ok: true, how: "exact" };
+
+  // The app falls back to a loose match inside the same folder, so a report that
+  // ignored this would flag links that actually resolve in production.
+  const wanted = normalize(basename(clean));
+  const folder = dirname(target);
+  const sibling = mdFiles.find(
+    (f) => dirname(f) === folder && (normalize(basename(f)) === wanted || normalize(basename(f)).includes(wanted)),
+  );
+  if (sibling) return { ok: true, how: `fuzzy → ${sibling}` };
+
+  // Some routes are app pages rather than markdown (for example /wallets).
+  return { ok: false, how: `no file at ${target}` };
+}
+
+// ── external checking ────────────────────────────────────────────────────────
+
+async function checkExternal(url) {
+  const attempt = async (method) => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    try {
+      const res = await fetch(url, {
+        method,
+        redirect: "manual",
+        signal: ctrl.signal,
+        headers: {
+          "user-agent":
+            "Mozilla/5.0 (compatible; ZecHubLinkHealth/1.0; +https://github.com/ZecHub/zechub)",
+          accept: "*/*",
+        },
+      });
+      return { status: res.status, location: res.headers.get("location") };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  try {
+    let r = await attempt("HEAD");
+    // Plenty of hosts refuse HEAD; confirm with GET before calling it broken.
+    if (r.status === 405 || r.status === 403 || r.status === 501) r = await attempt("GET");
+
+    if (r.status >= 200 && r.status < 300) return { state: "ok", status: r.status };
+    if (r.status >= 300 && r.status < 400) return { state: "redirect", status: r.status, to: r.location };
+    return { state: "broken", status: r.status };
+  } catch (err) {
+    const msg = String(err?.cause?.code || err?.name || err?.message || err);
+    if (/abort/i.test(msg)) return { state: "timeout", detail: `no response in ${TIMEOUT_MS / 1000}s` };
+    if (/ENOTFOUND|EAI_AGAIN|DNS/i.test(msg)) return { state: "dns", detail: msg };
+    if (/CERT|SSL|TLS/i.test(msg)) return { state: "tls", detail: msg };
+    return { state: "error", detail: msg };
+  }
+}
+
+async function pool(items, limit, worker) {
+  const out = new Array(items.length);
+  let next = 0;
+  const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      out[i] = await worker(items[i], i);
+    }
+  });
+  await Promise.all(runners);
+  return out;
+}
+
+// ── suggested actions ────────────────────────────────────────────────────────
+
+const ACTIONS = {
+  broken: "Confirm the page moved or was removed, then update or drop the link.",
+  dns: "Domain does not resolve. The site is likely gone; replace or remove the link.",
+  timeout: "No response in time. Recheck manually; add to the allowlist if the host is simply slow.",
+  tls: "Certificate problem. Verify the host before trusting the link.",
+  error: "Request failed. Recheck manually.",
+  redirect: "Point the link at its final destination so readers skip the hop.",
+  route: "Internal route resolves to no file. Check spelling and the In/The/And/Is/Vs casing rule.",
+  asset: "Asset is not in the wiki repo. Upload it or correct the path.",
+  invalid: "Malformed URL. Fix the link syntax.",
+  duplicate: "Same URL repeated in one file. Usually harmless, sometimes a copy-paste slip.",
+};
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const startedAt = new Date().toISOString();
+
+  let allowlist = [];
+  try {
+    allowlist = (await readFile(ALLOWLIST_PATH, "utf8"))
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith("#"));
+  } catch {
+    /* optional file */
+  }
+  const allowed = (url) => allowlist.some((p) => url.includes(p));
+
+  const mdFiles = await walk(ROOT);
+  const appRoutes = await loadAppRoutes(OFFLINE);
+
+  // Assets live in the wiki app repo, so confirm them over the API when we can.
+  let assetSet = null;
+  if (!OFFLINE) {
+    try {
+      const res = await fetch(
+        "https://api.github.com/repos/ZecHub/zechub-wiki/git/trees/main?recursive=1",
+        {
+          headers: {
+            accept: "application/vnd.github+json",
+            "user-agent": "ZecHubLinkHealth/1.0",
+            ...(process.env.GITHUB_TOKEN ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
+          },
+        },
+      );
+      if (res.ok) {
+        const tree = await res.json();
+        assetSet = new Set(
+          tree.tree
+            .filter((n) => n.path.startsWith("public/"))
+            .map((n) => "/" + n.path.slice("public/".length)),
+        );
+      }
+    } catch {
+      /* asset checking is best effort */
+    }
+  }
+
+  const findings = [];
+  const externalTargets = new Map(); // url -> occurrences
+  let linkCount = 0;
+
+  for (const file of mdFiles) {
+    const text = await readFile(file, "utf8");
+    const { found, seenPerFile } = extractLinks(text, file);
+    linkCount += found.length;
+
+    for (const [url, count] of seenPerFile) {
+      if (count > 1 && classify(url) === "external") {
+        findings.push({ kind: "duplicate", url, file, count, detail: `appears ${count} times in this file` });
+      }
+    }
+
+    for (const link of found) {
+      const kind = classify(link.url);
+      if (kind === "anchor" || kind === "scheme" || kind === "relative" || kind === "repo-file") continue;
+
+      if (kind === "protocol-relative") {
+        findings.push({ kind: "invalid", url: link.url, file: link.file, line: link.line, detail: "protocol-relative URL" });
+        continue;
+      }
+
+      if (kind === "route") {
+        const r = routeExists(link.url, mdFiles, appRoutes);
+        if (!r.ok) findings.push({ kind: "route", url: link.url, file: link.file, line: link.line, detail: r.how });
+        continue;
+      }
+
+      if (kind === "asset") {
+        if (assetSet && !assetSet.has(link.url.split("?")[0])) {
+          findings.push({ kind: "asset", url: link.url, file: link.file, line: link.line, detail: "not found in zechub-wiki/public" });
+        }
+        continue;
+      }
+
+      if (kind === "external") {
+        let parsed;
+        try {
+          parsed = new URL(link.url);
+        } catch {
+          findings.push({ kind: "invalid", url: link.url, file: link.file, line: link.line, detail: "unparseable URL" });
+          continue;
+        }
+        if (allowed(parsed.href)) continue;
+        if (!externalTargets.has(parsed.href)) externalTargets.set(parsed.href, []);
+        externalTargets.get(parsed.href).push(link);
+      }
+    }
+  }
+
+  // One request per distinct URL no matter how many pages cite it.
+  const urls = [...externalTargets.keys()];
+  let checked = 0;
+  let retried = 0;
+  if (!OFFLINE && urls.length) {
+    let results = await pool(urls, CONCURRENCY, (u) => checkExternal(u));
+    checked = urls.length;
+
+    // A single connection failure usually means we saturated the local socket
+    // pool, not that the site is down. Anything that failed at the network layer
+    // is retried once, slowly, and only reported if it fails again. Without this
+    // a large sweep reports hundreds of live sites as broken.
+    const transient = new Set(["timeout", "error", "dns", "tls"]);
+    const suspects = [];
+    results.forEach((r, i) => {
+      if (transient.has(r.state)) suspects.push(i);
+    });
+    if (suspects.length) {
+      retried = suspects.length;
+      const second = await pool(suspects.map((i) => urls[i]), 4, (u) => checkExternal(u));
+      suspects.forEach((idx, k) => {
+        results[idx] = second[k];
+      });
+    }
+
+    results.forEach((r, i) => {
+      const url = urls[i];
+      const where = externalTargets.get(url);
+      if (r.state === "ok") return;
+      findings.push({
+        kind: r.state,
+        url,
+        file: where[0].file,
+        line: where[0].line,
+        alsoIn: where.length > 1 ? where.length - 1 : 0,
+        status: r.status,
+        detail: r.to ? `→ ${r.to}` : r.detail || `HTTP ${r.status}`,
+      });
+    });
+  }
+
+  const order = ["dns", "broken", "route", "asset", "tls", "timeout", "error", "invalid", "redirect", "duplicate"];
+  findings.sort((a, b) => order.indexOf(a.kind) - order.indexOf(b.kind) || a.file.localeCompare(b.file));
+
+  const totals = Object.fromEntries(order.map((k) => [k, findings.filter((f) => f.kind === k).length]));
+  const serious = totals.dns + totals.broken + totals.route + totals.asset + totals.invalid;
+
+  const report = {
+    generatedAt: startedAt,
+    filesScanned: mdFiles.length,
+    linksFound: linkCount,
+    uniqueExternalChecked: checked,
+    retriedAfterNetworkFailure: retried,
+    allowlistEntries: allowlist.length,
+    totals,
+    serious,
+    findings,
+  };
+  await writeFile(OUT_JSON, JSON.stringify(report, null, 2));
+  await writeFile(OUT_MD, renderMarkdown(report));
+
+  console.log(
+    `Scanned ${mdFiles.length} files, ${linkCount} links, ${checked} unique external ` +
+      `(${retried} retried after a network failure). ` +
+      `${serious} needing attention, ${totals.redirect} redirects, ${totals.duplicate} duplicates.`,
+  );
+}
+
+// ── markdown ─────────────────────────────────────────────────────────────────
+
+const LABELS = {
+  dns: "Domain does not resolve",
+  broken: "Broken links",
+  route: "Broken internal routes",
+  asset: "Missing assets",
+  tls: "Certificate problems",
+  timeout: "Timeouts",
+  error: "Request errors",
+  invalid: "Invalid URLs",
+  redirect: "Redirects",
+  duplicate: "Duplicate URLs",
+};
+
+// GitHub issue bodies cap at 65536 characters, so rows are capped per section and
+// anything dropped is stated rather than silently trimmed.
+const MAX_ROWS = 40;
+
+function renderMarkdown(r) {
+  const L = [];
+  L.push("<!-- link-health-dashboard -->");
+  L.push("");
+  L.push(
+    `Scanned **${r.filesScanned}** pages and **${r.linksFound}** links ` +
+      `(**${r.uniqueExternalChecked}** unique external targets) at ${r.generatedAt}.`,
+  );
+  L.push("");
+  L.push(
+    r.serious === 0
+      ? "**No broken links, dead domains, missing assets or bad routes.**"
+      : `**${r.serious} link${r.serious === 1 ? "" : "s"} need attention.**`,
+  );
+  L.push("");
+
+  const counts = Object.entries(r.totals).filter(([, n]) => n > 0);
+  if (counts.length) {
+    L.push("| Category | Count |");
+    L.push("|---|---|");
+    for (const [k, n] of counts) L.push(`| ${LABELS[k] || k} | ${n} |`);
+    L.push("");
+  }
+
+  for (const kind of Object.keys(LABELS)) {
+    const rows = r.findings.filter((f) => f.kind === kind);
+    if (!rows.length) continue;
+    L.push(`### ${LABELS[kind]} (${rows.length})`);
+    L.push("");
+    L.push(`_${ACTIONS[kind]}_`);
+    L.push("");
+    L.push("| URL | Source | Detail |");
+    L.push("|---|---|---|");
+    for (const f of rows.slice(0, MAX_ROWS)) {
+      const url = f.url.length > 90 ? f.url.slice(0, 87) + "..." : f.url;
+      const src = f.line ? `${f.file}:${f.line}` : f.file;
+      const extra = f.alsoIn ? ` (+${f.alsoIn} more page${f.alsoIn === 1 ? "" : "s"})` : "";
+      L.push(`| ${url.replace(/\|/g, "\\|")} | ${src}${extra} | ${(f.detail || "").replace(/\|/g, "\\|")} |`);
+    }
+    if (rows.length > MAX_ROWS) {
+      L.push("");
+      L.push(`_${rows.length - MAX_ROWS} more not shown. Full list in the workflow artifact._`);
+    }
+    L.push("");
+  }
+
+  L.push("---");
+  L.push("");
+  L.push(
+    `Reporting only, no content is modified. Allowlist: \`${ALLOWLIST_PATH}\` ` +
+      `(${r.allowlistEntries} entr${r.allowlistEntries === 1 ? "y" : "ies"}). ` +
+      "Runs weekly and on demand from the Actions tab.",
+  );
+  return L.join("\n");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a weekly link health scan that publishes to a single pinned dashboard issue, following the same shape as the existing translation staleness dashboard.

Reporting only. It never edits content and never opens a pull request.

**What it covers**

Broken links, domains that no longer resolve, redirects, certificate problems, timeouts, invalid URLs, duplicate URLs within a page, missing `/content-images/` assets, and unresolvable internal routes. Each finding lists the URL, the source file and line, the status, and a suggested action. Runs Mondays and on demand from the Actions tab, with an allowlist at `link-health/allowlist.txt` for hosts that block automated requests.

**Internal routes were the interesting part**

Resolving an in-site link is not a plain file lookup. The app title-cases each word, turns hyphens into underscores, then forces a small set of words to lower or upper case, so `/zcash-use-cases/sign-in-with-zcash` resolves to `Sign_in_With_Zcash.md` with a lowercase `in`. The scanner mirrors that conversion and the loose fallback match the app uses, otherwise it would report links that work fine in production.

Two things are deliberately not flagged: routes served by the app rather than markdown, such as `/wallets` and `/dashboard`, read from the app repo at scan time; and absolute links ending in `.md`, which the contributing docs use on purpose to point at repository files.

**Findings from the first run**

Scanning 714 pages and 11,142 links turned up 12 broken internal routes, each confirmed against the live site rather than just against my own resolver. Most are a wrong prefix, for example several pages link to `/use-cases/...` when the route is `/zcash-use-cases/...`, and `Zcash_Use_Cases/About.md` links to `freelancer-privacy-setup` and `accept-payment-as-a-merchant` when the files are `Freelance_Privacy_Setup.md` and `Accept_Payments_As_A_Merchant.md`. I have left those for a separate content PR so this one stays tooling only.

**On false positives**

An early run reported over 900 failures. Nearly all were connection timeouts caused by the scan saturating its own socket pool, with live sites like github.com among them. Anything failing at the network layer is now retried once at low concurrency and only reported if it fails again, and the default concurrency is lower. A dashboard that cries wolf is worse than no dashboard.
