### PR TITLE
Mark the Akash zcashd guide deprecated and point at the Zebra guide

### DIFF
--- a/site/guides/Akash_Network_Zcashd.md
+++ b/site/guides/Akash_Network_Zcashd.md
@@ -1,5 +1,13 @@
 # Deploying zcashd to Akash via Console
 
+> **Deprecated. Do not follow this guide to deploy a node you intend to use.**
+>
+> zcashd reached its automatic End-of-Support halt on July 18, 2026. A zcashd node deployed today will not sync to the chain tip, so the deployment costs money every month and produces nothing.
+>
+> Deploy **Zebra** instead: [How to run Zebra on Akash Network](/guides/akash-network-zebra), which covers the same Akash Console workflow and needs roughly a third of the disk. If you are moving an existing setup, see the [zcashd to Zebra and Zallet migration guide](/guides/migration-guide-zcashd-to-zebrad-zallet).
+>
+> This page is kept as a historical record of the zcashd deployment.
+
 Guide for deploying a zcashd Zcash full node (Electric Coin Co implementation) using [Akash Console](https://console.akash.network). Here is a video tutorial below. A more in-depth guide can be found below.
 
 <div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
@@ -30,13 +38,13 @@ A full zcashd node that will:
 
 **zcashd vs Zebra:**
 
--> zcashd is the original Zcash node implementation by Electric Coin Co
+-> zcashd was the original Zcash node implementation by Electric Coin Co, halted since July 18, 2026
 
--> Zebra is the Zcash Foundation's alternative implementation
+-> Zebra, from the Zcash Foundation, is the full node in use today
 
--> Both are compatible with the Zcash network
+-> Only Zebra follows the current chain; a zcashd node cannot reach the tip
 
--> zcashd has more features (mining, wallet, Insight Explorer API)
+-> zcashd's wallet has been replaced by [Zallet](/using-zcash/zallet-quick-reference-guide)
 
 -> Use zcashd if you need wallet functionality or specific RPC APIs
 
@@ -89,6 +97,8 @@ Your AKT balance should appear in the top right. If it's zero, go fund your wall
 -> Choose **"Build your template"** (or skip directly to uploading SDL)
 
 ### Option A: Upload SDL File (Recommended)
+
+> **This button deploys a halted node.** It bills against your AKT balance for a node that cannot sync. Use the [Zebra guide](/guides/akash-network-zebra) instead.
 
 [![Deploy on Akash](/content-images/deploy-with-akash-btn-74abb88d44.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-zcash-zcashd)
 
@@ -442,7 +452,7 @@ The provider might be having issues. Close the deployment and try a different pr
 
 ### zcashd logs show "No peers connected"
 
-This is normal for the first few minutes. zcashd will discover peers automatically. If it persists after 10+ minutes, you might have a networking issue (unlikely on Akash).
+Since the End-of-Support halt on July 18, 2026, this is the expected permanent state rather than a startup delay, and no amount of waiting or redeployment will fix it. Deploy [Zebra](/guides/akash-network-zebra) instead.
 
 ### "Out of memory" errors in logs
 


### PR DESCRIPTION
Closes the bounty "The Akash zcashd guide never points at the Zebra guide sitting next to it" on the ZecHub bounty board.

## The problem

`site/guides/Akash_Network_Zcashd.md` is 516 lines of instructions for deploying a node that reached its End-of-Support halt on 18 July 2026. It contains a one-click **Deploy on Akash** button, a `~$15/month` cost estimate, and no deprecation notice of any kind — no "deprecated", "end of support", "EOL", "no longer" or "halted" anywhere in the file.

It also never links to `site/guides/Akash_Network_Zebra.md`, which already exists in the same directory and covers the same Akash Console workflow for the node people actually run. Both files are in `curated-pages.txt`, so both are carried into 18 locales.

The result is that someone arriving from search rents infrastructure monthly for a node that can never reach the chain tip, and is never told the replacement guide is sitting right next to it.

## What this changes

15 insertions, 5 deletions, one file.

1. **A deprecation banner at the top**, above both the video and the deploy button, matching the note already on the Raspberry Pi 4 guide. It links the Zebra Akash guide as the replacement and the zcashd-to-Zebra-and-Zallet migration guide for anyone moving an existing setup.
2. **A second warning immediately above the one-click deploy button.** The top banner is 90 lines above that button, and the button is where money actually gets committed, so the warning is repeated at the point of action.
3. **The "zcashd vs Zebra" comparison is corrected.** It claimed "Both are compatible with the Zcash network" and "zcashd has more features (mining, wallet, Insight Explorer API)", presenting a halted node as a live option with an advantage. It now states that only Zebra follows the current chain, and points at Zallet as the wallet replacement.
4. **The "No peers connected" troubleshooting entry is corrected.** It told readers this was normal for the first few minutes and to suspect a networking issue if it persisted past ten. Since the halt, that is the permanent expected state, so the old advice sends people to debug Akash for a problem Akash did not cause.

Everything else is untouched. The SDL, the configuration options, the troubleshooting and the cost management sections stay as a historical record of the zcashd deployment.

## Verification

Run against `main` @ `01c91a0a`.

```
node translation/check-invariants.mjs --base origin/main
  → Manifest invariants hold: 203 curated pages, 18 locales.

node translation/gen-menu-titles.mjs --check
  → menu-titles manifests up to date (19 files).

node link-health/check-links.mjs --offline
  → 719 files, 11,251 links, 5 needing attention — identical to baseline, 0 new
```

All four internal routes added here resolve: `/guides/akash-network-zebra` (twice), `/guides/migration-guide-zcashd-to-zebrad-zallet`, and `/using-zcash/zallet-quick-reference-guide`. I confirmed the offline checker actually validates this link form by temporarily inserting a deliberately broken route and watching the route count rise, rather than assuming that the absence of a finding meant the links had been checked.

Two expected side effects, both inherent to an English curated page gaining current terminology ahead of its translations:

- **`protected-terms`** goes from 180 to 216 missing terms. The 36 new ones are 18 locales × 2 terms (`Zallet`, `zebrad`), all on the not-yet-retranslated copies of this page. This is the same pattern as the merged Raspberry Pi rewrite (#1928) and the Viewing Keys rewrite (#1946).
- **`detect-staleness.mjs`** flags the page in all 18 locales, taking stale pairs from 43 to 61 — the correct signal for an updated curated page.