### PR TITLE
Add Zcash Ecosystem Digest 08-08-26

### DIFF
--- a/newsletter/Digest 08-08-26.md
+++ b/newsletter/Digest 08-08-26.md
@@ -1,0 +1,61 @@
+# Zcash Ecosystem Digest
+
+**Reporting Period:** July 7 – August 6, 2026
+
+---
+
+# Shielded Labs, ZODL, Zcash Foundation Updates
+
+- Ironwood (NU6.3) activated on Zcash mainnet on July 28, 2026, opening a new shielded pool and starting the community migration off the older Orchard pool. By early August, roughly 21.5% of all shielded ZEC had already moved into the Ironwood pool. — [Zcash Korea](https://x.com/zcashkorea/status/2084635935250194607?s=20) / [ZecHub Digest, Aug 2nd](https://zechub.substack.com/p/zcash-ecosystem-digest-august-2nd)
+- The Zcash Foundation released Zebra 6.0.0-rc.0 on July 3, adding NU6.3 "Ironwood" testnet support, an in-place state-database upgrade with no resync needed, reproducible Docker images, and signed binaries via `cargo binstall`. — [Zcash Foundation](https://x.com/ZcashFoundation/status/2073096818775187921?s=20)
+- zcashd, the original C++ full node running since 2016, formally reached end-of-support at block height 3,417,100 on July 18, 2026, completing the shift to Rust-based nodes. — [ZecHub Shielded News, Vol. 28](https://zechub.substack.com/p/zcash-shielded-news-vol28-2fd)
+- Zakura, the Zebra-derived full node from Project Tachyon and Valar Group, shipped version 1.0.5, proactively mitigating a Testnet issue shared with Zebra and adding stability/performance improvements. — [Zakura](https://x.com/ZakuraZcash/status/2081958808033931651?s=20)
+- The entire Zingo wallet ecosystem confirmed full compatibility with NU6.2 ahead of the Ironwood upgrade. — [ZecHub Digest, July 19th](https://zechub.substack.com/p/zcash-ecosystem-digest-july-19th)
+- The Sovright team launched Sovright Relay, a public, low-latency block-propagation network meant to reduce the infrastructure advantage of large mining pools; it runs alongside Zcash's existing P2P network with no consensus changes and is open source. — [ZecHub Shielded News, Vol. 29](https://zechub.substack.com/p/zcash-shielded-news-vol29-465)
+- The Zcash Foundation published its Q2 2026 transparency report on August 6, covering engineering-team activity and broader organizational work. — [Zcash Foundation](https://x.com/ZcashFoundation/status/2085306441120756103?s=20)
+- More than 50 contributors from 18 Zcash projects met in Prague (July 8–10) for a working summit on Ironwood, the zcashd retirement, Project Tachyon, and post-quantum plans. — [ZecHub Shielded News, Vol. 28](https://zechub.substack.com/p/zcash-shielded-news-vol28-2fd)
+- Background: Ironwood's design traces back to a critical Orchard circuit vulnerability Shielded Labs disclosed in early June 2026 — a soundness bug, present since 2022, that could have allowed undetectable counterfeit ZEC. It was patched immediately, and Ironwood was proposed to make ZEC's supply auditable without exposing individual transactions. — [Shielded Labs](https://shieldedlabs.net/the-orchard-counterfeiting-vulnerability/)
+
+---
+
+# Zcash Community Grants
+
+- Zcash Türkiye opened applications for the Coinholder-Directed Retroactive Grant Program (Q3 2026), rewarding already-completed, publicly verifiable ecosystem work. Deadline: August 14, followed by a 30-day community review and coinholder voting through September. Named applicants include Unstoppable Wallet, Zafu Wallet, CipherPay, THORSwap/Metro, ZcashNames, and ZODL. — [Zcash Türkiye](https://x.com/ZcashTR/status/2084681252150624346?s=20)
+- The Zcash Community Grants committee approved five new proposals this cycle: an educational series on Zcash within the privacy ecosystem, a penetration-testing engagement, ZECsy's Cypherpunk Week Amsterdam outreach, a Zcash Türkiye RLAY Hub hackathon event, and developer outreach at Web3Lagos. — [ZecHub Shielded News, Vol. 29](https://zechub.substack.com/p/zcash-shielded-news-vol29-465)
+- ZecBooks, a Mac-native, non-custodial accounting and treasury platform for Zcash teams, filed a $32,000 retroactive grant application for its notarized v0.1.1 release. — [Zcash Community Forum](https://forum.zcashcommunity.com/t/retroactive-grant-application-zecbooks/56914)
+- The ZECsy team applied for a 12-month grant to fund a four-person field crew running onboarding workshops and conference activations from September 2026 through August 2027. — [Zcash Community Forum](https://forum.zcashcommunity.com/t/grant-application-zecsy-community-building-12-months-of-zcash-on-the-ground/56890)
+- A grant proposal for constant-time hardening and explicit timing semantics in Zcash's Rust cryptography libraries remains open for community review. — [ZecHub Digest, July 12th](https://zechub.substack.com/p/zcash-ecosystem-digest-july-12th)
+
+---
+
+# Community Projects
+
+- **ZecHub** announced the winners of ZecHub Hackathon 3.0, where 36 projects were submitted across five tracks — Infrastructure, Games, FROST, Zcash Login, and Accounting — between May 25 and July 15, 2026. — [ZecHub](https://x.com/ZecHub/status/2084392732550951014?s=20)
+- **ZecHub** launched a dedicated Engineering Office Hours page, collecting release notes and playlists in one place. — [ZecHub Digest, July 26th](https://zechub.substack.com/p/zcash-ecosystem-digest-july-26th)
+- **Zcash Brasil** announced "ZEC Trivia – SeaZon II," an August 6 Discord trivia event testing community knowledge of Zcash and privacy, built around a "Zcine" screening with exclusive prizes. — [Zcash Brasil](https://x.com/zcashbrazil/status/2084685954896347414?s=20)
+- **Zcash Nigeria** welcomed August with a community graphic thanking supporters, developers, and privacy advocates for continued work on digital privacy education. — [Zcash Nigeria](https://x.com/ZcashNigeria/status/2083646169784234282?s=20)
+- **Zcash Korea** published a step-by-step guide for migrating ZEC into the Ironwood pool using the Zodl wallet, alongside live network-share tracking. — [Zcash Korea](https://x.com/zcashkorea/status/2084635935250194607?s=20)
+- **Zcash India** launched "Meetup Bounty #2," a $150 prize pool for members hosting mini meetups this August that cover the Ironwood upgrade and Zakura, with set attendance/content requirements. Deadline: August 25. — [Zcash India](https://x.com/ZcashIND/status/2084919775688552584?s=20)
+- **Zcash East Africa** kept its Ironwood explainer video challenge open (deadline August 10), rewarding community-made content about the upgrade with ZEC. — [Zcash East Africa](https://x.com/ZcashEastAfrica/status/2084647223313248317?s=20)
+- **Zcash Ghana** called for volunteer facilitators for a new pilot Zcash Developers Residency Programme launching September 1, 2026, after onboarding 500+ new community members in its first year. — [Zcash Ghana](https://x.com/ZcashGH/status/2083975354776162472?s=20)
+- **Zcash Arabia** hosted an Ask Me Anything with the Noir Wallet team (the first Zcash-enabled browser-extension wallet), published an Ironwood migration guide for Zodl users, and held its first in-person Zcash meetup in Algeria. — [ZecHub Digest, Aug 2nd](https://zechub.substack.com/p/zcash-ecosystem-digest-august-2nd)
+- **Zcash Türkiye** published Turkish-language explainers on the Ironwood upgrade and had its three-day RLAY Hub hackathon event approved for ZCG funding. — [Zcash Türkiye](https://x.com/ZcashTR/status/2084681252150624346?s=20)
+- **Club Zcash Querétaro** recapped its 7th in-person meetup, covering how Mexicans invest and where real estate fits the local financial landscape, followed by a ZEC-prize trivia session. — [Zcash QRO](https://x.com/zcashqro/status/2085071910757691708?s=20)
+- **ruZCASH** shared a Russian-language explainer on tracing crypto across blockchains — centralized exchanges, no-KYC swap services, and decentralized bridges such as THORChain, Relay, and LI.FI. — [ruZCASH](https://x.com/ruZCASH/status/2084588262006350150?s=20)
+- **ZK AV Club** recapped a busy July spanning Blockchain Week and DWeb Camp appearances, continued workshops, new recordings, and archive groundwork. — [ZK AV Club](https://x.com/ZkAv_Club/status/2083216414786142707?s=20)
+- **genzcash** shared a clip of Raoul Pal arguing that full on-chain transparency has become a liability as institutions adopt crypto. — [genzcash](https://x.com/genzcash/status/2085138992694239610?s=20)
+- **genzcash** joked that Zcash is what you get when you spell out "formally verified, quantum-resistant, infinitely scalable, thermodynamic, private, unstoppable money" in plain English. — [genzcash](https://x.com/genzcash/status/2084653563419230386?s=20)
+- **Zakura** published explainer content on how the Zakura full node fits Zcash's scalability roadmap alongside Project Tachyon. — [Zakura](https://x.com/ZakuraZcash/status/2081958808033931651?s=20)
+- **ZecMap** shared a market update: 400+ registered users, 212 iOS downloads, and 9,768 merchants via its Flexa integration, plus a new TEKCE Real Estate partnership enabling ZEC-based property purchases in several countries. — [ZecMap](https://x.com/ZecMap/status/2083887674583114059?s=20)
+- **Gleyo**, a new ZEC-native quest and community-growth platform, was submitted as part of ZecHub Hackathon 3.0. — [ZecHub Digest, July 19th](https://zechub.substack.com/p/zcash-ecosystem-digest-july-19th)
+- **ZK Loyalty**, a new privacy-first loyalty-program platform letting small businesses reward repeat customers anonymously, was showcased in ZecHub's community round-up. — [ZecHub Digest, July 26th](https://zechub.substack.com/p/zcash-ecosystem-digest-july-26th)
+- **LiveZEC** continued promoting Zcash's use case for real-world private payments during the Ironwood migration push. — [ZecHub Digest, July 19th](https://zechub.substack.com/p/zcash-ecosystem-digest-july-19th)
+- A community-driven **"Privacy Is Normal"** manifesto became available in 32 languages through a volunteer translation effort. — [ZecHub Digest, July 26th](https://zechub.substack.com/p/zcash-ecosystem-digest-july-26th)
+- The **Zcash Community Forum** hosted active discussion on Orchard-to-Ironwood migration tooling and a new Rust implementation of lightwalletd. — [ZecHub Digest, July 26th](https://zechub.substack.com/p/zcash-ecosystem-digest-july-26th)
+
+---
+
+# Meme of the Week
+
+**"When I say 'formally verified quantum resistant infinitely scalable thermodynamic private unstoppable money' instead of 'Zcash'"** — a deadpan post from genzcash poking fun at how dense Zcash's technical pitch can sound compared to just saying its name, posted right in the middle of the Ironwood migration news cycle.
+[genzcash](https://x.com/genzcash/status/2084653563419230386?s=20)


### PR DESCRIPTION
Zcash Ecosystem Digest covering July 7–Aug 6, 2026: Ironwood mainnet activation, Zebra/Zakura releases, ZCG grants, and 21 community project updates across 15+ regional communities, each sourced with a matching link. Note: the two failing checks (menu-titles-fresh, protected-terms) are unrelated to this submission, they validate wiki translation files, not the newsletter folder.