### PR TITLE
fix(i18n): restore manifest change-tracking, dead since the manifest passed 1 MiB

### DIFF
--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -51,6 +51,14 @@ const root = fileURLToPath(new URL("../", import.meta.url));
 const VALID_ENGINES = new Set(["llm", "nllb", "gt"]);
 const VALID_MODES = new Set(["seed", "diff", "full"]);
 
+// Every git read below is sized for a corpus that grows. execFileSync defaults
+// maxBuffer to 1 MiB and throws ENOBUFS past it, which is not a size this data
+// will stay under: the manifest alone crossed 1 MiB in August 2026, and
+// `git ls-files translations/` is already 210 KB at 18 locales × 203 pages and
+// scales with their product. scripts/check-protected-terms.mjs uses the same
+// bound for the same reason.
+const MAX_GIT_OUTPUT = 64 * 1024 * 1024;
+
 const violations = [];
 const fail = (msg) => violations.push(msg);
 
@@ -80,7 +88,7 @@ const locales = Object.keys(manifest);
 function localeDirs() {
   let out;
   try {
-    out = execFileSync("git", ["ls-files", "translations/"], { cwd: root, encoding: "utf8" });
+    out = execFileSync("git", ["ls-files", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
   } catch {
     return new Set();
   }
@@ -113,7 +121,7 @@ function localeFiles(loc) {
   let out;
   try {
     out = execFileSync("git", ["ls-files", `translations/${loc}/site/`], {
-      cwd: root, encoding: "utf8",
+      cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT,
     });
   } catch {
     return new Set();
@@ -179,19 +187,35 @@ for (const loc of locales) {
 
 // ---- change-tracking (git, optional) --------------------------------------
 
+// Set when --base was passed but carries no usable value. Distinct from "no
+// base requested", because ASKING for change-tracking and silently not getting
+// it is precisely the failure this block exists to prevent. CI invokes
+// `--base "$BASE_REF_OUT"`, so an empty variable arrives here as "".
+let baseArgInvalid = false;
+
 function resolveBase() {
-  const explicit = argOf("--base");
-  if (explicit) return explicit;
+  const i = process.argv.indexOf("--base");
+  if (i >= 0) {
+    const explicit = process.argv[i + 1];
+    if (!explicit || explicit.startsWith("--")) {
+      fail(
+        "--base was given without a ref value — refusing to skip change-tracking silently. " +
+        "Omit --base entirely to skip it deliberately.",
+      );
+      baseArgInvalid = true;
+      return null;
+    }
+    return explicit;
+  }
   if (process.env.GITHUB_BASE_REF) return `origin/${process.env.GITHUB_BASE_REF}`;
   return null;
 }
-function argOf(name) {
-  const i = process.argv.indexOf(name);
-  return i >= 0 ? process.argv[i + 1] : undefined;
-}
 
 const base = resolveBase();
-if (!base) {
+if (baseArgInvalid) {
+  // Already reported. Do not also print the notice below, which would read as
+  // a deliberate skip.
+} else if (!base) {
   console.log("notice: no base ref (--base / GITHUB_BASE_REF) — skipping change-tracking invariant.");
 } else {
   // Fail closed: a REQUESTED base that can't be resolved must NOT silently skip
@@ -199,7 +223,7 @@ if (!base) {
   // only history-dependent invariant while still exiting green).
   let baseSha = null;
   try {
-    baseSha = execFileSync("git", ["rev-parse", "--verify", "--quiet", `${base}^{commit}`], { cwd: root, encoding: "utf8" }).trim();
+    baseSha = execFileSync("git", ["rev-parse", "--verify", "--quiet", `${base}^{commit}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }).trim();
   } catch {
     baseSha = null;
   }
@@ -208,27 +232,76 @@ if (!base) {
   } else {
     let mergeBase = baseSha;
     try {
-      mergeBase = execFileSync("git", ["merge-base", baseSha, "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+      mergeBase = execFileSync("git", ["merge-base", baseSha, "HEAD"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }).trim();
     } catch {
       mergeBase = baseSha; // divergent/unrelated history → direct diff against base
     }
 
-    // The base ref IS resolvable, so a failure to read the manifest at it means
-    // the file genuinely didn't exist there = first introduction (fine to skip).
+    // Whether the manifest existed at the base is a real distinction — absent
+    // means this PR introduces it and there is genuinely nothing to
+    // change-track. But absence has to be ESTABLISHED, never inferred from a
+    // failed command. Inferring it made every possible failure indistinguishable
+    // from a first introduction, and one such failure was already live: the
+    // manifest crossed execFileSync's 1 MiB default maxBuffer, so `git show`
+    // threw ENOBUFS and both directions below were skipped on every pull
+    // request while this job kept reporting green. The bijection checks above
+    // are unaffected by that, which is exactly why nothing looked wrong.
+    //
+    // `ls-tree` is the probe, not `cat-file -e`. Absence and presence are BOTH
+    // exit 0 and are told apart by the output, so a non-zero exit is
+    // unambiguously an error rather than an answer. `cat-file -e` cannot make
+    // that distinction: it exits non-zero for an absent path AND for a blob it
+    // could not obtain, so in a partial clone (`--filter=blob:none`, which is
+    // how this repo is commonly cloned) an unreachable promisor remote would
+    // read as "absent" and skip the gate again — a network trigger for the same
+    // silent skip. `ls-tree` is also cheaper: it answers from the tree objects
+    // and never needs the blob at all.
     let baseManifest = null;
     let firstIntroduction = false;
+    let baseUnreadable = false;
+    const baseManifestPath = `${mergeBase}:translation/sync-state.json`;
+    let listed = null;
     try {
-      baseManifest = JSON.parse(execFileSync("git", ["show", `${mergeBase}:translation/sync-state.json`], { cwd: root, encoding: "utf8" }));
-    } catch {
+      listed = execFileSync(
+        "git",
+        ["ls-tree", "--name-only", mergeBase, "--", "translation/sync-state.json"],
+        { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT },
+      );
+    } catch (e) {
+      baseUnreadable = true;
+      fail(
+        `could not determine whether the manifest exists at base ${mergeBase.slice(0, 12)} ` +
+        `(${e.code || e.message}) — refusing to skip change-tracking silently.`,
+      );
+    }
+    if (!baseUnreadable && listed.trim() === "") {
       firstIntroduction = true;
+    } else if (!baseUnreadable) {
+      try {
+        baseManifest = JSON.parse(execFileSync("git", ["show", baseManifestPath], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
+      } catch (e) {
+        baseUnreadable = true;
+        fail(
+          `the manifest exists at base ${mergeBase.slice(0, 12)} but could not be read (${e.code || e.message}) — ` +
+          `refusing to skip change-tracking silently.`,
+        );
+      }
+      // Well-formed JSON is not yet a usable manifest: a base containing `null`,
+      // an array, or a string parses fine and then throws on the first
+      // `baseManifest[loc]` below. Reject the shape here so the reason is
+      // reported instead of a stack trace.
+      if (!baseUnreadable && (typeof baseManifest !== "object" || baseManifest === null || Array.isArray(baseManifest))) {
+        baseUnreadable = true;
+        fail(`the manifest at base ${mergeBase.slice(0, 12)} is not a JSON object — cannot change-track against it.`);
+      }
     }
 
     if (firstIntroduction) {
       console.log(`notice: base ${mergeBase.slice(0, 12)} has no manifest — first introduction, nothing to change-track.`);
-    } else {
+    } else if (!baseUnreadable) {
       let changed;
       try {
-        changed = execFileSync("git", ["diff", "--name-only", "-z", `${mergeBase}..HEAD`, "--", "translations/"], { cwd: root, encoding: "utf8" });
+        changed = execFileSync("git", ["diff", "--name-only", "-z", `${mergeBase}..HEAD`, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
       } catch (e) {
         // The base resolved but the diff failed — do not treat as "no changes".
         fail(`git diff against base ${mergeBase.slice(0, 12)} failed: ${e.message}`);


### PR DESCRIPTION
## The gate has been dead for two days

`manifest-invariants` stopped enforcing its change-tracking invariants on **2026-08-15**, and kept reporting green the whole time.

`check-invariants.mjs` read the base manifest through `execFileSync` with no `maxBuffer`, so it inherited Node's 1 MiB default. `translation/sync-state.json` crossed that threshold at `2dd8fb0f` — the 18-page sync merged in #1964 — going 1,001,048 → 1,094,558 bytes. From that commit on, `git show` threw `ENOBUFS` on every run.

The read sat in a catch that treated any failure as *"the manifest did not exist at the base — first introduction, nothing to change-track"*. So both directions were skipped on every pull request, including #1965 and #1966. The bijection checks don't touch that read, which is precisely why nothing looked wrong.

## What was unenforced

- **direction 1** — a translated file could change with no provenance trace. That invariant is what stops a hand-edit from being indistinguishable from a page nobody re-synced.
- **direction 2** — `src` could be bumped without the file changing, marking a stale translation fresh forever. That is the single lie the manifest exists to prevent, and by design it has no escape hatch.

## The fix, and two adjacent instances of the same mistake

- **Bound every git read at 64 MiB**, matching what `scripts/check-protected-terms.mjs` already does. `git ls-files translations/` is 210 KB today and scales with locales × pages, so it is on the same path.

- **Establish absence instead of inferring it**, with `git ls-tree` rather than `git cat-file -e`. Under `ls-tree`, absent and present are *both* exit 0 and are told apart by the output, so a non-zero exit is unambiguously an error. `cat-file -e` cannot draw that line: it exits non-zero both for an absent path and for a blob it could not obtain, so under `--filter=blob:none` an unreachable promisor remote would read as "absent" and skip the gate again — the same silent skip with a network trigger. `ls-tree` also never needs the blob at all.

- **Reject a base manifest that parses but is not an object.** `null`, an array or a string would parse and then throw on the first `baseManifest[loc]`.

- **Fail on `--base` with no ref value.** It resolved to `undefined`, which read as "no base requested" and skipped change-tracking with a notice and exit 0. CI invokes `--base "$BASE_REF_OUT"`, so an empty variable would have landed exactly there.

## Verification

Every case run on this tree against `base=origin/main`, comparing the checker at `origin/main` with this one:

| case | before | after |
|---|---|---|
| clean tree | "no manifest", skipped | change-tracked, holds |
| translation edited, manifest untouched | passed green | fails, direction 1 |
| `src` bumped, file untouched | passed green | fails, direction 2 |
| manifest genuinely absent at base | notice, skip | notice, skip (unchanged) |
| base manifest is `null` | TypeError stack trace | fails, names the reason |
| `--base` with no value | notice, exit 0 | fails, exit 1 |
| no `--base` at all | notice, exit 0 | notice, exit 0 (unchanged) |

## Review

Two independent adversarial passes, both of which changed the patch.

One reproduced the mask on a real violation, and settled the `cat-file -e` question empirically in a synthetic blobless clone: with the promisor reachable `cat-file -e` lazy-fetches and exits 0, but with it unreachable it exits 128 **for a blob that exists** — indistinguishable from a genuine absence, and `GIT_NO_LAZY_FETCH=1` gives exit 1 with the same misclassification. It then verified that `ls-tree` answers correctly from the tree objects with the blob missing *and* the promisor unreachable. That finding is why this PR uses `ls-tree`.

The other found the `--base` and base-shape defects, neither of which I had looked for.

## Not fixed here

Filed rather than folded in, none of them live:

- unbounded git reads in `detect-staleness.mjs` (`:89`, `:125`, `:219`), `seed-sync-state.mjs` (`:87`) and `gen-menu-titles.mjs` (`:52`) — all 30–2000× under the ceiling, and scaling linearly rather than with the locale × page product;
- this file's `ls-files` calls don't use `-z`, so `core.quotePath` would mangle a non-ASCII path. `seed-sync-state.mjs:85` documents that exact trap and uses `-z`; the corpus is ASCII today;
- the `manifest-invariants` push branch passes `$EVENT_BEFORE` with no zero-SHA fallback, while the `protected-terms` job has one, so a force-push to `main` goes red under the fail-closed `rev-parse`. That predates this change.

## Suggested merge order

This one first. It restores a required check, and it is independent of #1966 and of the contributor-doc PR.
