### PR TITLE
Update current-product Zashi references to Zodl

### DIFF
--- a/site/Start_Here/New_User_Guide.md
+++ b/site/Start_Here/New_User_Guide.md
@@ -7,7 +7,7 @@
 ## TL;DR
 
 - **Buy ZEC** on a supported exchange (Gemini, BitcoinVN, etc.)
-- **Set up a shielded wallet** (Zashi, YWallet, or ZODL recommended)
+- **Set up a shielded wallet** (Zodl, Zingo, or Zkool recommended)
 - **Withdraw** your ZEC from the exchange to your shielded wallet
 - **Send a shielded transaction** — your first private payment on Zcash
 - **Join the community** on the forum or Discord

--- a/site/Start_Here/Who_Can_See_Your_Zcash_Payment.md
+++ b/site/Start_Here/Who_Can_See_Your_Zcash_Payment.md
@@ -64,7 +64,7 @@ The order matters. Give the narrowest key that does the job, not the widest one 
 
 ## Put it into practice
 
-- Use a wallet that shields by default, such as [Zashi](https://electriccoin.co/zashi/) or [Ywallet](https://ywallet.app/).
+- Use a wallet that shields by default, such as [Zodl](https://zodl.com) or [Ywallet](https://ywallet.app/).
 - Shield funds as soon as they arrive from an exchange, before spending.
 - Pay to shielded addresses whenever the receiver supports one.
 - Before sharing a viewing key, ask which key is the smallest one that answers the question being asked.

--- a/site/Using_Zcash/Encifher_Swaps.md
+++ b/site/Using_Zcash/Encifher_Swaps.md
@@ -50,8 +50,8 @@ Navigate to the **Wrap** section. Choose **SOL** or **USDC**, enter the amount, 
 
 ---
 
-###  Step 3: Prepare Your Zashi Wallet  
-Download [**Zashi**](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://play.google.com/store/apps/details%3Fid%3Dco.electriccoin.zcash%26hl%3Den%26referrer%3Dutm_source%253Dgoogle%2526utm_medium%253Dorganic%2526utm_term%253Ddownload%2Bzashi%26pcampaignid%3DAPPU_1_BU7zaJ3oL8CEhbIP373a0Qs&ved=2ahUKEwjd_p7KqK2QAxVAQkEAHd-eNroQ5YQBegQIDRAC&usg=AOvVaw2x5eoefTu-3dkuC3ujc4cn), the official Zcash wallet by Electric Coin Co. Copy your **Unified Address** from the Receive tab - it supports both transparent and shielded ZEC. Save your seed phrase securely before proceeding.  
+###  Step 3: Prepare Your Zodl Wallet  
+Download [**Zodl**](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://play.google.com/store/apps/details%3Fid%3Dco.electriccoin.zcash%26hl%3Den%26referrer%3Dutm_source%253Dgoogle%2526utm_medium%253Dorganic%2526utm_term%253Ddownload%2Bzashi%26pcampaignid%3DAPPU_1_BU7zaJ3oL8CEhbIP373a0Qs&ved=2ahUKEwjd_p7KqK2QAxVAQkEAHd-eNroQ5YQBegQIDRAC&usg=AOvVaw2x5eoefTu-3dkuC3ujc4cn), the official Zcash wallet by Electric Coin Co. Copy your **Unified Address** from the Receive tab - it supports both transparent and shielded ZEC. Save your seed phrase securely before proceeding.  
 
 
 ![img7](/content-images/SykjhpgRll-60d19f6979.webp)
@@ -60,7 +60,7 @@ Download [**Zashi**](https://www.google.com/url?sa=t&source=web&rct=j&opi=899784
 ---
 
 ###  Step 4: Swap Privately  
-Back on **encrypt.trade**, go to **Swap**. Select **eSOL/eUSDC -> ZEC**, paste your Zashi address, review details, and confirm.
+Back on **encrypt.trade**, go to **Swap**. Select **eSOL/eUSDC -> ZEC**, paste your Zodl address, review details, and confirm.
 
 
 
@@ -72,7 +72,7 @@ Back on **encrypt.trade**, go to **Swap**. Select **eSOL/eUSDC -> ZEC**, paste y
 ![img9](/content-images/S1yoapgRle-6d2031a62c.webp)
 
 
-The **NEAR Intents** engine automatically handles cross-chain routing - delivering **ZEC** directly to your Zashi wallet within seconds.  
+The **NEAR Intents** engine automatically handles cross-chain routing - delivering **ZEC** directly to your Zodl wallet within seconds.  
 
 
 
@@ -81,7 +81,7 @@ The **NEAR Intents** engine automatically handles cross-chain routing - deliveri
 ---
 
 ###  Step 5: Shield and Stay Private  
-Once received, use Zashi's **Shield** option to move your ZEC into the shielded pool for maximum privacy. Always verify links, avoid reusing addresses, and test small amounts first.  
+Once received, use Zodl's **Shield** option to move your ZEC into the shielded pool for maximum privacy. Always verify links, avoid reusing addresses, and test small amounts first.  
 
 ---
 

--- a/site/Using_Zcash/Zcash_Mining_Guide.md
+++ b/site/Using_Zcash/Zcash_Mining_Guide.md
@@ -25,7 +25,7 @@ This guide focuses on mining Zcash using personal hardware (e.g., a home PC with
   - For GPUs: lolMiner (supports AMD/NVIDIA), GMiner, or miniZ (NVIDIA-focused). Download from official GitHub repos (e.g., github.com/Lolliedieb/lolMiner-releases).
   - For ASICs: Use the manufacturer's built-in firmware/dashboard (e.g., Bitmain's web interface).
 - **Wallet:** A Zcash wallet to receive payouts. Recommended:
-  - Shielded (private): Zashi Wallet, Zingo (Mobile/Desktop) YWallet (mobile/desktop).
+  - Shielded (private): Zodl Wallet, Zingo (Mobile/Desktop) YWallet (mobile/desktop).
   - Transparent (easier but less private): Edge Wallet, Zecwallet Lite.
   - Download from [wallets](https://zechub.wiki/wallets). Generate a shielded address (starts with 'zs') for privacy if the pool supports it.
 

--- a/site/Zcash_Community/Community_Projects.md
+++ b/site/Zcash_Community/Community_Projects.md
@@ -102,7 +102,7 @@ Discord bot providing seamless and secure access to Zcash transactions.
 [Visit](https://forum.zcashcommunity.com/t/dizzy-wallet-a-dedicated-zcash-wallet-for-discord/43988)
 
 ### ZODL
-Flagship Zcash wallet from Shielded Labs (formerly Zashi). Available on iOS and Android. Supports shielded ZEC and NU7 coinholder voting.  
+Flagship Zcash wallet from ZODL (formerly Zashi). Available on iOS and Android. Supports shielded ZEC and NU7 coinholder voting.  
 [Visit](https://zodl.app/)
 
 ### Noir Wallet

--- a/site/Zcash_Tech/What_a_Block_Explorer_Can_See.md
+++ b/site/Zcash_Tech/What_a_Block_Explorer_Can_See.md
@@ -56,7 +56,7 @@ Query the raw data and the shielded sender and receiver fields come back empty. 
 
 ## Put it into practice
 
-- Use a wallet that defaults to shielded addresses, such as [Zashi](https://electriccoin.co/zashi/) or [Ywallet](https://ywallet.app/).
+- Use a wallet that defaults to shielded addresses, such as [Zodl](https://zodl.com) or [Ywallet](https://ywallet.app/).
 - When you receive ZEC at a transparent address, move it into a shielded address before you spend it.
 - Pay to shielded addresses where you can. Every transparent payment is fully public; a shielded one is not.
 

--- a/site/Zcash_Tech/ZECD.md
+++ b/site/Zcash_Tech/ZECD.md
@@ -31,7 +31,7 @@ ZECD is a shielded-first wallet server for Zcash, built on [librustzcash](https:
 
 ZECD separates wallet responsibility from consensus. It is a **dedicated wallet layer** that sits between applications and a Zebra full node, providing:
 
-- A clean, modern Rust implementation built on librustzcash (the same library powering Zashi and Zodl)
+- A clean, modern Rust implementation built on librustzcash (the same library powering Zodl and Zingo)
 - Privacy-by-default design (Orchard addresses unless otherwise configured)
 - A Bitcoin-compatible RPC interface that removes the need to learn Zcash-specific tooling
 - Stateless, seed-recoverable architecture suited to containerized and cloud deployments

--- a/site/Zcash_Use_Cases/Receive_Donations_Privately.md
+++ b/site/Zcash_Use_Cases/Receive_Donations_Privately.md
@@ -51,7 +51,7 @@ This allows you to receive funds **without exposing your financial graph**.
 ## <img src="/content-images/icons8-toolbox-9bebbb1619.svg" width="24" height="24" className="inline-block align-middle mr-1 p-[2px]" alt="toolbox icon"/> What You Need
 
 - A Zcash wallet that supports shielded addresses:
-  - Zashi
+  - Zodl
   - YWallet
   - Other supported wallets
 

--- a/site/guides/ShapeShift_Zcash.md
+++ b/site/guides/ShapeShift_Zcash.md
@@ -56,7 +56,7 @@ Users can send ZEC between transparent and shielded addresses. For maximum priva
 
 ### Unified Addresses
 
-Modern Zcash wallets like [Zashi](https://electriccoin.co/zashi/) use **Unified Addresses**, which combine both transparent and shielded receivers into a single address. This simplifies the user experience while defaulting to the highest level of privacy available.
+Modern Zcash wallets like [Zodl](https://zodl.com) use **Unified Addresses**, which combine both transparent and shielded receivers into a single address. This simplifies the user experience while defaulting to the highest level of privacy available.
 
 ### Why Privacy Matters
 
@@ -82,7 +82,7 @@ Connect a compatible self-custody wallet. ShapeShift supports a range of wallets
 - **Keplr** (for Cosmos-based assets)
 - **WalletConnect-compatible wallets**
 
-Since you are swapping to or from ZEC, ensure you have a Zcash-compatible wallet (such as Zashi) ready to receive your funds.
+Since you are swapping to or from ZEC, ensure you have a Zcash-compatible wallet (such as Zodl) ready to receive your funds.
 
 ### Step 3: Select Your Swap Pair
 
@@ -98,7 +98,7 @@ Review the transaction details and confirm. The swap is executed on-chain throug
 
 ### Step 6: Shield Your ZEC
 
-Once your ZEC arrives, use your Zcash wallet's **shield** function (available in wallets like Zashi) to move the funds into the shielded pool. This ensures that your balance and future transactions remain fully private.
+Once your ZEC arrives, use your Zcash wallet's **shield** function (available in wallets like Zodl) to move the funds into the shielded pool. This ensures that your balance and future transactions remain fully private.
 
 ### Supported Cross-Chain Pairs
 
@@ -165,7 +165,7 @@ The ShapeShift and Zcash integration represents a meaningful step forward for pr
 
 [Zcash Official Website](https://z.cash/)
 
-[Zashi Wallet (by Electric Coin Co.)](https://electriccoin.co/zashi/)
+[Zodl Wallet](https://zodl.com)
 
 [ShapeShift DAO Governance (FOX Token)](https://shapeshift.com/fox-token)
 

--- a/site/guides/Using_ZEC_Privately.md
+++ b/site/guides/Using_ZEC_Privately.md
@@ -65,7 +65,7 @@ Here's a tutorial for how to shield your ZEC from a transparent address to a shi
 
 
 ---
-Here's a tutorial for how to buy ZEC on Coinbase and send to Zashi.
+Here's a tutorial for how to buy ZEC on Coinbase and send to Zodl.
 
 <div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
   <iframe

--- a/site/tutorials/Wallet_Tutorials.md
+++ b/site/tutorials/Wallet_Tutorials.md
@@ -7,7 +7,7 @@
 Below are a list of wallet tutorials that can help you get started with ZEC.
 
 
-- Zashi Wallet 
+- Zodl Wallet 
 
 [![Video Thumbnail](/content-images/hqdefault-a4a2a5de7f.webp)](https://www.youtube.com/watch?v=G92zBIr-Wms)
 


### PR DESCRIPTION
Zashi has been Zodl since February and the wiki was still using the old name where it reads as a current product.

Changed 18 references across 11 pages. The New User Guide was the one worth fixing first, it recommended "Zashi, YWallet, or ZODL" as if the first and third were different wallets. That now reads Zodl, Zingo, or Zkool.

Rest are wallet recommendations and walkthrough steps, mostly Encifher Swaps and ShapeShift. Links to electriccoin.co/zashi now point at zodl.com, which is where they redirect anyway.

Found two errors on the way: Community Projects credited the wallet to Shielded Labs rather than ZODL, and ZECD listed "Zashi and Zodl" as if they were two wallets.

Left the historical mentions alone, and the Keystone guide as you said, though its filename still carries the old name if you ever want that moved.
