### PR TITLE
i18n(terms): protect two key forms, four case variants, and a singular

### DIFF
--- a/translation/protected-terms.json
+++ b/translation/protected-terms.json
@@ -81,7 +81,14 @@
     "Zcash Engineering Office Hours",
     "NU6.1",
     "NU6.2",
-    "NU7"
+    "NU7",
+    "Full Viewing Key",
+    "Incoming Viewing Key",
+    "Zcash.me",
+    "Zingo!",
+    "ZGo",
+    "Zgo",
+    "ZK-SNARK"
   ],
   "glossaryOnly": [
     "token",


### PR DESCRIPTION
## Why

Three gaps found while auditing `translation/protected-terms.json` against the categorized list in the frontend repo.

**1. Key and address compounds are only half protected.** `Unified Address` and `Viewing Key` are enforced; the other expanded forms are not, so a translation can localize them and no check complains.

**2. The check is case-sensitive**, so a term protected in one casing is unprotected in the other. The list carries `Free2Z`, `Zcash.Me`, `MetaMask Snap` and `Zingo`, while the variants that actually appear in the wiki went unenforced. Same trap as `Zodl` vs `ZODL`, still open.

**3. `ZK-SNARKs` is enforced but its singular is not.**

## What is added — all seven cost nothing

| term | English pages | translations missing it |
|---|---|---|
| `Full Viewing Key` | 5 | **0** |
| `Incoming Viewing Key` | 2 | **0** |
| `Zcash.me` | 1 | **0** |
| `Zingo!` | 20 | **0** |
| `ZGo` | 27 | **0** |
| `Zgo` | 9 | **0** |
| `ZK-SNARK` | 1 | **0** |

Every existing translation already keeps them verbatim, so this locks in current behaviour and prevents a future regression.

**Verified:** the whole-tree audit reports **72 violations both before and after**, and none names a newly added term. (Those 72 are pre-existing drift from #1948 and #1957, cleared by the pending backfill/re-sync PR.)

## What is not here — and why it should not be added later either

An earlier draft of this PR listed `Unified Addresses` as merely *expensive*: 94 violations, 113 after the pending re-sync. Measuring what those violations actually are changed the conclusion. **Protecting an English plural is wrong in principle, not just costly.**

Of the 113, **70% already carry the protected singular** `Unified Address`. They did not lose the concept — they declined to pluralize an English loanword:

- English *"for inspecting Unified Addresses"* → Italian *"per ispezionare gli Unified Address"*. That is **correct Italian**; Italian does not add `-s` to English loanwords.
- Japanese writes `Unified Addressを調べる`, because Japanese **does not inflect plurals at all**. 23 of the 113 sit in `ja`/`ko`/`zh`, none of which do.

Enforcing the plural would push a grammatical error into Italian, French and Spanish, and a meaningless string into three more, to satisfy a check the singular already satisfies conceptually.

**The principle: protect singulars, not plurals.** Languages differ in whether and how they pluralize borrowed nouns, so a protected plural imposes English grammar on all 18 locales.

This is not hypothetical. **`ZK-SNARKs` is enforced today**, and on all four English pages using it, `ja`/`ko`/`zh`/`it` carry the English plural verbatim — they had no choice. A follow-up will teach the checker that a plural is satisfied by its protected singular and retire the plural entries; this PR adds `ZK-SNARK` so that follow-up has something to fall back to.

## Still held back

Priced against both `main` and the pending re-sync tree. These create violations that **no queued sync repairs** — the terms list is not part of staleness detection, so the debt would be invisible to the dashboard and unreachable by the sync agent:

`TEX Address` 39 · `Dev Fund` 25 (29 after re-sync) · `Diversified Address` 14 · `Spending Key` 7 · `Metamask Snap` 2 · `zk-SNARK` 2 · `Free2z` 1

**Skipped entirely:** `Unified Viewing Key` and `Outgoing Viewing Key` are in the categorized list but appear on no English page, so there is nothing to protect yet.
