### PR TITLE
Repoint ZIP links at zips.z.cash and correct statuses on the Improvement Proposals page

### DIFF
--- a/site/guides/Akash_Network_Zcashd.md
+++ b/site/guides/Akash_Network_Zcashd.md
@@ -1,5 +1,13 @@
 # Deploying zcashd to Akash via Console
 
+> **Deprecated. Do not follow this guide to deploy a node you intend to use.**
+>
+> zcashd reached its automatic End-of-Support halt on July 18, 2026. A zcashd node deployed today will not sync to the chain tip, so the deployment costs money every month and produces nothing.
+>
+> Deploy **Zebra** instead: [How to run Zebra on Akash Network](/guides/akash-network-zebra), which covers the same Akash Console workflow and needs roughly a third of the disk. If you are moving an existing setup, see the [zcashd to Zebra and Zallet migration guide](/guides/migration-guide-zcashd-to-zebrad-zallet).
+>
+> This page is kept as a historical record of the zcashd deployment.
+
 Guide for deploying a zcashd Zcash full node (Electric Coin Co implementation) using [Akash Console](https://console.akash.network). Here is a video tutorial below. A more in-depth guide can be found below.
 
 <div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
@@ -30,13 +38,13 @@ A full zcashd node that will:
 
 **zcashd vs Zebra:**
 
--> zcashd is the original Zcash node implementation by Electric Coin Co
+-> zcashd was the original Zcash node implementation by Electric Coin Co, halted since July 18, 2026
 
--> Zebra is the Zcash Foundation's alternative implementation
+-> Zebra, from the Zcash Foundation, is the full node in use today
 
--> Both are compatible with the Zcash network
+-> Only Zebra follows the current chain; a zcashd node cannot reach the tip
 
--> zcashd has more features (mining, wallet, Insight Explorer API)
+-> zcashd's wallet has been replaced by [Zallet](/using-zcash/zallet-quick-reference-guide)
 
 -> Use zcashd if you need wallet functionality or specific RPC APIs
 
@@ -89,6 +97,8 @@ Your AKT balance should appear in the top right. If it's zero, go fund your wall
 -> Choose **"Build your template"** (or skip directly to uploading SDL)
 
 ### Option A: Upload SDL File (Recommended)
+
+> **This button deploys a halted node.** It bills against your AKT balance for a node that cannot sync. Use the [Zebra guide](/guides/akash-network-zebra) instead.
 
 [![Deploy on Akash](/content-images/deploy-with-akash-btn-74abb88d44.svg)](https://console.akash.network/new-deployment?step=edit-deployment&templateId=akash-network-awesome-akash-zcash-zcashd)
 
@@ -442,7 +452,7 @@ The provider might be having issues. Close the deployment and try a different pr
 
 ### zcashd logs show "No peers connected"
 
-This is normal for the first few minutes. zcashd will discover peers automatically. If it persists after 10+ minutes, you might have a networking issue (unlikely on Akash).
+Since the End-of-Support halt on July 18, 2026, this is the expected permanent state rather than a startup delay, and no amount of waiting or redeployment will fix it. Deploy [Zebra](/guides/akash-network-zebra) instead.
 
 ### "Out of memory" errors in logs
 

--- a/site/guides/Zcash_Improvement_Proposals.md
+++ b/site/guides/Zcash_Improvement_Proposals.md
@@ -28,27 +28,46 @@ For every ZIP that comes in, it must undergo the review process. ZIP editors are
 * Sam and Mark, associated with SL.
 ```
 
-## Notable Current Draft ZIPs
+## Notable Current ZIPs
 
-> Draft: [Transarent Zcash Extensions](https://github.com/zcash/zips/blob/main/zip-0222)
+Statuses and titles below were checked against the ZIP index at [zips.z.cash](https://zips.z.cash/#index-of-zips) on 18 August 2026. A ZIP's status changes over time, so treat the index as the source of truth.
 
-> Draft: [Transfer and Burn of Zcash Shielded Assets](https://github.com/zcash/zips/blob/main/zip-0226)
+> Draft: [Transparent Zcash Extensions](https://zips.z.cash/zip-0222)
 
-> Draft: [Issuance of Zcash Shielded Assets](https://github.com/zcash/zips/blob/main/zip-0227)
+> Draft: [Transfer and Burn of Zcash Shielded Assets](https://zips.z.cash/zip-0226)
 
-> Draft: [Version 6 Transaction Format](https://github.com/zcash/zips/blob/main/zip-0230)
+> Draft: [Issuance of Zcash Shielded Assets](https://zips.z.cash/zip-0227)
 
-> Draft: [Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions](https://github.com/zcash/zips/blob/main/zip-0245)
+> Withdrawn: [Withdrawn Version 6 Transaction Format](https://zips.z.cash/zip-0230) — obsoleted by ZIP 229, which now defines transaction version 6. See the NU6.3 list below.
 
-> Draft: [Standardized Memo Field Format](https://github.com/zcash/zips/blob/main/zip-0302)
+> Draft: [Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions](https://zips.z.cash/zip-0245)
 
-> Draft: [Sapling Address Signatures](https://github.com/zcash/zips/blob/main/zip-0304)
+> Draft: [Standardized Memo Field Format](https://zips.z.cash/zip-0302)
 
-> Draft: [Light Client Protocol for Payment Detection](https://github.com/zcash/zips/blob/main/zip-0307.)
+> Draft: [Sapling Address Signatures](https://zips.z.cash/zip-0304)
 
-> Draft: [Security Properties of Sapling Viewing Keys](https://github.com/zcash/zips/blob/main/zip-0310)
+> Draft: [Light Client Protocol for Payment Detection](https://zips.z.cash/zip-0307)
 
-> Draft: [Defining an Address Type to which funds can only be sent from Transparent Addresses](https://github.com/zcash/zips/blob/main/zip-0320)
+> Draft: [Security Properties of Sapling Viewing Keys](https://zips.z.cash/zip-0310)
 
-> Draft: [Wallet.dat format](https://github.com/zcash/zips/blob/main/zip-0400)
+> Active: [Defining an Address Type to which funds can only be sent from Transparent Addresses](https://zips.z.cash/zip-0320)
 
+> Draft: [Wallet.dat format](https://zips.z.cash/zip-0400)
+
+## NU6.3 (Ironwood) ZIPs
+
+NU6.3 is described in ZIP 258, together with the additional ZIPs listed here. The full candidate set is published on the [ZIP index](https://zips.z.cash/#nu6-3-candidate-zips).
+
+> Draft: [Deployment of the NU6.3 Network Upgrade](https://zips.z.cash/zip-0258)
+
+> Draft: [Version 6 Transaction Format](https://zips.z.cash/zip-0229)
+
+> Draft: [Orchard to Ironwood Migration](https://zips.z.cash/zip-0318)
+
+> Draft: [NU6.3 Consequences for Wallets](https://zips.z.cash/zip-0326)
+
+> Proposed: [Ironwood Quantum Recoverability](https://zips.z.cash/zip-2005)
+
+> Reserved: [Restricting Transfers into the Orchard Pool](https://zips.z.cash/zip-2006)
+
+Three earlier ZIPs are also updated for NU6.3: [ZIP 209](https://zips.z.cash/zip-0209), [ZIP 213](https://zips.z.cash/zip-0213) and [ZIP 317](https://zips.z.cash/zip-0317).


### PR DESCRIPTION
Rewrites the ZIP list on `site/guides/Zcash_Improvement_Proposals.md`. One file changed, 31 insertions, 12 deletions.

## What was wrong

Every one of the 11 links in the "Notable Current Draft ZIPs" section pointed at `https://github.com/zcash/zips/blob/main/zip-XXXX`. That path returns **404** — the repository stores ZIPs under `zips/`, and the canonical rendered form is `https://zips.z.cash/zip-XXXX`. The section also carried a misspelled title, a malformed URL, two stale statuses, and predated NU6.3 entirely.

## What changed

**All 11 links repointed** at `https://zips.z.cash/zip-XXXX`. Every URL in the file was checked with `curl` on the day of this PR; all return 200.

**Four content corrections**, each verified against the ZIP's own published header on zips.z.cash rather than from memory:

| ZIP | Was | Now |
|---|---|---|
| 222 | "Transarent Zcash Extensions" | "Transparent Zcash Extensions" |
| 230 | Draft — "Version 6 Transaction Format" | Withdrawn — "Withdrawn Version 6 Transaction Format" |
| 307 | URL ended `zip-0307.` (trailing period, 404) | `zip-0307` |
| 320 | Draft | Active |

ZIP 230's own abstract states that it has been obsoleted by ZIP 229 and that transaction version 6 is now defined by ZIP 229. The entry says so and points readers at ZIP 229 in the new section below.

**New "NU6.3 (Ironwood) ZIPs" section** carrying the candidate set as published on the ZIP index:

- ZIP 258 — Deployment of the NU6.3 Network Upgrade (Draft)
- ZIP 229 — Version 6 Transaction Format (Draft)
- ZIP 318 — Orchard to Ironwood Migration (Draft)
- ZIP 326 — NU6.3 Consequences for Wallets (Draft)
- ZIP 2005 — Ironwood Quantum Recoverability (**Proposed**, not Draft)
- ZIP 2006 — Restricting Transfers into the Orchard Pool (**Reserved**, not Draft)

The three earlier ZIPs the index marks as updated for NU6.3 — 209, 213 and 317 — are linked in a closing line.

**Section heading** changed from "Notable Current Draft ZIPs" to "Notable Current ZIPs", because the list now legitimately contains Active, Withdrawn, Proposed and Reserved entries. Nothing in the repo links to that anchor; `gen-menu-titles --check` is unaffected, since the menu title derives from the H1.

A dated line records when statuses were checked and points at the ZIP index as the source of truth, so the next reader knows how old the snapshot is.

## Two upstream inconsistencies, and the call made on each

The zips.z.cash README and the individual ZIP headers disagree in two places. In both cases this PR follows the ZIP's own published header, which is what the ZIP index's status tables also say:

1. The README's "NU7 Candidate ZIPs" list still calls ZIP 230 "Version 6 Transaction Format". ZIP 230's own header reads "Withdrawn Version 6 Transaction Format", status Withdrawn, and the README's own Withdrawn table agrees. Listed here as Withdrawn.
2. The README's NU6.3 list calls ZIP 2006 "Restricting Transfers **to** the Orchard Pool". ZIP 2006's own header reads "Restricting Transfers **into** the Orchard Pool". Used "into".

## Verification

Run on this branch against `main` @ `01c91a0a`:

```
node translation/check-invariants.mjs --base origin/main
  → Manifest invariants hold: 203 curated pages, 18 locales.

node translation/gen-menu-titles.mjs --check
  → menu-titles manifests up to date (19 files).

node link-health/check-links.mjs --offline
  → 719 files, 11257 links, 5 needing attention, 0 redirects, 272 duplicates.
```

The link checker's finding set is **byte-identical** to `main`: 277 findings before, 277 after, zero added and zero removed. The 5 needing attention and the 272 duplicates are all pre-existing and untouched by this PR. Link count rises by 11 because the NU6.3 section adds entries.

## Expected side effects on a curated page

This page is curated and translated into 18 locales, so updating the English source moves two counters. Both are the correct signal for an updated curated page, not regressions introduced here:

- **`check-protected-terms.mjs`: 180 → 216 missing.** All 36 new failures are on this page's 18 not-yet-retranslated copies: "NU6" ×18 (from NU6.3) and "Orchard" ×18 (from the ZIP 318 and 2006 titles). Before this PR the page contributed 0 failures.
- **`detect-staleness.mjs`: 43 → 61 stale pairs**, 18 → 36 high-severity — one entry per locale for this page.

No translation files, manifests or sync state were touched. `curated-pages.txt`, `sync-state.json` and the `menu-titles/` manifests are unchanged.

---

Bounty: "The Improvement Proposals page has 11 dead ZIP links and two wrong statuses" (Web Development, 0.12 ZEC).

ZEC address: `<PASTE UNIFIED ADDRESS HERE>`
