### PR TITLE
Rewrite Viewing Keys around software that still runs

### DIFF
--- a/site/Zcash_Tech/Viewing_Keys.md
+++ b/site/Zcash_Tech/Viewing_Keys.md
@@ -4,64 +4,112 @@
 
 # Viewing Keys
 
-Shielded addresses enable users to transact while revealing as little information as possible on the Zcash blockchain. What happens when you need to disclose sensitive information around a shielded Zcash transaction to a specific party? Every shielded address includes a viewing key. Viewing keys were introduced in [ZIP 310](https://zips.z.cash/zip-0310) and added to the protocol in the Sapling network upgrade. Viewing keys are a crucial part of Zcash as they allow users to selectively disclose information about transactions.
+Shielded addresses let you transact while revealing as little as possible on the Zcash blockchain. So what happens when you *do* need to show a specific party what you hold, or what you sent? Every shielded address has a viewing key that grants read access without granting the ability to spend. Viewing keys were introduced in [ZIP 310](https://zips.z.cash/zip-0310) and added to the protocol in the Sapling network upgrade.
 
-### Why use a viewing key?
+A viewing key is the tool for selective disclosure: you choose who sees what, and you never hand over spend authority to do it.
 
-Why would a user ever want to do this? From Electric Coin Co.'s blog on the matter...
+## Why use a viewing key?
 
-*- An exchange wants to detect when a customer deposits ZEC to a shielded address, while keeping the **spend authority** keys on secure hardware. The exchange could generate an incoming viewing key and load it onto an Internet-connected **detection** node, while the spending key remains on the more secure system.*
+Electric Coin Company's writing on the subject sets out the situations that come up most often, and they are still the common ones today:
 
-*- A custodian needs to provide visibility of their Zcash holdings to auditors. The custodian may generate a full viewing key for each of their shielded addresses and share that key with their auditor. The auditor will be able to verify the balance of those addresses and review past transaction activity to and from those addresses.* 
+- **An exchange watching for deposits.** The exchange loads an incoming viewing key onto an internet-facing detection node so it can notice customer deposits to a shielded address, while the spending key stays on hardware that never touches the network.
+- **A custodian proving its holdings.** The custodian hands an auditor a full viewing key for each shielded address. The auditor can check those balances and review past activity to and from those addresses, and can do nothing else.
+- **Due diligence on a counterparty.** Where an exchange needs to review a customer's shielded history as part of enhanced due diligence, it can ask for the viewing key rather than for the funds.
 
-*- An exchange may need to conduct due diligence checks on a customer who makes deposits from a shielded address. The exchange could request the customers viewing key for their shielded address and use it to review the customers shielded transaction activity as part of these enhanced due diligence procedures.*
+## What a viewing key does and does not reveal
 
-### How to find your viewing key
+There is more than one kind of key, and the difference decides how much you give away.
 
-#### zcashd
+| Key | Prefix | Grants |
+|---|---|---|
+| Unified full viewing key (UFVK) | `uview…` | Sees incoming **and** outgoing transactions for every pool in the account |
+| Unified incoming viewing key (UIVK) | `uivk…` | Sees incoming transactions only, for every pool in the account |
+| Sapling extended full viewing key | `zxviews…` | Sees incoming and outgoing Sapling activity for the key's addresses |
 
-* List all known addresses using *./zcash-cli listaddresses*
+None of these can spend. All of them are permanent in the way that matters: a key you have handed out cannot be recalled, only outlived, by moving funds to an account whose keys the other party does not hold.
 
-* Then issue the following command for either UA's or Sapling shielded addresses
+Two disclosure traps are worth knowing before you share anything.
 
-  ```bash
-  ./zcash-cli z_exportviewingkey "<UA or Z address>"
-  ```
+**Incoming does not mean narrow.** A unified incoming viewing key is scoped to the whole account, not to the one address you were asked about. Exporting a UIVK for a single Sapling address still grants incoming visibility across every pool in that account, so it discloses more than the address it names. The [Zallet Book](https://zcash.github.io/zallet/zcashd/json_rpc.html) states this explicitly.
 
-#### Ywallet
+**A published address already exposes its incoming viewing key to a future adversary.** [ZIP 326](https://zips.z.cash/zip-0326) notes that an adversary with a quantum computer could recover the incoming viewing key from a published diversified address, which is feasible in a way that recovering the nullifier key is not. Publishing an address is not the same as publishing a viewing key today, but the two sit closer together over a long enough horizon.
 
-* On the top right corner select "Backup", Authenticate your phone, then simply copy your viewing key that is displayed.
+## Viewing keys after Ironwood
 
-### How to use your viewing key
+NU6.3 introduced the Ironwood shielded pool and made the Orchard pool spend-only, so funds migrate from one to the other over time. See [Ironwood](/zcash-tech/ironwood) and [The turnstile](/zcash-tech/the-turnstile) for the upgrade itself.
 
-#### zcashd
+**A viewing key issued before Ironwood keeps working after the migration.** ZIP 326 specifies that a receiver, and its corresponding incoming viewing key, is scoped to the Orchard *protocol* rather than to a pool: the same incoming viewing key trial-decrypts both Orchard-pool and Ironwood-pool note ciphertexts. Zallet implements it that way, describing Ironwood notes as Orchard-shaped and trial-decrypted with the account's Orchard viewing keys under the Ironwood note-encryption domain.
 
-* Use the following with any vkey or ukey: 
+Three consequences for anyone holding or issuing a key:
+
+1. **Balances move between pools, and the viewer sees it happen.** [ZIP 318](https://zips.z.cash/zip-0318) specifies migration as a series of small, deliberately uniform Orchard-to-Ironwood transactions broadcast on a randomised schedule, each spending one Orchard note and producing one Ironwood output of a canonical denomination. An auditor watching with a viewing key sees holdings shift from one pool to the other in steps over weeks, not in a single move. A wallet can reconstruct its own migration progress from chain data using its viewing keys.
+2. **Each migration step reveals the value it moves.** That is inherent to crossing a turnstile, and it is what makes the migration auditable. Splitting the balance into canonical denominations means no single transaction reveals the whole Orchard-pool balance.
+3. **Accounts created after Ironwood may derive their keys differently.** [ZIP 2005](https://zips.z.cash/zip-2005) adds a `use_qsk` flag for quantum-recoverable keys, and it changes how the incoming, outgoing and diversifier keys are derived, so `use_qsk = true` keys are genuinely different keys. ZIP 326 requires the flag to be uniform across an account and forbids generating `use_qsk = true` keys before NU6.3 activated on Mainnet. A key exported from an account that existed before Ironwood is therefore a `use_qsk = false` key, and stays correct for that account. Do not assume a key exported from one account describes another.
+
+## Exporting a viewing key
+
+### Zallet
+
+[Zallet](https://github.com/zcash/zallet) is the full-node wallet that replaced the wallet inside zcashd. Viewing-key export and import arrived in **v0.1.0-beta.2 (28 July 2026)**, so check your version first; earlier builds do not have these methods. Every argument after the method name must be valid JSON, which means string values keep their own double quotes. The [Zallet Quick Reference Guide](/using-zcash/zallet-quick-reference-guide) covers the general command style.
+
+List what the wallet holds:
 
 ```bash
-./zcash-cli z_importviewingkey "vkey/ukey" whenkeyisnew 30000
+zallet rpc listaddresses
 ```
 
-#### ywallet
+Export the account's unified full viewing key by passing a unified address:
 
-* In the top right corner, select "Account", click on "+" in the bottom right corner to add and import your viewing key to add your 'read-only' account.
+```bash
+zallet rpc z_exportviewingkey '"<unified address>"'
+```
 
-<a href="">
-    <img src="/content-images/image-2024-01-13-175554676-8cdf988797.webp" alt="" width="200" height="280"/>
-</a>
+Export the account's unified incoming viewing key instead, using the optional `ivk` argument:
 
+```bash
+zallet rpc z_exportviewingkey '"<unified address>"' true
+```
 
-#### zcashblockexplorer.com
+Passing a Sapling address returns that account's Sapling extended full viewing key (`zxviews…`), matching the old zcashd behaviour. Two documented limits: Sprout addresses are rejected, and a Sapling extended full viewing key cannot be exported from an account that was itself imported as view-only, because the wallet cannot reconstruct it. The `ivk` form does work for imported view-only accounts.
 
-* Simply point your browser to [here](https://zcashblockexplorer.com/vk) and wait for the results! note: this result is now on the zcashblockexplorer node and thus you're trusting this info with the owners of zcashblockexplorer.com
+### Wallets that export viewing keys from their own interface
 
-### Resources
+The [Wallets](/using-zcash/wallets) page tracks viewing-key support and Ironwood readiness for each wallet. At the time of writing, wallets listing both viewing-key support and **Ironwood: Ready** include ZODL, Zingo!, Zkool, Cake, Zallet, Zecd and Nozy. Check that page rather than this one before relying on any single wallet, because readiness changes.
 
-While a great technology, it's recommended that you use viewing keys on an as needed basis.
+## Importing a viewing key as a watch-only account
 
-Check out this tutorial on viewing keys. A list of resources on the subject is below if you want to dive deeper:
+### Zkool
 
+[Zkool](https://github.com/hhanh00/zkool2) is the most flexible option here, because it accepts unified keys as well as legacy ones. Its README documents view-only accounts created from a **unified viewing key** or a **Sapling extended viewing key**, alongside legacy shielded extended keys exported from zcashd. Add a new account, choose the view-only route, and paste the `uview…` or `zxviews…` key; the account then syncs and reports balances and history with no spend authority.
+
+Ironwood protocol support and the Orchard-to-Ironwood migration landed in Zkool 6.24.0 (20 July 2026), and 6.26.1 (2 August 2026) fixed Ironwood transaction detection in the mempool. Run 6.26.1 or later.
+
+### Zallet
+
+```bash
+zallet rpc z_importviewingkey '"<zxviews… key>"' '"whenkeyisnew"' 0
+```
+
+The second argument is the rescan policy: `"whenkeyisnew"` (the default), `"yes"` or `"no"`. The third is the block height to rescan from. Zallet imports the key as a view-only account and tracks incoming and outgoing transactions for its addresses without spending authority.
+
+**Zallet imports Sapling extended full viewing keys only.** It will not import a `uview…` unified full viewing key, even though it can export one. To hand over read access to a whole unified account, export the UFVK from Zallet and import it into a wallet that accepts unified keys, such as Zkool.
+
+## What changed, and what to stop looking for
+
+If you followed an older version of this page, or a translation of it, three routes no longer work.
+
+- **`zcash-cli z_exportviewingkey` and `z_importviewingkey`.** zcashd reached its end-of-support halt on 18 July 2026 and no longer runs. Zallet's identically named methods are the replacement; see the [migration guide](/guides/migration-guide-zcashd-to-zebrad-zallet).
+- **The Ywallet walkthrough.** The Wallets page marks Ywallet **Ironwood: Not Ready**, so it is not the wallet to point people at for Ironwood-era viewing keys. Zkool, from the same developer, accepts the same range of keys and is marked Ready.
+- **zcashblockexplorer.com/vk.** The service returns HTTP 503 with an invalid certificate, and it has been dropped rather than replaced. Pasting a viewing key into a website hands your whole transaction history to whoever runs that website, which was always the weakest of the three options on the old page. Import the key into a wallet you run instead.
+
+## Resources
+
+Use viewing keys on an as-needed basis, and prefer the narrowest key that answers the question being asked.
+
+- [ZIP 326: NU6.3 Consequences for Wallets](https://zips.z.cash/zip-0326) — how viewing keys behave across the Orchard and Ironwood pools
+- [ZIP 229: Version 6 Transaction Format](https://zips.z.cash/zip-0229) — defines the Orchard and Ironwood pools
+- [Zallet changelog](https://github.com/zcash/zallet/blob/main/CHANGELOG.md) — which release added which RPC method
+- [Zkool README](https://github.com/hhanh00/zkool2/blob/main/README.md) — supported account and key types
 - [ECC, Explaining Viewing Keys](https://electriccoin.co/blog/explaining-viewing-keys/)
 - [ECC, Selective Disclosure and Viewing Keys](https://electriccoin.co/blog/viewing-keys-selective-disclosure/)
 - [ECC, Zcash Viewing Key Video Presentation](https://www.youtube.com/watch?v=NXjK_Ms7D5U&t=199s)
-- [ZIP 310](https://zips.z.cash/zip-0310)


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="53:1-53:126;1289-1414">Closes the bounty <a class="underline underline underline-offset-2 decoration-1 decoration-current/40 hover:decoration-current focus:decoration-current" href="https://bounties.zechub.wiki">"Every method on the Viewing Keys page is dead"</a> on the ZecHub bounty board.</p>

<h3 dir="ltr" class="mt-2 -mb-1 text-base font-bold" data-sourcepos="55:1-55:16;1416-1431">The problem</h3>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="57:1-57:138;1433-1570"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">site/Zcash_Tech/Viewing_Keys.md</code> documented three ways to work with a viewing key. All three were dead when I checked on 10 August 2026:</p>

<div dir="ltr" class="overflow-x-auto w-full px-2 mb-6 print:overflow-x-visible" data-sourcepos="59:1-63:72;1572-1915">
Method on the page | State
-- | --
./zcash-cli z_exportviewingkey / z_importviewingkey | zcashd reached its end-of-support halt on 18 July 2026
Ywallet find-and-import walkthrough, with screenshot | The Wallets page marks Ywallet Ironwood: Not Ready
zcashblockexplorer.com/vk | HTTP 503, invalid certificate altname

</div>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="65:1-65:135;1917-2051">The page never mentioned Zallet, Zodl, Zingo, Zkool or Ironwood. It is a curated page, so the same content is carried into 18 locales.</p>

<h3 dir="ltr" class="mt-2 -mb-1 text-base font-bold" data-sourcepos="67:1-67:22;2053-2074">What this changes</h3>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="69:1-69:472;2076-2547"><strong>Export, via Zallet.</strong> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">z_exportviewingkey</code> and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">z_importviewingkey</code> arrived in Zallet <strong>v0.1.0-beta.2 on 28 July 2026</strong>, so the page states that minimum version. It documents the UFVK form, the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ivk</code> argument for a UIVK, and the three limits the Zallet Book records: Sprout addresses are rejected, a Sapling extended full viewing key cannot be exported from an account that was itself imported as view-only, and the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ivk</code> form does work for imported view-only accounts.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="71:1-71:502;2549-3050"><strong>Import, via Zkool.</strong> Zallet imports Sapling extended full viewing keys only — it will not import a <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">uview…</code> UFVK even though it can export one. Zkool accepts unified viewing keys and Sapling extended viewing keys, so the page pairs the two: export the UFVK from Zallet, import it into Zkool. Both wallets are marked <strong>Ironwood: Ready</strong> on the Wallets page. Zkool version guidance is 6.26.1 or later, since 6.24.0 added Ironwood support and 6.26.1 fixed Ironwood transaction detection in the mempool.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="73:1-73:1007;3052-4058"><strong>A new section on viewing keys after Ironwood</strong>, answering the question the old page could not: a viewing key issued before Ironwood keeps working after funds migrate. <a class="underline underline underline-offset-2 decoration-1 decoration-current/40 hover:decoration-current focus:decoration-current" href="https://zips.z.cash/zip-0326">ZIP 326</a> specifies that a receiver and its corresponding incoming viewing key are scoped to the Orchard <em>protocol</em> rather than to a pool, so the same incoming viewing key trial-decrypts both Orchard-pool and Ironwood-pool note ciphertexts. Zallet's changelog corroborates this at the implementation level. The section also covers <a class="underline underline underline-offset-2 decoration-1 decoration-current/40 hover:decoration-current focus:decoration-current" href="https://zips.z.cash/zip-2005">ZIP 2005</a>'s <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">use_qsk</code> distinction — those are genuinely different keys, and ZIP 326 forbids generating them before NU6.3 activated on Mainnet, so a pre-Ironwood key is necessarily a <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">use_qsk = false</code> key that stays correct for its account — and what <a class="underline underline underline-offset-2 decoration-1 decoration-current/40 hover:decoration-current focus:decoration-current" href="https://zips.z.cash/zip-0318">ZIP 318</a> migration looks like to someone watching with a viewing key: many small canonical transactions on a randomised schedule, each revealing the value it moves.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="75:1-75:418;4060-4477"><strong>Two disclosure warnings the page was missing.</strong> A unified incoming viewing key is account-scoped, so exporting one for a single Sapling address still grants incoming visibility across every pool in the account. And ZIP 326 notes that an adversary with a quantum computer could recover an incoming viewing key from a published diversified address, which is feasible in a way that recovering the nullifier key is not.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="77:1-77:150;4479-4628"><strong>A short "what changed" section</strong> so readers arriving from search or from a stale translation learn why the commands they were looking for are gone.</p>

<h3 dir="ltr" class="mt-2 -mb-1 text-base font-bold" data-sourcepos="79:1-79:43;4630-4672">Two editorial decisions worth flagging</h3>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="81:1-81:342;4674-5015"><strong>The ECC block quotes are now paraphrased.</strong> The "Why use a viewing key?" section reproduced three paragraphs verbatim from the Electric Coin Company blog. I kept the section and all three use cases, rewrote them in ZecHub's own words, and kept the attribution and links. The framing was the good part of the old page and it is still there.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="83:1-83:379;5017-5395"><strong>The stale Ywallet screenshot is removed rather than replaced.</strong> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">/content-images/image-2024-01-13-175554676-8cdf988797.webp</code> is not in this repository, and I did not want to invent a click-by-click walkthrough for a wallet interface I could not verify, since that is roughly how the old page decayed. The Zkool instructions stay at the level its README documents and link out.</p>

<h3 dir="ltr" class="mt-2 -mb-1 text-base font-bold" data-sourcepos="85:1-85:29;5397-5425">Relationship to PR #1905</h3>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="87:1-87:527;5427-5953">PR #1905 "docs: expand Viewing Keys article with comprehensive coverage" is open on this same file, unchanged since 27 July. It removes the same three dead sections, but its replacement text still directs readers to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">zcashd</code> commands for export and contains no mention of Zallet, Zodl, Zingo, Zkool or Ironwood, so it does not resolve the defect this bounty describes. Happy to rebase onto it instead if maintainers would rather land that one first — the substantive content here would need to be re-applied on top either way.</p>

<h3 dir="ltr" class="mt-2 -mb-1 text-base font-bold" data-sourcepos="89:1-89:17;5955-5971">Verification</h3>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="91:1-91:33;5973-6005">Run against <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">main</code> @ <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">b1177731</code>.</p>

<div role="group" aria-label="Code" tabindex="0" data-sourcepos="93:1-101:4;6007-6329" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"></div></div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre-wrap;">node translation/check-invariants.mjs --base origin/main
  → Manifest invariants hold: 181 curated pages, 18 locales.

node link-health/check-links.mjs --offline
  → 714 files, 11,133 links, 4 needing attention, 0 new
  → all 5 internal routes in this page resolve
  → repo-wide duplicate URLs down from 271 to 264</code></pre></div></div>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="103:1-103:151;6331-6481">Every external link on the page returns 200: ZIPs 310, 318, 326, 2005 and 229, the Zallet Book, the Zallet and Zkool repositories, and both ECC posts.</p>

<p class="font-claude-response-body break-words whitespace-normal" dir="ltr" data-sourcepos="105:1-105:83;6483-6565">Two known-failing checks, both pre-existing on <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">main</code> and neither introduced here:</p>

<ul dir="ltr" class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3 print:block print:space-y-1" data-sourcepos="107:1-108:669;6567-7609">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="107:1-107:374;6567-6940"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">menu-titles-fresh</code></strong> fails on <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">main</code> today, for <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Zcash_Tech/FROST_Threshold_Custody.md</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Zcash_Tech/The_Turnstile.md</code> and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">guides/Raspberry_Pi_4_Full_Node.md</code>. This PR keeps the H1 as <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]"># Viewing Keys</code>, so it adds no drift, and it deliberately does not touch <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">translation/menu-titles/en.json</code> — the regeneration is already in PR #1944 and doing it here would conflict.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="108:1-108:669;6941-7609"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">protected-terms</code></strong> fails on <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">main</code> with 558 missing terms. This PR takes it to 702: 144 new, being 18 locales × 8 terms (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Electric Coin Company</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">NU6</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Orchard</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ZODL</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Zallet</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Zingo</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Zkool</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">zebrad</code>), all attributed to the 18 not-yet-retranslated copies of this page. That is the unavoidable consequence of the English source gaining current terminology, and it is the same pattern as the merged Raspberry Pi rewrite (#1928), which accounts for 72 of the existing 558. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">detect-staleness.mjs</code> correctly flags the page in all 18 locales, taking the totals from 594 to 612 stale and 162 to 180 high-severity — the right signal for a rewritten curated page.</li></ul><!--EndFragment-->
</body>
</html>Closes the bounty ["Every method on the Viewing Keys page is dead"](https://bounties.zechub.wiki/) on the ZecHub bounty board.

The problem

site/Zcash_Tech/Viewing_Keys.md documented three ways to work with a viewing key. All three were dead when I checked on 10 August 2026:

Method on the page	State
./zcash-cli z_exportviewingkey / z_importviewingkey	zcashd reached its end-of-support halt on 18 July 2026
Ywallet find-and-import walkthrough, with screenshot	The Wallets page marks Ywallet Ironwood: Not Ready
zcashblockexplorer.com/vk	HTTP 503, invalid certificate altname

The page never mentioned Zallet, Zodl, Zingo, Zkool or Ironwood. It is a curated page, so the same content is carried into 18 locales.

What this changes

Export, via Zallet. z_exportviewingkey and z_importviewingkey arrived in Zallet v0.1.0-beta.2 on 28 July 2026, so the page states that minimum version. It documents the UFVK form, the ivk argument for a UIVK, and the three limits the Zallet Book records: Sprout addresses are rejected, a Sapling extended full viewing key cannot be exported from an account that was itself imported as view-only, and the ivk form does work for imported view-only accounts.

Import, via Zkool. Zallet imports Sapling extended full viewing keys only — it will not import a uview… UFVK even though it can export one. Zkool accepts unified viewing keys and Sapling extended viewing keys, so the page pairs the two: export the UFVK from Zallet, import it into Zkool. Both wallets are marked Ironwood: Ready on the Wallets page. Zkool version guidance is 6.26.1 or later, since 6.24.0 added Ironwood support and 6.26.1 fixed Ironwood transaction detection in the mempool.

A new section on viewing keys after Ironwood, answering the question the old page could not: a viewing key issued before Ironwood keeps working after funds migrate. [ZIP 326](https://zips.z.cash/zip-0326) specifies that a receiver and its corresponding incoming viewing key are scoped to the Orchard protocol rather than to a pool, so the same incoming viewing key trial-decrypts both Orchard-pool and Ironwood-pool note ciphertexts. Zallet's changelog corroborates this at the implementation level. The section also covers [ZIP 2005](https://zips.z.cash/zip-2005)'s use_qsk distinction — those are genuinely different keys, and ZIP 326 forbids generating them before NU6.3 activated on Mainnet, so a pre-Ironwood key is necessarily a use_qsk = false key that stays correct for its account — and what [ZIP 318](https://zips.z.cash/zip-0318) migration looks like to someone watching with a viewing key: many small canonical transactions on a randomised schedule, each revealing the value it moves.

Two disclosure warnings the page was missing. A unified incoming viewing key is account-scoped, so exporting one for a single Sapling address still grants incoming visibility across every pool in the account. And ZIP 326 notes that an adversary with a quantum computer could recover an incoming viewing key from a published diversified address, which is feasible in a way that recovering the nullifier key is not.

A short "what changed" section so readers arriving from search or from a stale translation learn why the commands they were looking for are gone.

Two editorial decisions worth flagging

The ECC block quotes are now paraphrased. The "Why use a viewing key?" section reproduced three paragraphs verbatim from the Electric Coin Company blog. I kept the section and all three use cases, rewrote them in ZecHub's own words, and kept the attribution and links. The framing was the good part of the old page and it is still there.

The stale Ywallet screenshot is removed rather than replaced. /content-images/image-2024-01-13-175554676-8cdf988797.webp is not in this repository, and I did not want to invent a click-by-click walkthrough for a wallet interface I could not verify, since that is roughly how the old page decayed. The Zkool instructions stay at the level its README documents and link out.

Relationship to PR #1905

PR #1905 "docs: expand Viewing Keys article with comprehensive coverage" is open on this same file, unchanged since 27 July. It removes the same three dead sections, but its replacement text still directs readers to zcashd commands for export and contains no mention of Zallet, Zodl, Zingo, Zkool or Ironwood, so it does not resolve the defect this bounty describes. Happy to rebase onto it instead if maintainers would rather land that one first — the substantive content here would need to be re-applied on top either way.

Verification

Run against main @ b1177731.

node translation/check-invariants.mjs --base origin/main
  → Manifest invariants hold: 181 curated pages, 18 locales.

node link-health/check-links.mjs --offline
  → 714 files, 11,133 links, 4 needing attention, 0 new
  → all 5 internal routes in this page resolve
  → repo-wide duplicate URLs down from 271 to 264

Every external link on the page returns 200: ZIPs 310, 318, 326, 2005 and 229, the Zallet Book, the Zallet and Zkool repositories, and both ECC posts.

Two known-failing checks, both pre-existing on main and neither introduced here:

menu-titles-fresh fails on main today, for Zcash_Tech/FROST_Threshold_Custody.md, Zcash_Tech/The_Turnstile.md and guides/Raspberry_Pi_4_Full_Node.md. This PR keeps the H1 as # Viewing Keys, so it adds no drift, and it deliberately does not touch translation/menu-titles/en.json — the regeneration is already in PR #1944 and doing it here would conflict.
protected-terms fails on main with 558 missing terms. This PR takes it to 702: 144 new, being 18 locales × 8 terms (Electric Coin Company, NU6, Orchard, ZODL, Zallet, Zingo, Zkool, zebrad), all attributed to the 18 not-yet-retranslated copies of this page. That is the unavoidable consequence of the English source gaining current terminology, and it is the same pattern as the merged Raspberry Pi rewrite (#1928), which accounts for 72 of the existing 558. detect-staleness.mjs correctly flags the page in all 18 locales, taking the totals from 594 to 612 stale and 162 to 180 high-severity — the right signal for a rewritten curated page.

Unified ZEC address: u1v7g6ngfwurrn3d34tukzlc6lrstn44pwhac7qdeeyl6yje3vrra2cshpuvpm2m9dwga8j3rlqp3fukzslyg5ghmudely7tkwwt909a4tadm0jx4tf0v40phke38degnqwrvzjs5qktqj3ygc9kwpmgnxekfnm2yrh0g4lu7tpywzn25s