### PR TITLE
Fix broken internal wiki routes

### DIFF
--- a/site/Start_Here/What_is_ZecHub.md
+++ b/site/Start_Here/What_is_ZecHub.md
@@ -15,7 +15,7 @@ ZecHub is a decentralized education hub for Zcash. The goal of [ZecHub](http://z
 
 The tutorials, short-form blogs, and newsletter are open sourced and hosted on GitHub, meaning anyone from the community can contribute. This is to ensure content is accurate and that the channel itself suffers from no single point of failure.
 
-If you're new to Zcash, use [this guide](/site/Start_Here/New_User_Guide).****
+If you're new to Zcash, use [this guide](/start-here/new-user-guide).****
 
 ## How to make changes to ZecHub
 

--- a/site/Using_Zcash/Non-Custodial_Exchanges.md
+++ b/site/Using_Zcash/Non-Custodial_Exchanges.md
@@ -4,7 +4,7 @@
 
 # <img src="/content-images/ZEC-USD-a2189a84b9.webp" alt="Alt Text" width="50"/>   Non-Custodial Exchanges
 
-[Zcash Non-Custodial Exchanges](/site/Using_Zcash/DEX_List)
+[Zcash Non-Custodial Exchanges](/dex)
 
 In the ever-evolving world of cryptocurrency trading, the rise of non-custodial exchanges which is also known as Decentralized Exchanges or DEXs is redefining how users engage with digital assets. These platforms offer a revolutionary approach to trading by eliminating the need for intermediaries or third parties and returning control to users.
 

--- a/site/Using_Zcash/Shielded_Pools.md
+++ b/site/Using_Zcash/Shielded_Pools.md
@@ -56,7 +56,7 @@ Orchard significantly improved usability, efficiency, and privacy by reducing tr
 
 Today, Orchard remains the primary shielded pool for Zcash. However, the community is evaluating a future migration to a new shielded pool called Ironwood, which would provide additional assurance regarding the integrity of the shielded ZEC supply while preserving Zcash's privacy guarantees.
 
-[Zcash Shielded wallets](/site/Using_Zcash/Wallets) now support Orchard. 
+[Zcash Shielded wallets](/wallets) now support Orchard.
 
 ____
 

--- a/site/Zcash_Use_Cases/About.md
+++ b/site/Zcash_Use_Cases/About.md
@@ -33,15 +33,15 @@ Learn how to accept funds without exposing your identity or financial history.
 Avoid exposing your wallet, identity, or transaction graph when sending funds.
 
 
-###  [Freelancer Privacy Setup](/zcash-use-cases/freelancer-privacy-setup)  
+###  [Freelancer Privacy Setup](/zcash-use-cases/freelance-privacy-setup)
 Get paid in Zcash while keeping your clients and income private.
 
 
-###  [Accept Payments as a Merchant](/zcash-use-cases/accept-payment-as-a-merchant)  
+###  [Accept Payments as a Merchant](/zcash-use-cases/accept-payments-as-a-merchant)
 Accept payments using a shielded address and avoid exposing customer transaction data
 
 
-###  [Run a Private Community Treasury](/zcash-use-cases/run-a-private-community-treasury)
+###  [Run a Private Community Treasury](/zcash-use-cases/private-community-treasury)
 Use shielded addresses to hold shared funds and limit visibility of balances and transactions
 
 ###  [Journalist Privacy Setup](/zcash-use-cases/journalist-privacy-setup)   

--- a/site/Zcash_Use_Cases/Accept_Payments_As_A_Merchant.md
+++ b/site/Zcash_Use_Cases/Accept_Payments_As_A_Merchant.md
@@ -135,5 +135,5 @@ You can now run private payment flows for business.
 
 ## Next Step
 
-- [Run a Private Community Treasury](/use-cases/private-community-treasury)
+- [Run a Private Community Treasury](/zcash-use-cases/private-community-treasury)
 <br/>

--- a/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md
+++ b/site/Zcash_Use_Cases/Freelance_Privacy_Setup.md
@@ -124,5 +124,5 @@ You now understand how to receive income privately.
 
 ## Next Step
 
-- [Accept Payments as a Merchant](/use-cases/accept-payments-as-a-merchant)
+- [Accept Payments as a Merchant](/zcash-use-cases/accept-payments-as-a-merchant)
 <br/>

--- a/site/Zcash_Use_Cases/Journalist_Privacy_Setup.md
+++ b/site/Zcash_Use_Cases/Journalist_Privacy_Setup.md
@@ -114,7 +114,7 @@ You can:
 ## <img src="/content-images/chain-for-links-svgrepo-com-117ee0dec1.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
 - [Privacy - Best practices](/privacy/best-practices)
-- [Send money without linking identity](/use-cases/send-money-without-linking-identity)
+- [Send money without linking identity](/zcash-use-cases/send-money-without-linking-identity)
 
  <br/>
 

--- a/site/Zcash_Use_Cases/Private_Community_Treasury.md
+++ b/site/Zcash_Use_Cases/Private_Community_Treasury.md
@@ -122,7 +122,7 @@ Your community can:
 ## <img src="/content-images/chain-for-links-svgrepo-com-117ee0dec1.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="chain-links icon"/> Related
 
 - [Privacy - Best practices](/privacy/best-practices)
-- [Send money without linking identity](/use-cases/send-money-without-linking-identity)
+- [Send money without linking identity](/zcash-use-cases/send-money-without-linking-identity)
  
 
 <br/>
@@ -137,4 +137,4 @@ You understand how to manage shared funds privately.
 
 ## Next Step
 
-- [Journalist Privacy Setup](/use-cases/journalist-privacy-setup)
+- [Journalist Privacy Setup](/zcash-use-cases/journalist-privacy-setup)

--- a/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md
+++ b/site/Zcash_Use_Cases/Send_Money_Without_Linking_Identity.md
@@ -110,4 +110,4 @@ You can now send funds privately without exposing identity.
 
 ## Next Step
 
-- [Freelancer Privacy Setup](/use-cases/freelancer-privacy-setup)
+- [Freelancer Privacy Setup](/zcash-use-cases/freelance-privacy-setup)


### PR DESCRIPTION
## Changes

This fixes the 12 internal routes still reported on current main.

* Pointed the New User Guide link at its current content route.
* Replaced the old exchange and wallet paths with the current app routes, /dex and /wallets.
* Corrected three misspelled use case slugs and six links that still used the old /use-cases prefix.

I checked each replacement against the current site routing and its live destination. This PR does not change the checker, workflow, allowlist, or external links.

## Verification

node link-health/check-links.mjs --offline

* Broken internal routes: 12 before, 0 after
* Invalid URLs: 1 before, 1 after, pre existing and outside this PR
* Duplicate URLs: 264 before, 264 after

The scan covered 714 files and 11,119 links in both runs.

Related to #1923
Background: #1920