### PR TITLE
ci(i18n): let a protected term be satisfied by a declared equivalent form

### DIFF
--- a/scripts/check-protected-terms.mjs
+++ b/scripts/check-protected-terms.mjs
@@ -40,6 +40,8 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
+import { buildEquivalence, formsFor } from "../translation/lib/term-forms.mjs";
+
 const root = new URL("../", import.meta.url).pathname;
 const config = JSON.parse(
   readFileSync(join(root, "translation/protected-terms.json"), "utf8"),
@@ -87,15 +89,40 @@ function sourceForTranslation(absTranslated) {
   return sourceRel;
 }
 
+const reCache = new Map();
 function termRegExp(term) {
+  const hit = reCache.get(term);
+  if (hit) return hit;
   // Word-boundary match so short terms don't false-positive inside other
   // words (e.g. "mining" must not match "deter*mining*"; "chain" is still
   // satisfied by "block*chain*" only via the standalone token's boundaries).
   const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(?<![A-Za-z0-9])${escaped}(?![A-Za-z0-9])`);
+  const re = new RegExp(`(?<![A-Za-z0-9])${escaped}(?![A-Za-z0-9])`);
+  reCache.set(term, re);
+  return re;
 }
 
 const terms = config.preserveVerbatim ?? [];
+
+// Some protected terms are the same word in two shapes — a singular and its
+// plural — and a translation may satisfy the term with any form DECLARED
+// equivalent to it in translation/protected-terms.json. The pairing is never
+// inferred from spelling; see translation/lib/term-forms.mjs for why that
+// matters (`Argos` is not `Argo`). A malformed declaration is fatal rather
+// than ignored, since a silently dropped group would weaken this gate in the
+// way least likely to be noticed.
+let equivalence;
+try {
+  equivalence = buildEquivalence(terms, config.equivalentForms);
+} catch (e) {
+  die(`translation/protected-terms.json: ${e.message}`);
+}
+
+// The SOURCE side always tests the exact term — the English page really does
+// use that form. Only the TRANSLATION side accepts an equivalent.
+function satisfiedIn(translated, term, forms = equivalence) {
+  return formsFor(term, forms).some((f) => termRegExp(f).test(translated));
+}
 
 // ---- pass 1: every violation in the working tree ---------------------------
 
@@ -125,8 +152,7 @@ for (const translatedAbs of walk(translationsDir)) {
   checked += 1;
 
   for (const term of terms) {
-    const re = termRegExp(term);
-    if (re.test(source) && !re.test(translated)) {
+    if (termRegExp(term).test(source) && !satisfiedIn(translated, term)) {
       violations.push({ translatedRel, sourceRel, term });
     }
   }
@@ -234,6 +260,29 @@ function baseContentAt(basePath) {
   return content;
 }
 
+// Base content must be judged by the BASE declaration, not this change's.
+// The config comes from the working tree while base translations come from
+// git, so a change that removes an equivalence group would otherwise make the
+// base look as though it had already been violating — bucketing a genuine
+// regression as "pre-existing" and exiting 0. A base config that cannot be
+// read, parsed or validated is not this change's fault, so fall back to the
+// head declaration rather than failing the PR over history.
+let baseEquivalence = equivalence;
+if (mergeBase) {
+  const rawBaseConfig = baseContentAt("translation/protected-terms.json");
+  if (rawBaseConfig !== null) {
+    try {
+      const baseConfig = JSON.parse(rawBaseConfig);
+      baseEquivalence = buildEquivalence(
+        baseConfig.preserveVerbatim ?? [],
+        baseConfig.equivalentForms,
+      );
+    } catch {
+      baseEquivalence = equivalence;
+    }
+  }
+}
+
 function classify(v) {
   if (!mergeBase) return "introduced"; // no base requested → whole-tree audit
   // Judge pre-existence against the pairing that ACTUALLY existed at the base:
@@ -253,7 +302,7 @@ function classify(v) {
     baseTranslated !== null &&
     baseSource !== null &&
     termRegExp(v.term).test(baseSource) &&
-    !termRegExp(v.term).test(baseTranslated);
+    !satisfiedIn(baseTranslated, v.term, baseEquivalence);
   if (violatedAtBase) return "pre-existing";
   return changedTranslations.has(v.translatedRel) ? "introduced" : "stale-source";
 }

--- a/translation/lib/term-forms.mjs
+++ b/translation/lib/term-forms.mjs
@@ -1,0 +1,104 @@
+// Equivalent forms of a protected term.
+//
+// Some protected terms are the same word in two shapes — a singular and its
+// plural. Whether an English loanword takes an -s is a decision each language
+// makes for itself, not one English makes for it: Italian writes "gli Unified
+// Address" because Italian does not pluralize borrowed nouns, and Japanese,
+// Korean and Chinese do not inflect plurals at all. Demanding one exact shape
+// therefore forces English grammar into 18 languages that do not share it, to
+// assert a term the other shape already carries.
+//
+// So a translation may satisfy a protected term with any form declared
+// equivalent to it. The pairing is DECLARED, never inferred from spelling.
+// Deriving it by stripping a trailing "s" would make `Argos` interchangeable
+// with `Argo` and `zec.rocks` with `zec.rock` — different things that merely
+// look related — and would silently miss irregular plurals such as
+// `Technologies` / `Technology`. A maintainer states which forms are the same
+// word; the checker never guesses.
+//
+// Shape in translation/protected-terms.json (the key is optional):
+//
+//   "equivalentForms": [
+//     ["ZK-SNARK", "ZK-SNARKs"]
+//   ]
+//
+// Membership is symmetric by construction: the group says "these are one
+// term", so any member asserts it. This module is pure — no filesystem, no
+// process, no clock — so it can be unit tested directly.
+
+export class TermFormsError extends Error {}
+
+/**
+ * Build a lookup of term -> Set of forms that satisfy it.
+ *
+ * Every group is validated against the protected list, and every failure is
+ * loud. A malformed group that was quietly ignored would weaken the gate in
+ * exactly the way nobody would notice.
+ *
+ * @param {string[]} terms  the preserveVerbatim list
+ * @param {string[][]} groups  the equivalentForms list (may be undefined)
+ * @returns {Map<string, Set<string>>}
+ */
+export function buildEquivalence(terms, groups) {
+  const protectedSet = new Set(terms);
+  const map = new Map();
+  if (groups === undefined) return map;
+
+  if (!Array.isArray(groups)) {
+    throw new TermFormsError("equivalentForms must be an array of groups");
+  }
+
+  const seen = new Map(); // term -> index of the group that already claimed it
+  groups.forEach((group, i) => {
+    if (!Array.isArray(group) || group.length < 2) {
+      throw new TermFormsError(
+        `equivalentForms[${i}]: a group needs at least two terms`,
+      );
+    }
+    if (new Set(group).size !== group.length) {
+      throw new TermFormsError(`equivalentForms[${i}]: contains a duplicate`);
+    }
+    for (const term of group) {
+      // Reject anything that is not a clean, non-blank string. A blank or
+      // padded entry is the one shape that could do real damage: paired with a
+      // junk entry in preserveVerbatim, a term of " " matches nearly every
+      // page and would silently satisfy whatever it was grouped with.
+      if (typeof term !== "string" || !term.trim() || term.trim() !== term) {
+        throw new TermFormsError(
+          `equivalentForms[${i}]: entries must be non-empty strings without surrounding whitespace`,
+        );
+      }
+      if (!protectedSet.has(term)) {
+        // Otherwise a typo would create a group that silently relaxes nothing,
+        // or worse, relaxes a term nobody protects.
+        throw new TermFormsError(
+          `equivalentForms[${i}]: "${term}" is not in preserveVerbatim`,
+        );
+      }
+      if (seen.has(term)) {
+        throw new TermFormsError(
+          `equivalentForms[${i}]: "${term}" is already in group ${seen.get(term)}`,
+        );
+      }
+      seen.set(term, i);
+    }
+    const forms = new Set(group);
+    for (const term of group) map.set(term, forms);
+  });
+
+  return map;
+}
+
+/**
+ * The forms that satisfy `term`, always including the term itself first so the
+ * common case costs a single test.
+ *
+ * @param {string} term
+ * @param {Map<string, Set<string>>} equivalence
+ * @returns {string[]}
+ */
+export function formsFor(term, equivalence) {
+  const group = equivalence.get(term);
+  if (!group) return [term];
+  return [term, ...[...group].filter((f) => f !== term)];
+}

--- a/translation/lib/term-forms.test.mjs
+++ b/translation/lib/term-forms.test.mjs
@@ -1,0 +1,105 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { buildEquivalence, formsFor, TermFormsError } from "./term-forms.mjs";
+
+const TERMS = [
+  "ZK-SNARK", "ZK-SNARKs",
+  "Unified Address", "Unified Addresses",
+  "Argos", "Zcash", "CSS",
+];
+
+test("no equivalentForms key leaves every term alone", () => {
+  const eq = buildEquivalence(TERMS, undefined);
+  assert.equal(eq.size, 0);
+  assert.deepEqual(formsFor("ZK-SNARKs", eq), ["ZK-SNARKs"]);
+});
+
+test("a declared pair satisfies in both directions", () => {
+  const eq = buildEquivalence(TERMS, [["ZK-SNARK", "ZK-SNARKs"]]);
+  assert.deepEqual(formsFor("ZK-SNARKs", eq).sort(), ["ZK-SNARK", "ZK-SNARKs"]);
+  assert.deepEqual(formsFor("ZK-SNARK", eq).sort(), ["ZK-SNARK", "ZK-SNARKs"]);
+});
+
+test("the term itself is always tried first", () => {
+  const eq = buildEquivalence(TERMS, [["ZK-SNARK", "ZK-SNARKs"]]);
+  assert.equal(formsFor("ZK-SNARKs", eq)[0], "ZK-SNARKs");
+});
+
+test("an -es plural pairs correctly when declared", () => {
+  // The case a naive strip-one-character derivation gets wrong:
+  // "Unified Addresses" -> "Unified Addresse", which is nothing.
+  const eq = buildEquivalence(TERMS, [["Unified Address", "Unified Addresses"]]);
+  assert.ok(formsFor("Unified Addresses", eq).includes("Unified Address"));
+});
+
+test("terms that merely look related are NOT equivalent", () => {
+  // Argos/Argo and CSS/CS are the reason pairing is declared, not derived.
+  const eq = buildEquivalence(TERMS, [["ZK-SNARK", "ZK-SNARKs"]]);
+  assert.deepEqual(formsFor("Argos", eq), ["Argos"]);
+  assert.deepEqual(formsFor("CSS", eq), ["CSS"]);
+  assert.deepEqual(formsFor("Zcash", eq), ["Zcash"]);
+});
+
+test("a group naming an unprotected term is rejected", () => {
+  assert.throws(
+    () => buildEquivalence(TERMS, [["ZK-SNARK", "ZK-SNARKz"]]),
+    (e) => e instanceof TermFormsError && /not in preserveVerbatim/.test(e.message),
+  );
+});
+
+test("a term cannot belong to two groups", () => {
+  assert.throws(
+    () => buildEquivalence(TERMS, [["ZK-SNARK", "ZK-SNARKs"], ["ZK-SNARK", "Zcash"]]),
+    (e) => e instanceof TermFormsError && /already in group 0/.test(e.message),
+  );
+});
+
+test("a group needs at least two members", () => {
+  assert.throws(
+    () => buildEquivalence(TERMS, [["ZK-SNARK"]]),
+    (e) => e instanceof TermFormsError && /at least two/.test(e.message),
+  );
+});
+
+test("a duplicate inside a group is rejected", () => {
+  assert.throws(
+    () => buildEquivalence(TERMS, [["ZK-SNARK", "ZK-SNARK"]]),
+    (e) => e instanceof TermFormsError && /duplicate/.test(e.message),
+  );
+});
+
+test("a blank or padded entry is rejected", () => {
+  // The dangerous shape: a term of " " matches nearly every page, so pairing
+  // it with a real term would silently satisfy that term everywhere.
+  for (const junk of ["", " ", "\t", " ZK-SNARK"]) {
+    assert.throws(
+      () => buildEquivalence([...TERMS, junk], [["ZK-SNARK", junk]]),
+      (e) => e instanceof TermFormsError && /non-empty strings/.test(e.message),
+      `expected "${junk}" to be rejected`,
+    );
+  }
+});
+
+test("a non-string entry is rejected", () => {
+  for (const junk of [null, 42, {}, []]) {
+    assert.throws(
+      () => buildEquivalence(TERMS, [["ZK-SNARK", junk]]),
+      (e) => e instanceof TermFormsError,
+    );
+  }
+});
+
+test("equivalentForms must be an array", () => {
+  assert.throws(
+    () => buildEquivalence(TERMS, { "ZK-SNARKs": ["ZK-SNARK"] }),
+    (e) => e instanceof TermFormsError && /must be an array/.test(e.message),
+  );
+});
+
+test("groups of three or more are supported", () => {
+  const terms = [...TERMS, "zk-SNARK"];
+  const eq = buildEquivalence(terms, [["ZK-SNARK", "ZK-SNARKs", "zk-SNARK"]]);
+  assert.equal(formsFor("zk-SNARK", eq).length, 3);
+  assert.ok(formsFor("ZK-SNARK", eq).includes("zk-SNARK"));
+});

--- a/translation/protected-terms.json
+++ b/translation/protected-terms.json
@@ -90,6 +90,9 @@
     "Zgo",
     "ZK-SNARK"
   ],
+  "equivalentForms": [
+    ["ZK-SNARK", "ZK-SNARKs"]
+  ],
   "glossaryOnly": [
     "token",
     "chain",

--- a/translation/protected-terms.json
+++ b/translation/protected-terms.json
@@ -81,7 +81,14 @@
     "Zcash Engineering Office Hours",
     "NU6.1",
     "NU6.2",
-    "NU7"
+    "NU7",
+    "Full Viewing Key",
+    "Incoming Viewing Key",
+    "Zcash.me",
+    "Zingo!",
+    "ZGo",
+    "Zgo",
+    "ZK-SNARK"
   ],
   "glossaryOnly": [
     "token",


### PR DESCRIPTION
## Why

Some protected terms are the same word in two shapes — a singular and its plural. Whether an English loanword takes an `-s` is a decision each language makes for itself, not one English makes for it. Italian writes *"gli Unified Address"*, because Italian does not pluralize borrowed nouns; Japanese, Korean and Chinese do not inflect plurals at all.

Demanding one exact shape therefore forces English grammar into 18 languages that do not share it, to assert a term the other shape already carries.

**This is not hypothetical.** `ZK-SNARKs` is protected and its singular was not, so on all four English pages using it, `ja`/`ko`/`zh`/`it` carry the English plural verbatim. They had no choice — the gate required it.

## What this does

A translation may now satisfy a protected term with any form **declared** equivalent to it, via a new optional key in `translation/protected-terms.json`:

```json
"equivalentForms": [
  ["ZK-SNARK", "ZK-SNARKs"]
]
```

A group means *"these are one term"*, so membership is symmetric — any member asserts it. **The source side still tests the exact term**, because the English page really does use that form; only the translation side accepts an equivalent.

## Declared, never derived

An earlier draft inferred the pairing by stripping a trailing `s`/`es`. Two reviewers independently rejected that, and they were right:

- it makes `Argos` interchangeable with `Argo`, and `zec.rocks` with `zec.rock` — different things that merely look related;
- it breaks on acronyms (`CSS` → `CS`);
- it silently misses irregular plurals such as `Technologies` / `Technology`;
- and it got its own motivating case wrong, deriving `Unified Addresse` from `Unified Addresses`, so the relaxation would never have fired for the term that prompted it.

A maintainer now states which forms are one word; the checker never guesses.

Every malformed declaration is **fatal**: a member absent from `preserveVerbatim`, a term in two groups, a duplicate within a group, a group of fewer than two, a non-array, a blank or whitespace-padded entry. A group that was quietly ignored would weaken this gate in the way least likely to be noticed — and a blank entry is the one shape that could do real damage, since a term of `" "` matches nearly every page.

## It also closes a false negative

`satisfiedIn` is applied to `classify()`'s baseline test, and that **tightens** the gate rather than merely preserving it. If a base translation carries only the singular and a change strips it, the previous exact-match baseline made `violatedAtBase` true — bucketing the result `pre-existing` and exiting 0, silently passing a change that removed the last protected form. It is now correctly `introduced`, exit 1.

Base content is judged by the **base** declaration, read from git at the merge base, not by this change's config. Otherwise a PR that removed an equivalence group could never fail the gate: the base would look as though it had already been violating. A base config that cannot be read or parsed falls back to the head declaration rather than failing a PR over history it did not write.

## Verification

| check | result |
|---|---|
| unit tests | **51 pass / 0 fail** (38 existing + 13 new) |
| whole-tree violations | 72 before and after |
| scoped gate on this branch | exit 0 |
| remove the group **and** strip the last form | exit 1, reported as introduced |
| malformed declaration | fatal, exit 1, names the offending entry |

The logic lives in `translation/lib/term-forms.mjs` — pure, no filesystem, process or clock — which puts its tests where the existing `hash-lib-tests` job already globs (`translation/lib/*.test.mjs`), so no workflow change is needed. They cover the declared pair in both directions, the `-es` case the old derivation got wrong, look-alikes that must **not** pair, and each validation failure.

`termRegExp` now memoizes; it was recompiling per (page, locale, term).

## Note on scope

**This changes nothing on the current corpus** — 72 violations before and after — because the harm already landed: the locales were forced to carry the plural, so no violations remain to clear. The value is preventive, and it is why the companion PR adds `ZK-SNARK` rather than removing `ZK-SNARKs`.

## Merge order

Stacked on #1965, which adds the `ZK-SNARK` singular that the declared group refers to. Merge that first; the diff here collapses to the checker change once it lands.

## Known limitation

A PR that *edits* `equivalentForms` while also changing translations is judged partly by its own declaration, so removing a group cannot itself fail the gate in every case. Reviewers should treat a change to `equivalentForms` as needing a whole-tree audit (`node scripts/check-protected-terms.mjs` with no `--base`) rather than trusting the scoped result alone.
