### PR TITLE
Update the Zcash Library with terms from the past year

### DIFF
--- a/site/Glossary_and_FAQs/Zcash_Library.md
+++ b/site/Glossary_and_FAQs/Zcash_Library.md
@@ -33,6 +33,8 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Canopy | The 5th Major Network Upgrade for Zcash. [More Info](https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html?highlight=orchard#canopy) |
 | Commitment Scheme | Allows a committer to commit to a polynomial with a short string that can be used by a verifier to confirm claimed evaluations of the committed polynomial. Useful for reducing communication costs in the Zcash protocol. |
 | Community | [The Official Zcash Community Forum](https://forum.zcashcommunity.com) / [Zcash Community Discord](https://discord.com/channels/669694001464737815/669694001921654794) / [Zcash R&D Discord](https://discord.com/invite/6AK7keWFaK) / [Reddit](https://www.reddit.com/r/zec/) / [Telegram](https://t.me/Zcash_Community) / [Twitter](https://x.com/zcash) |
+| Crosslink | A proposed hybrid consensus design that keeps proof-of-work block production and adds a proof-of-stake finality layer on top, so blocks gain stronger finality without abandoning mining. It grew out of Trailing Finality Layer research and is being built by Shielded Labs, still in testnet development as of 2026. |
+| CrossPay | A feature in the Zodl wallet that lets you spend shielded ZEC while the recipient is paid in the asset and chain they prefer, routed through NEAR Intents rather than a centralized exchange. |
 | Cypherpunk Zero | A Creative Universe and collaborative effort between ECC, illustrator Stranger Wolf, Mighty Jaxx and select ecosystem partners. [Cypherpunk Zero Site](https://halo.electriccoin.co/?utm_source=ECC&utm_medium=Website&utm_campaign=None) / [Opensea Collection](https://opensea.io/collection/cypherpunk-zero) |
 
 ## D
@@ -48,7 +50,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 
 | Term | Definition |
 |------|-----------|
-| ECC | The Electric Coin Company, the team behind the Zcash protocol, previously known as the Zcash Company. |
+| ECC | The Electric Coin Company, the team that launched the Zcash protocol, previously known as the Zcash Company. Its entire engineering team resigned in January 2026 following a governance dispute with the Bootstrap board, and went on to form ZODL. |
 | ECDSA | Elliptic Curve Digital Signature Algorithm is a cryptographically secure digital signature scheme. The ECDSA sign/verify algorithm relies on elliptic curve point multiplication. |
 | Education | Learning oriented videos explaining Zcash [here](https://www.zcashcommunity.com/zcash-education/) |
 | Encrypted Memos | An additional field for transactions sent to shielded addresses that is visible to the recipient of a payment. The encrypted memo is visible only to the sender and recipient. |
@@ -124,10 +126,12 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 
 | Term | Definition |
 |------|-----------|
+| Network Sustainability Mechanism (NSM) | A proposal from Shielded Labs to burn a share of transaction fees so the protocol's long-term security budget does not rest entirely on issuance. Specified in ZIP 234, under review in 2026. |
 | Nighthawk | A Mobile wallet for Zcash. [Website](https://nighthawkwallet.com) |
+| Noir Wallet | A Zcash browser extension wallet supported by Zcash Community Grants, built to connect shielded ZEC directly to browser applications instead of relying on QR codes and manual transfers. [zknoir.com](https://www.zknoir.com/) |
 | NU5 | The 6th Major Network Upgrade for Zcash, introducing the Orchard shielded pool and Unified Addresses. [More Info](https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html#nu5) |
 | NU6 | The 7th Major Network Upgrade for Zcash, adjusting the block subsidy to fund the Zcash Community Grants program and Shielded Labs. Activated in late 2024. [More Info](https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html#nu6) |
-| NU7 | The upcoming 8th Major Network Upgrade for Zcash. Community sentiment polling is open via ZODL in 2026. Expected to include further shielded pool improvements and governance updates. [Forum Discussion](https://forum.zcashcommunity.com/t/nu7-sentiment-polling-questions-for-community-review-coinholder-voting-via-zodl/55713) |
+| NU7 | The next major network upgrade after Ironwood. Candidate features include Project Tachyon's scaling work, Zcash Shielded Assets, and the Network Sustainability Mechanism. |
 
 ## O
 
@@ -167,6 +171,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Sapling | A major network upgrade that introduced significant efficiency improvements for shielded transactions and paved the way for mobile adoption. Activated at block 419200. |
 | Selective Disclosure | Allows the owner of a shielded address to selectively share viewing keys or payment disclosures with third parties while keeping data private from everyone else. |
 | Shielded Address | Also called zaddr. Starts with z. Hides sender, receiver, amount, and memo using zk-SNARKs. |
+| Shielded Labs | An independent organization working on Zcash protocol economics and consensus. Currently leads Crosslink and the Network Sustainability Mechanism. [GitHub](https://github.com/ShieldedLabs) |
 | Shielded Transaction | A transaction exclusively between shielded addresses. Fully private on the blockchain. |
 | Sol/s | Solutions per second - measures Equihash mining performance. |
 | Spending Key | The private key that allows spending from a shielded address (also lets you view balance and history). |
@@ -179,6 +184,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Tachyon | Zcash's scaling programme, targeted at NU7. It moves wallets away from scanning every block toward proof-carrying wallet state, oblivious synchronization and prunable node state, aiming for shielded throughput in the thousands of transactions per second. [Project site](https://tachyon.z.cash/overview/) |
 | TAZ | Testnet Zcash (valueless test currency). |
 | Testnet | A separate blockchain for testing upgrades and features before mainnet. |
+| Trailing Finality Layer (TFL) | Research into adding a finality layer behind Zcash's proof-of-work chain so recent blocks can be finalized without replacing mining. Crosslink is the design that came out of it. |
 | Transaction | A payment between users, submitted to the network and eventually confirmed in a block. |
 | Transaction Expiry | Transactions expire after approximately 25 minutes (20 blocks) if unconfirmed; funds return automatically. |
 | Transaction Fee | Default fee is 0.0001 ZEC. Higher fees get priority; very low fees may cause delays or expiry. |
@@ -204,6 +210,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Term | Definition |
 |------|-----------|
 | Wallet | Software or hardware that stores private keys and lets you send/receive ZEC. Active wallets include ZODL (iOS/Android), Zingo! (mobile/desktop), Nighthawk (Android), YWallet, Zallet (upcoming), and Keystone (hardware). For a full list, see [Zcash Ecosystem Wallets](https://z.cash/ecosystem/?wallets=#tag-wallets) |
+| WebZjs | The first JavaScript SDK for Zcash, built by ChainSafe for browser environments. It underpins the Zcash Shielded Wallet snap that brought shielded ZEC to MetaMask. |
 
 ## X
 
@@ -215,7 +222,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 
 | Term | Definition |
 |------|-----------|
-| YWallet | A high-performance, privacy-focused Zcash wallet supporting Orchard, Sapling, and transparent addresses. Known for fast sync speeds. Available for iOS and Android. [YWallet](https://ywallet.app) |
+| YWallet | A privacy-focused Zcash wallet supporting Orchard, Sapling and transparent addresses, known for fast sync. No longer maintained: its developer has confirmed it will not be updated for Ironwood, so it can no longer follow the network. Zkool, by the same developer, is the maintained successor. |
 
 ## Z
 
@@ -228,11 +235,13 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Zerocash | The academic protocol (2014) that Zcash is based on. |
 | Zaino | The next-generation Zcash indexer replacing lightwalletd, built by the Zcash Foundation. Enables light clients to sync faster and more privately. Part of the Zcash Z3 infrastructure upgrade. |
 | Zakura | A Zcash full node implementation released in July 2026, built as a fork of Zebra by Valar Group and Project Tachyon. It targets throughput and sync speed, with snapshot bootstrapping and a stated goal of card-network scale, around 50,000 transactions per second. [zakura.com](https://zakura.com) |
-| Zallet | The upcoming official Zcash wallet by the Electric Coin Co / ZODL team, built on Zaino. Zallet Alpha is in active development as of 2026. [Forum](https://forum.zcashcommunity.com/t/zcash-z3-updates-formerly-zcashd-deprecation/48965) |
+| Zallet | The wallet component that took over zcashd's wallet functions when it was retired, built on Zaino as part of the Zcash Z3 infrastructure work. |
 | Zebra | The Zcash Foundation's Rust-based full node implementation (alternative to zcashd). Production-ready and actively maintained. [GitHub](https://github.com/ZcashFoundation/zebra) |
+| zcashd | The original Zcash full node, forked from Bitcoin Core. Retired in July 2026 after a long deprecation, with its roles split between Zebra for consensus and Zallet for wallet functions. |
 | ZIP | Zcash Improvement Proposal - the community governance process used to propose and ratify protocol changes. [ZIP Repository](https://github.com/zcash/zips) |
-| ZODL | The rebranded name for the Electric Coin Company's consumer products, including the ZODL wallet app (formerly called ECC Wallet) and ZODL governance platform for Coinholder polling. [zodl.com](https://zodl.com) |
+| ZODL | Zcash Open Development Lab. The independent organization founded in early 2026 by Josh Swihart and the former Electric Coin Company engineering team after they resigned over a governance dispute with Bootstrap. It raised over $25 million in seed funding in March 2026 and maintains the Zodl wallet, which was renamed from Zashi in February 2026. [zodl.com](https://zodl.com) |
 | zk-SNARKs | Zero-Knowledge Succinct Non-Interactive Arguments of Knowledge — the cryptography powering Zcash shielded transactions. Allows proving a statement (e.g., valid spend) without revealing any secret information. |
+| ZSA (Zcash Shielded Assets) | User-issued tokens that inherit Zcash's shielded privacy, letting assets other than ZEC move privately on the network. Specified in [ZIP 226](https://zips.z.cash/zip-0226) and a candidate feature for NU7. |
 
 ---
 

--- a/site/Glossary_and_FAQs/Zcash_Library.md
+++ b/site/Glossary_and_FAQs/Zcash_Library.md
@@ -61,6 +61,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Term | Definition |
 |------|-----------|
 | Fiat-Shamir | A technique for taking an interactive proof of knowledge and creating a digital signature based on it. This way, some fact (e.g. knowledge of a secret) can be publicly proven without revealing underlying information. |
+| Formal Verification | Proving mathematically that a system behaves exactly as specified, rather than relying on testing alone. The Ironwood Action circuit was verified this way by contributors from zkSecurity and ZODL using the Lean theorem prover, to demonstrate the absence of soundness bugs. |
 | Founders Reward | The Founder reward represents 20 percent of the total block reward and it is deducted from every block's value and transparently distributed to drive protocol development and growth. |
 | Free2z | A tool for anonymous content and private donations powered by Zcash. [Free2z](https://free2z.com) |
 | FROST | Flexible Round-Optimized Schnorr Threshold signature scheme. [Research Paper](https://eprint.iacr.org/2020/852) |
@@ -87,6 +88,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Integrations | You can accept Zcash payments through a number of 3rd party providers. [Payment Processors](https://z.cash/zcash-for-business/) |
 | Interactive Proof System | An abstract machine that models computation as the exchange of messages between two parties: a Prover and a Verifier. |
 | Investment | A number of Financial options are available for institutional investors or family offices who want to gain exposure to Zcash. [Full list](https://z.cash/investors/) |
+| Ironwood | The network upgrade (NU6.3) that activated on mainnet on 28 July 2026 at block 3,428,143. It introduced a new shielded pool, also called Ironwood, and made the Orchard pool spend-only so existing value migrates across the turnstile. [More info](/zcash-tech/ironwood) |
 
 ## J
 
@@ -131,6 +133,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 
 | Term | Definition |
 |------|-----------|
+| Oblivious Synchronization | A method under development in Project Tachyon that lets a wallet request the data it needs from an untrusted server without revealing which notes it is asking about. The server never learns your nullifiers, because the protocol makes them evolve in an unlinkable way. [Write-up](https://seanbowe.com/blog/tachyon-scaling-zcash-oblivious-synchronization/) |
 | Orchard Shielded Pool | The third shielded pool for Zcash and represents the continued evolution of our zk-SNARK technology stack. [Full details](https://electriccoin.co/blog/explaining-halo-2/) |
 | Overwinter | The 1st Network Upgrade for Zcash. [More Info](https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html#overwinter) |
 
@@ -139,7 +142,9 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Term | Definition |
 |------|-----------|
 | Payments | It is possible to use Zcash for everyday purchases through a number of different payment providers. [Payment Apps](https://z.cash/pay-with-zcash/) |
+| PCD (Proof-Carrying Data) | A primitive where data travels alongside a proof of its own correctness, so combining data also combines the proofs. Project Tachyon rebuilds the shielded protocol around PCD, letting each wallet carry a recursive proof that its own balance is correct instead of rescanning the chain. The Zcash implementation is [Ragu](https://github.com/tachyon-zcash/ragu), which follows Halo and needs no trusted setup. |
 | Peer-to-Peer Network | P2P networks are based on the concept of decentralization. The foundational architecture of blockchain technology. |
+| PIR (Private Information Retrieval) | Techniques that let you fetch a record from a server without the server learning which record you asked for. Under active research for Zcash as a way for light wallets to retrieve what they need without leaking what they are looking for. |
 | Podcast | [Radiolab (Zcash Ceremony)](https://archive.org/details/radiolab_podcast17crypto_zcash_ceremony) / [RealVisionFinance](https://www.youtube.com/watch?v=ibA_4kwd_YI) / [EthDenver](https://www.youtube.com/watch?v=t62isi58XcQ) / [UpOnlyPodcast](https://www.youtube.com/watch?v=AjC9T938o3Q) / [Zcast en Español](https://www.youtube.com/@ZcastEsp) |
 
 ## Q
@@ -147,6 +152,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Term | Definition |
 |------|-----------|
 | QR Code | A machine-readable code used to encode Zcash addresses for easy scanning. Unified Addresses (UAs) are typically shared via QR codes in modern Zcash wallets. |
+| Quantum Recoverability | A property of Ironwood notes, specified in [ZIP 2005](https://zips.z.cash/zip-2005), that keeps a coin's on-chain record recoverable if a future quantum computer breaks the cryptography protecting it today. It is a recovery path rather than quantum resistance, and it applies to Ironwood notes, not to existing Sprout, Sapling or Orchard funds. |
 
 ## R
 
@@ -170,6 +176,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 
 | Term | Definition |
 |------|-----------|
+| Tachyon | Zcash's scaling programme, targeted at NU7. It moves wallets away from scanning every block toward proof-carrying wallet state, oblivious synchronization and prunable node state, aiming for shielded throughput in the thousands of transactions per second. [Project site](https://tachyon.z.cash/overview/) |
 | TAZ | Testnet Zcash (valueless test currency). |
 | Testnet | A separate blockchain for testing upgrades and features before mainnet. |
 | Transaction | A payment between users, submitted to the network and eventually confirmed in a block. |
@@ -177,6 +184,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | Transaction Fee | Default fee is 0.0001 ZEC. Higher fees get priority; very low fees may cause delays or expiry. |
 | Transparent Address | Also called taddr. Starts with t. Fully public (like Bitcoin). |
 | Transparent Transaction | A transaction exclusively between transparent addresses - everything is publicly visible. |
+| Turnstile | The accounting rule that tracks how much value enters and leaves each shielded pool, so no pool can release more than went into it. Used at every pool transition in Zcash's history, and currently guarding the migration from Orchard into Ironwood. [More info](/zcash-tech/the-turnstile) |
 
 ## U
 
@@ -219,6 +227,7 @@ A comprehensive glossary of key terms, concepts, and resources related to Zcash.
 | ZEC | The official currency code for Zcash (some exchanges still show XZC). |
 | Zerocash | The academic protocol (2014) that Zcash is based on. |
 | Zaino | The next-generation Zcash indexer replacing lightwalletd, built by the Zcash Foundation. Enables light clients to sync faster and more privately. Part of the Zcash Z3 infrastructure upgrade. |
+| Zakura | A Zcash full node implementation released in July 2026, built as a fork of Zebra by Valar Group and Project Tachyon. It targets throughput and sync speed, with snapshot bootstrapping and a stated goal of card-network scale, around 50,000 transactions per second. [zakura.com](https://zakura.com) |
 | Zallet | The upcoming official Zcash wallet by the Electric Coin Co / ZODL team, built on Zaino. Zallet Alpha is in active development as of 2026. [Forum](https://forum.zcashcommunity.com/t/zcash-z3-updates-formerly-zcashd-deprecation/48965) |
 | Zebra | The Zcash Foundation's Rust-based full node implementation (alternative to zcashd). Production-ready and actively maintained. [GitHub](https://github.com/ZcashFoundation/zebra) |
 | ZIP | Zcash Improvement Proposal - the community governance process used to propose and ratify protocol changes. [ZIP Repository](https://github.com/zcash/zips) |


### PR DESCRIPTION
Went through the past year and added 18 terms: Crosslink, CrossPay, Formal Verification, Ironwood, NSM, Noir Wallet, Oblivious Synchronization, PCD, PIR, Quantum Recoverability, Shielded Labs, Tachyon, Trailing Finality Layer, Turnstile, WebZjs, Zakura, zcashd, ZSA.

Also fixed five entries that had gone stale. The ZODL one was describing it as ECC's consumer product line, so I rewrote it. ECC, YWallet, Zallet and NU7 needed smaller updates.