### PR TITLE
ci: stop a pull request whose front matter drifts from its English source

### DIFF
--- a/.github/workflows/translation-validation.yml
+++ b/.github/workflows/translation-validation.yml
@@ -114,3 +114,52 @@ jobs:
         env:
           BASE_REF_OUT: ${{ steps.base.outputs.ref }}
         run: node translation/check-invariants.mjs --base "$BASE_REF_OUT"
+
+  frontmatter-parity:
+    # A translated page must declare the same leading YAML block as its English
+    # source. One of the shapes this catches — a `---` the source does not have —
+    # takes down the GitHub Pages build for the entire site, and did on
+    # 2026-08-14; the others corrupt the page silently. The Pages build only runs
+    # after a merge, so this is the only place a pull request can be stopped.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the check can tell what this change touched from
+          # damage it merely inherited.
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Determine base ref
+        id: base
+        # Only a pull request gets a base. A push to `main` is swept in full:
+        # scoping it to the last push would let damage introduced earlier — by a
+        # force-push, or by a merge whose own PR predated this job — sit on the
+        # branch that Pages builds from, reported by nothing.
+        #
+        # Pass the (attacker-influenceable) ref name through env, never inline
+        # into the shell, to avoid command injection via a crafted branch name.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags --quiet origin "$BASE_REF"
+            echo "ref=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Check front-matter parity
+        # On a pull request, blocking only on what this change introduced;
+        # anything already broken is printed as a notice. On a push, no --base,
+        # so every page is checked.
+        env:
+          BASE_REF_OUT: ${{ steps.base.outputs.ref }}
+        run: |
+          if [ -n "$BASE_REF_OUT" ]; then
+            node scripts/check-frontmatter.mjs --base "$BASE_REF_OUT"
+          else
+            node scripts/check-frontmatter.mjs
+          fi

--- a/docs/translation-contributor-workflow.md
+++ b/docs/translation-contributor-workflow.md
@@ -151,7 +151,7 @@ Do not translate the key, do not translate the date, and do not add a block to a
 
 Three quieter shapes break nothing and are caught by the same job: an empty block ahead of the real one, a translated key such as `wotae:` or `bipụtara:`, and a lost opening `---` with the closing one still there. All three put the date into the page as visible text or lose it entirely.
 
-`--base` scopes this job the same way as the terminology gate; run it bare for a whole-tree sweep.
+`--base` scopes this job to the translations your change touched, and it fails only on damage your change actually did — a defect already on the page, left alone, is a notice. If you edit an English page that has front matter, its translations are not yours to answer for either; that drift is the sync pipeline's work. Run the check bare for a whole-tree sweep, which is also what a push to `main` runs.
 
 ## Adding a new language
 

--- a/docs/translation-contributor-workflow.md
+++ b/docs/translation-contributor-workflow.md
@@ -115,7 +115,7 @@ The full rules — where not to gloss, RTL nesting, the per-category breakdown �
 
 ## Validation
 
-Four jobs run on **every** pull request, and on pushes to `main`. There is deliberately no path filter: `manifest-invariants` and `menu-titles-fresh` are required checks, and a required check that is skipped on unrelated pull requests leaves them stuck at "Expected — waiting for status". So expect these jobs on a pull request that touches no translation at all.
+Five jobs run on **every** pull request, and on pushes to `main`. There is deliberately no path filter: `manifest-invariants` and `menu-titles-fresh` are required checks, and a required check that is skipped on unrelated pull requests leaves them stuck at "Expected — waiting for status". So expect these jobs on a pull request that touches no translation at all.
 
 Each one is reproducible locally. CI resolves the base ref from the pull request; substitute your own:
 
@@ -125,6 +125,7 @@ Each one is reproducible locally. CI resolves the base ref from the pull request
 | `manifest-invariants` | `node translation/check-invariants.mjs --base origin/main` | manifest ⇔ files ⇔ curated list, plus the two provenance rules above |
 | `hash-lib-tests` | `node --test translation/lib/*.test.mjs` | the pure hash, title and term-form modules |
 | `menu-titles-fresh` | `node translation/gen-menu-titles.mjs --check` | generated menu-title manifests match the content |
+| `frontmatter-parity` | `node scripts/check-frontmatter.mjs --base origin/main` | a translation declares the same leading YAML block as its English source |
 
 `--base` scopes the terminology gate to what your change actually did. It fails only on a violation your change **introduced** — one that did not exist for that page and locale at the merge base. Two other kinds are reported as notices instead of failures: violations already present at the base, and violations that come from an English page edited after the translation was last synced, which are the sync pipeline's work rather than yours.
 
@@ -135,6 +136,22 @@ node scripts/check-protected-terms.mjs
 ```
 
 Do that as well whenever you change `translation/protected-terms.json`, since a scoped run judges a change to the term list partly by that change's own configuration.
+
+### Front matter
+
+If `site/<page>.md` starts with a YAML block, every translation of it must start with the same block, copied verbatim:
+
+```
+---
+published: 2025-08-19
+---
+```
+
+Do not translate the key, do not translate the date, and do not add a block to a page whose English source has none. A stray `---` is not cosmetic: Jekyll builds the GitHub Pages copy of this repo from `main`, reads a leading `---` as a front-matter opener, scans to the next `---` far down the page, and fails the build for the whole site. That happened on 2026-08-14 and the published site stayed frozen for four days — and because the Pages build only runs after a merge, `frontmatter-parity` is the only place a pull request can be stopped.
+
+Three quieter shapes break nothing and are caught by the same job: an empty block ahead of the real one, a translated key such as `wotae:` or `bipụtara:`, and a lost opening `---` with the closing one still there. All three put the date into the page as visible text or lose it entirely.
+
+`--base` scopes this job the same way as the terminology gate; run it bare for a whole-tree sweep.
 
 ## Adding a new language
 

--- a/scripts/check-frontmatter.mjs
+++ b/scripts/check-frontmatter.mjs
@@ -1,0 +1,163 @@
+// Blocking front-matter parity check for translated pages.
+//
+// Every translations/<locale>/site/<page>.md must declare the same leading YAML
+// block as site/<page>.md. See translation/lib/frontmatter.mjs for what can go
+// wrong and why one of those shapes takes the whole GitHub Pages build down.
+//
+// Scope, like scripts/check-protected-terms.mjs: with a base ref, only pages
+// this change could have damaged are BLOCKING — a translation it touched, or one
+// whose English source it touched. Anything else is reported as a notice, so a
+// pre-existing violation somewhere in 3654 pages does not redden an unrelated
+// PR. Without a base ref every page is blocking, which is the right default for
+// a local sweep (`node scripts/check-frontmatter.mjs`).
+//
+// Usage:
+//   node scripts/check-frontmatter.mjs [--base <ref>]
+// Exit 0 = no blocking violation; 1 = at least one (all of them printed).
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { frontMatterViolation } from "../translation/lib/frontmatter.mjs";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+
+// `git ls-files translations/` is already 210 KB at 18 locales × 203 pages and
+// grows with their product, well past execFileSync's 1 MiB default. The same
+// bound, for the same reason, as the sibling checks.
+const MAX_GIT_OUTPUT = 64 * 1024 * 1024;
+const git = (args) => execFileSync("git", args, { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+
+const die = (msg) => {
+  console.error(`Front-matter parity check could not run: ${msg}`);
+  process.exit(1);
+};
+
+// ---- scope ----------------------------------------------------------------
+
+function resolveBase() {
+  const i = process.argv.indexOf("--base");
+  if (i < 0) return null;
+  const explicit = process.argv[i + 1];
+  // Asking for a scoped run and silently getting an unscoped one is a real
+  // difference in what the job blocks on, so refuse rather than guess. CI
+  // invokes `--base "$BASE_REF_OUT"`, so an empty variable arrives as "".
+  if (!explicit || explicit.startsWith("--")) {
+    die("--base was given without a ref value. Omit it to check every page.");
+  }
+  return explicit;
+}
+
+const base = resolveBase();
+let inScope = null;   // null = everything is blocking
+let mergeBase = null; // set alongside inScope
+
+if (base) {
+  let baseSha = null;
+  try {
+    baseSha = git(["rev-parse", "--verify", "--quiet", `${base}^{commit}`]).trim();
+  } catch { /* reported below */ }
+  // Fail closed: a base that cannot be resolved (shallow clone, force-push,
+  // typo) must not quietly widen or narrow what this job blocks on.
+  if (!baseSha) die(`base ref "${base}" could not be resolved (shallow clone? force-push? run CI with fetch-depth: 0)`);
+
+  mergeBase = baseSha;
+  try {
+    mergeBase = git(["merge-base", baseSha, "HEAD"]).trim();
+  } catch { /* divergent history — compare against the base directly */ }
+
+  const changed = new Set();
+  const collect = (args) => {
+    for (const p of git(args).split("\0")) if (p.endsWith(".md")) changed.add(p);
+  };
+  try {
+    collect(["diff", "--name-only", "-z", `${mergeBase}..HEAD`, "--", "translations/", "site/"]);
+  } catch (e) {
+    // The base resolved but the diff failed. Treating that as "nothing changed"
+    // would pass every introduced violation.
+    die(`git diff against base ${mergeBase.slice(0, 12)} failed: ${e.message}`);
+  }
+  // A local run reads the working tree, where an uncommitted or untracked page
+  // is invisible to the range diff. No effect in CI, where the checkout is clean.
+  for (const args of [
+    ["diff", "--name-only", "-z", "HEAD", "--", "translations/", "site/"],
+    ["ls-files", "--others", "--exclude-standard", "-z", "--", "translations/", "site/"],
+  ]) {
+    try { collect(args); } catch { /* non-fatal: scope stays range-only */ }
+  }
+
+  inScope = (transPath, srcPath) => changed.has(transPath) || changed.has(srcPath);
+}
+
+// ---- check ----------------------------------------------------------------
+
+let files;
+try {
+  files = git(["ls-files", "-z", "--", "translations/"]).split("\0").filter((p) => p.endsWith(".md"));
+} catch (e) {
+  die(`could not list translated files: ${e.message}`);
+}
+
+const read = (p) => {
+  try { return readFileSync(join(root, p), "utf8"); } catch { return null; }
+};
+
+// What the page looked like at the merge base. `git show` on a missing path
+// exits non-zero, which is the answer "it did not exist", not an error.
+const readAtBase = (p) => {
+  try { return git(["show", `${mergeBase}:${p}`]); } catch { return null; }
+};
+
+// A violation this change did not create is not this change's to fix. Editing an
+// English page must not make every old defect in its 17 translations blocking —
+// that is the sibling terminology gate's rule too.
+function introduced(transPath, srcPath, violation) {
+  if (!mergeBase) return true;
+  const wasSrc = readAtBase(srcPath);
+  const wasTrans = readAtBase(transPath);
+  if (wasSrc === null || wasTrans === null) return true; // new page: it is yours
+  const was = frontMatterViolation(wasSrc, wasTrans);
+  return !was || was.code !== violation.code;
+}
+
+const blocking = [];
+const inherited = [];
+let checked = 0;
+
+for (const transPath of files) {
+  const parts = transPath.split("/");
+  if (parts.length < 4 || parts[2] !== "site") continue;
+  const srcPath = ["site", ...parts.slice(3)].join("/");
+  const srcText = read(srcPath);
+  // No English source: an orphan translation. translation/check-invariants.mjs
+  // owns that relationship; there is nothing here to compare against.
+  if (srcText === null) continue;
+  const transText = read(transPath);
+  if (transText === null) continue;
+
+  checked += 1;
+  const violation = frontMatterViolation(srcText, transText);
+  if (!violation) continue;
+  const line = `${transPath}: ${violation.message}`;
+  if ((!inScope || inScope(transPath, srcPath)) && introduced(transPath, srcPath, violation)) blocking.push(line);
+  else inherited.push(line);
+}
+
+if (inherited.length) {
+  console.log(`notice: ${inherited.length} page(s) already differ from their source outside this change:`);
+  for (const l of inherited.slice(0, 20)) console.log(`  - ${l}`);
+  if (inherited.length > 20) console.log(`  … and ${inherited.length - 20} more`);
+}
+
+if (blocking.length) {
+  console.error(`Front-matter parity FAILED for ${blocking.length} page(s):`);
+  for (const l of blocking) console.error(`  - ${l}`);
+  console.error(
+    "\nA translated page must declare the same leading YAML block as its English source — " +
+    "copy site/<page>.md's block verbatim. A `---` the source does not have breaks the Jekyll build for the whole site.",
+  );
+  process.exit(1);
+}
+
+console.log(`Front-matter parity holds for ${checked} translated page(s).`);

--- a/scripts/check-frontmatter.mjs
+++ b/scripts/check-frontmatter.mjs
@@ -19,7 +19,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
-import { frontMatterViolation } from "../translation/lib/frontmatter.mjs";
+import { frontMatterRegion, frontMatterViolation } from "../translation/lib/frontmatter.mjs";
 
 const root = fileURLToPath(new URL("../", import.meta.url));
 
@@ -87,7 +87,11 @@ if (base) {
     try { collect(args); } catch { /* non-fatal: scope stays range-only */ }
   }
 
-  inScope = (transPath, srcPath) => changed.has(transPath) || changed.has(srcPath);
+  // Only a change to the TRANSLATION is this author's to answer for. Adding
+  // front matter to an English page leaves 17 translations out of step, but
+  // that is the sync pipeline's work, reported by the staleness dashboard —
+  // the sibling terminology gate draws the same line.
+  inScope = (transPath) => changed.has(transPath);
 }
 
 // ---- check ----------------------------------------------------------------
@@ -109,16 +113,23 @@ const readAtBase = (p) => {
   try { return git(["show", `${mergeBase}:${p}`]); } catch { return null; }
 };
 
-// A violation this change did not create is not this change's to fix. Editing an
-// English page must not make every old defect in its 17 translations blocking —
-// that is the sibling terminology gate's rule too.
-function introduced(transPath, srcPath, violation) {
+// A violation this change did not create is not this change's to fix. But
+// "did not create" has to mean the damage is UNTOUCHED, not merely that it falls
+// in the same bucket: a resync that rewrites one broken block into a different
+// broken block of the same kind is exactly what happened on 2026-08-14, and
+// comparing only the violation code would wave it through. So the front-matter
+// region itself must be unchanged on both sides.
+function introduced(transPath, srcPath, transText, srcText, violation) {
   if (!mergeBase) return true;
   const wasSrc = readAtBase(srcPath);
   const wasTrans = readAtBase(transPath);
   if (wasSrc === null || wasTrans === null) return true; // new page: it is yours
   const was = frontMatterViolation(wasSrc, wasTrans);
-  return !was || was.code !== violation.code;
+  if (!was || was.code !== violation.code) return true;
+  return (
+    frontMatterRegion(wasTrans) !== frontMatterRegion(transText) ||
+    frontMatterRegion(wasSrc) !== frontMatterRegion(srcText)
+  );
 }
 
 const blocking = [];
@@ -140,7 +151,7 @@ for (const transPath of files) {
   const violation = frontMatterViolation(srcText, transText);
   if (!violation) continue;
   const line = `${transPath}: ${violation.message}`;
-  if ((!inScope || inScope(transPath, srcPath)) && introduced(transPath, srcPath, violation)) blocking.push(line);
+  if ((!inScope || inScope(transPath)) && introduced(transPath, srcPath, transText, srcText, violation)) blocking.push(line);
   else inherited.push(line);
 }
 

--- a/translation/lib/frontmatter.mjs
+++ b/translation/lib/frontmatter.mjs
@@ -1,0 +1,144 @@
+// Front-matter parity between an English source page and its translations.
+//
+// A page's leading YAML block is metadata, not prose: whatever `site/<page>.md`
+// declares, every `translations/<locale>/site/<page>.md` must declare the same.
+// Nothing about a publication date changes between languages.
+//
+// This is not a style rule. Jekyll builds the GitHub Pages copy of this repo
+// straight from `main`, and it reads a leading `---` as a front-matter opener,
+// scans to the next `---` far down the page, and fails the WHOLE build if what
+// lies between is not valid YAML. That is what happened on 2026-08-14: one
+// translated page acquired a `---` its source did not have, and the published
+// site stayed frozen for four days.
+//
+// The other three shapes below do not break the build. They are worse in one
+// respect — nothing reports them at all:
+//
+//   duplicated opener   `---` / `---` / `published: <date>` / `---`
+//                       Jekyll consumes the empty first block, so the date
+//                       lands in the body and the `---` under it turns the line
+//                       into a setext H2 heading.
+//   translated key      `wotae:`, `iliyochapishwa:`, `wotintimii:`, `bipụtara:`
+//                       — the date is still there and nothing can read it.
+//   lost opener         the opening `---` gone, the closing one surviving; the
+//                       page has no front matter and the line renders as a
+//                       heading.
+//
+// 316 pages carried one of these before #1975. A first-line comparison (the
+// check this repo's generator used to run) sees only the first shape, because
+// as soon as the source legitimately has front matter the first lines match.
+
+// Jekyll reads pages as `bom|utf-8` and strips U+FEFF BEFORE matching front
+// matter, so `﻿---` IS an opener to it. Judge the text the way it will.
+const stripBom = (text) => (text.charCodeAt(0) === 0xfeff ? text.slice(1) : text);
+
+// Line endings are not part of the comparison: a CRLF source and an LF
+// translation carry the same metadata.
+const bare = (lines) => lines.map((l) => l.replace(/\r$/, ""));
+
+// Jekyll anchors both delimiters at column 1 — a line reading ` ---` is body,
+// not a delimiter — so an indented lookalike must not be read as front matter
+// here either, in EITHER file.
+const OPENER = /^---[ \t]*\r?$/;
+const CLOSER = /^(---|\.\.\.)[ \t]*\r?$/;
+
+/**
+ * The leading front-matter block, as Jekyll would find it.
+ * @returns {{block: string[], end: number} | null} — null when the file has
+ * none, including an opener that never closes (to Jekyll that is a failed
+ * parse, not a block).
+ */
+export function parseFrontMatter(text) {
+  const lines = stripBom(text).split("\n");
+  if (!lines.length || !OPENER.test(lines[0])) return null;
+  for (let i = 1; i < lines.length; i += 1) {
+    if (CLOSER.test(lines[i])) return { block: lines.slice(1, i), end: i + 1 };
+  }
+  return null;
+}
+
+const keysOf = (block) =>
+  block
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => (l.match(/^([A-Za-z_][A-Za-z0-9_-]*):/) || [])[1] || l.split(":")[0].trim());
+
+/**
+ * @returns {{code: string, message: string} | null} — null when the translation
+ * agrees with its source.
+ */
+// Not a YAML parser — this repo has no dependencies and needs none: every block
+// in the corpus is one flat `key: value` line. Anything else is rejected rather
+// than guessed at, because a block Jekyll cannot parse fails the whole build,
+// and comparing two files for PARITY would happily pass a broken block that both
+// of them share.
+function unparseableLine(block) {
+  return block
+    .map((l) => l.replace(/\r$/, ""))
+    .find((line) => {
+      const l = line.trim();
+      if (!l) return false;
+      const m = l.match(/^([A-Za-z_][A-Za-z0-9_-]*):(?:[ \t]+(.*))?$/);
+      if (!m) return true; // not `key: value` at all
+      const value = (m[2] || "").trim();
+      if (!value) return false; // an empty value is valid YAML (null)
+      // A properly closed quoted scalar is valid whatever it contains — that is
+      // what quoting is for — so judge it on the quoting alone.
+      if (/^["']/.test(value)) return !/^"[^"]*"$/.test(value) && !/^'[^']*'$/.test(value);
+      // Unquoted: a leading YAML indicator opens a structure this block is not
+      // allowed to have, and a bare `: ` inside the value is the classic
+      // "mapping values are not allowed here" build failure.
+      return /^[[\]{}&*!|>%@`#]/.test(value) || /:\s/.test(value);
+    });
+}
+
+export function frontMatterViolation(srcText, transText) {
+  const src = parseFrontMatter(srcText);
+  const transLines = stripBom(transText).split("\n");
+  const firstContent = transLines.findIndex((l) => l.trim());
+
+  // Front matter is anchored at the very start of the file. A blank line above
+  // an otherwise perfect block means the page has NO front matter, and the
+  // block renders as a rule plus a setext heading.
+  if (firstContent > 0 && OPENER.test(transLines[firstContent])) {
+    return { code: "unanchored", message: "front matter does not start at the first line of the file" };
+  }
+
+  const opens = transLines.length > 0 && OPENER.test(transLines[0]);
+
+  if (!src) {
+    return opens
+      ? { code: "stray-opener", message: "opens with a '---' the English source does not have (breaks the Jekyll build)" }
+      : null;
+  }
+  if (!opens) return { code: "dropped", message: "has no front matter, but its English source does" };
+
+  if (transLines.length > 1 && CLOSER.test(transLines[1])) {
+    return { code: "duplicated-opener", message: "opens with an empty front-matter block ahead of the real one" };
+  }
+
+  const trans = parseFrontMatter(transText);
+  if (!trans) return { code: "unterminated", message: "opens with '---' that never closes" };
+
+  const want = bare(src.block);
+  const got = bare(trans.block);
+
+  const badSrc = unparseableLine(want);
+  if (badSrc !== undefined) {
+    return { code: "invalid", message: `its English source's front matter is not flat \`key: value\` (${badSrc.trim()}) — fix the source page first` };
+  }
+  const badTrans = unparseableLine(got);
+  if (badTrans !== undefined) {
+    return { code: "invalid", message: `front matter is not flat \`key: value\` (${badTrans.trim()}) — Jekyll fails the whole build on a block it cannot parse` };
+  }
+
+  if (want.join("\n") === got.join("\n")) return null;
+
+  const wantKeys = keysOf(want);
+  const gotKeys = keysOf(got);
+  const detail =
+    wantKeys.join(",") === gotKeys.join(",")
+      ? `values differ from the source (${got.filter(Boolean).join("; ")} vs ${want.filter(Boolean).join("; ")})`
+      : `keys ${gotKeys.join(", ") || "(none)"} != source ${wantKeys.join(", ") || "(none)"}`;
+  return { code: "mismatch", message: `front matter differs from its English source — ${detail}` };
+}

--- a/translation/lib/frontmatter.mjs
+++ b/translation/lib/frontmatter.mjs
@@ -61,7 +61,29 @@ const keysOf = (block) =>
   block
     .map((l) => l.trim())
     .filter(Boolean)
-    .map((l) => (l.match(/^([A-Za-z_][A-Za-z0-9_-]*):/) || [])[1] || l.split(":")[0].trim());
+    .map((l) => (l.match(/^([\p{L}_][\p{L}\p{N}_-]*):/u) || [])[1] || l.split(":")[0].trim());
+
+/**
+ * The slice of a file the rules above look at: its leading front-matter block,
+ * or the mangled remains of one. Two files with the same region carry the same
+ * front-matter damage, which is how a change that rewrites a broken block is
+ * told from one that merely leaves it alone.
+ * @returns {string} — empty when the file has no front matter of any shape.
+ */
+export function frontMatterRegion(text) {
+  const lines = stripBom(text).split("\n");
+  const fm = parseFrontMatter(text);
+  if (fm) return bare(lines.slice(0, fm.end)).join("\n");
+  const first = lines.findIndex((l) => l.trim());
+  if (first < 0) return "";
+  if (OPENER.test(lines[first])) return bare(lines.slice(0, first + 1)).join("\n");
+  // `key: value` with only the closing delimiter left under it
+  const next = lines.findIndex((l, i) => i > first && l.trim());
+  if (next > 0 && CLOSER.test(lines[next]) && lines[first].includes(":")) {
+    return bare(lines.slice(0, next + 1)).join("\n");
+  }
+  return "";
+}
 
 /**
  * @returns {{code: string, message: string} | null} — null when the translation
@@ -78,7 +100,7 @@ function unparseableLine(block) {
     .find((line) => {
       const l = line.trim();
       if (!l) return false;
-      const m = l.match(/^([A-Za-z_][A-Za-z0-9_-]*):(?:[ \t]+(.*))?$/);
+      const m = l.match(/^([\p{L}_][\p{L}\p{N}_-]*):(?:[ \t]+(.*))?$/u);
       if (!m) return true; // not `key: value` at all
       const value = (m[2] || "").trim();
       if (!value) return false; // an empty value is valid YAML (null)
@@ -88,7 +110,7 @@ function unparseableLine(block) {
       // Unquoted: a leading YAML indicator opens a structure this block is not
       // allowed to have, and a bare `: ` inside the value is the classic
       // "mapping values are not allowed here" build failure.
-      return /^[[\]{}&*!|>%@`#]/.test(value) || /:\s/.test(value);
+      return /^[[\]{}&*!|>%@`#?-]/.test(value) || /:\s/.test(value);
     });
 }
 
@@ -107,18 +129,29 @@ export function frontMatterViolation(srcText, transText) {
   const opens = transLines.length > 0 && OPENER.test(transLines[0]);
 
   if (!src) {
-    return opens
-      ? { code: "stray-opener", message: "opens with a '---' the English source does not have (breaks the Jekyll build)" }
-      : null;
+    if (!opens) return null;
+    // The source opens a block it never closes. Jekyll finds no front matter in
+    // either file and copies both through, so a translation that mirrors it is
+    // not the build hazard — the source is the thing to fix, and that is not
+    // this check's business. Only a translation that closes one is out of step.
+    if (OPENER.test(stripBom(srcText).split("\n")[0] || "")) {
+      return parseFrontMatter(transText)
+        ? { code: "mismatch", message: "declares front matter its English source only appears to have — the source's block is never closed" }
+        : null;
+    }
+    return { code: "stray-opener", message: "opens with a '---' the English source does not have (breaks the Jekyll build)" };
   }
   if (!opens) return { code: "dropped", message: "has no front matter, but its English source does" };
 
-  if (transLines.length > 1 && CLOSER.test(transLines[1])) {
-    return { code: "duplicated-opener", message: "opens with an empty front-matter block ahead of the real one" };
-  }
-
   const trans = parseFrontMatter(transText);
   if (!trans) return { code: "unterminated", message: "opens with '---' that never closes" };
+
+  // An empty block is valid front matter and Jekyll is happy with it — it is
+  // only a defect when the source declares something the page then repeats
+  // below, as body.
+  if (trans.block.every((l) => !l.trim()) && src.block.some((l) => l.trim())) {
+    return { code: "duplicated-opener", message: "opens with an empty front-matter block ahead of the real one" };
+  }
 
   const want = bare(src.block);
   const got = bare(trans.block);

--- a/translation/lib/frontmatter.test.mjs
+++ b/translation/lib/frontmatter.test.mjs
@@ -1,0 +1,126 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { frontMatterViolation, parseFrontMatter } from "./frontmatter.mjs";
+
+const SRC = "---\npublished: 2025-08-19\n---\n\n# Title\n\nbody\n";
+const SRC_PLAIN = '<a href="x">Edit</a>\n\n# Title\n\nbody\n';
+const code = (s, t) => (frontMatterViolation(s, t) || {}).code ?? null;
+
+test("a matching block is not a violation", () => {
+  assert.equal(code(SRC, "---\npublished: 2025-08-19\n---\n\n# Заголовок\n"), null);
+});
+
+test("no front matter on either side is not a violation", () => {
+  assert.equal(code(SRC_PLAIN, SRC_PLAIN), null);
+});
+
+test("an opener the source lacks is caught (the build breaker)", () => {
+  assert.equal(code(SRC_PLAIN, `---\n${SRC_PLAIN}`), "stray-opener");
+});
+
+test("a duplicated opener is caught", () => {
+  assert.equal(code(SRC, "---\n---\npublished: 2025-08-19\n---\n\n# T\n"), "duplicated-opener");
+});
+
+test("a translated key is caught", () => {
+  assert.equal(code(SRC, "---\nwotae: 2025-08-19\n---\n\n# T\n"), "mismatch");
+});
+
+test("a lost opening delimiter is caught", () => {
+  assert.equal(code(SRC, "bipụtara: 2025-08-19\n---\n\n# T\n"), "dropped");
+});
+
+test("a block pushed down by a blank line is caught — Jekyll anchors at the first line", () => {
+  assert.equal(code(SRC, "\n---\npublished: 2025-08-19\n---\n\n# T\n"), "unanchored");
+});
+
+test("an opener that never closes is caught", () => {
+  assert.equal(code(SRC, "---\npublished: 2025-08-19\n\n# T\n"), "unterminated");
+});
+
+test("a changed value is caught, and named", () => {
+  const v = frontMatterViolation(SRC, "---\npublished: 2024-01-01\n---\n\n# T\n");
+  assert.equal(v.code, "mismatch");
+  assert.match(v.message, /values differ/);
+});
+
+test("a differing key set is named as keys, not values", () => {
+  const v = frontMatterViolation(SRC, "---\nwotae: 2025-08-19\n---\n\n# T\n");
+  assert.match(v.message, /keys wotae != source published/);
+});
+
+test("line endings are not part of the comparison", () => {
+  assert.equal(code(SRC, "---\r\npublished: 2025-08-19\r\n---\r\n\r\n# T\r\n"), null);
+});
+
+test("a UTF-8 BOM does not hide an opener, as it does not from Jekyll", () => {
+  assert.equal(code(SRC_PLAIN, `﻿---\n${SRC_PLAIN}`), "stray-opener");
+});
+
+test("a body line containing a colon is not mistaken for front matter", () => {
+  assert.equal(code(SRC_PLAIN, "Note: this is body text\n\n# T\n"), null);
+});
+
+test("parseFrontMatter returns the block and where the body starts", () => {
+  const fm = parseFrontMatter(SRC);
+  assert.deepEqual(fm.block, ["published: 2025-08-19"]);
+  assert.equal(SRC.split("\n")[fm.end], "");
+});
+
+test("parseFrontMatter treats an unterminated opener as no front matter", () => {
+  assert.equal(parseFrontMatter("---\npublished: 2025-08-19\n"), null);
+});
+
+test("a block Jekyll cannot parse is caught even when both files share it", () => {
+  const broken = "---\npublished: [\n---\n\n# T\n";
+  const v = frontMatterViolation(broken, broken);
+  assert.equal(v.code, "invalid");
+  assert.match(v.message, /source/);
+});
+
+test("an unquoted colon in a value is caught — the classic build failure", () => {
+  const broken = "---\npublished: a: b\n---\n\n# T\n";
+  assert.equal(frontMatterViolation(broken, broken).code, "invalid");
+});
+
+test("a translation-only unparseable block names the translation, not the source", () => {
+  const v = frontMatterViolation(SRC, "---\npublished: {a}\n---\n\n# T\n");
+  assert.equal(v.code, "invalid");
+  assert.doesNotMatch(v.message, /source/);
+});
+
+test("an empty value is valid YAML and not a violation", () => {
+  const empty = "---\npublished:\n---\n\n# T\n";
+  assert.equal(frontMatterViolation(empty, empty), null);
+});
+
+test("an indented '---' is body to Jekyll, so it is not front matter here either", () => {
+  assert.equal(parseFrontMatter(" ---\npublished: 2025-08-19\n---\n"), null);
+});
+
+test("'...' closes a block, as it does for Jekyll", () => {
+  assert.deepEqual(parseFrontMatter("---\npublished: 2025-08-19\n...\n\n# T\n").block, ["published: 2025-08-19"]);
+});
+
+test("a trailing space after the date is not a difference", () => {
+  const s = "---\npublished: 2023-10-23 \n---\n\n# T\n";
+  assert.equal(frontMatterViolation(s, s), null);
+});
+
+test("a quoted scalar is valid however it is punctuated", () => {
+  const q = '---\ntitle: "Foo: Bar"\n---\n\n# T\n';
+  assert.equal(frontMatterViolation(q, q), null);
+});
+
+test("an unclosed quote is not", () => {
+  const q = '---\ntitle: "Foo\n---\n\n# T\n';
+  assert.equal(frontMatterViolation(q, q).code, "invalid");
+});
+
+test("an indented lookalike in the body is body, not a stray opener", () => {
+  assert.equal(frontMatterViolation(SRC_PLAIN, ` ---\n${SRC_PLAIN}`), null);
+});
+
+test("a blank line above an indented lookalike is body too", () => {
+  assert.equal(frontMatterViolation(SRC_PLAIN, `\n ---\n${SRC_PLAIN}`), null);
+});

--- a/translation/lib/frontmatter.test.mjs
+++ b/translation/lib/frontmatter.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { frontMatterViolation, parseFrontMatter } from "./frontmatter.mjs";
+import { frontMatterRegion, frontMatterViolation, parseFrontMatter } from "./frontmatter.mjs";
 
 const SRC = "---\npublished: 2025-08-19\n---\n\n# Title\n\nbody\n";
 const SRC_PLAIN = '<a href="x">Edit</a>\n\n# Title\n\nbody\n';
@@ -123,4 +123,49 @@ test("an indented lookalike in the body is body, not a stray opener", () => {
 
 test("a blank line above an indented lookalike is body too", () => {
   assert.equal(frontMatterViolation(SRC_PLAIN, `\n ---\n${SRC_PLAIN}`), null);
+});
+
+test("a non-ASCII key is valid YAML, so it reads as a mismatch and not as unparseable", () => {
+  const v = frontMatterViolation(SRC, "---\nbipụtara: 2025-08-19\n---\n\n# T\n");
+  assert.equal(v.code, "mismatch");
+  assert.match(v.message, /bipụtara/);
+});
+
+test("an empty block is valid front matter when the source has one too", () => {
+  assert.equal(frontMatterViolation("---\n---\nbody\n", "---\n---\nbody\n"), null);
+});
+
+test("a value opening a block sequence is caught — Psych rejects it", () => {
+  const broken = "---\npublished: - x\n---\n\n# T\n";
+  assert.equal(frontMatterViolation(broken, broken).code, "invalid");
+});
+
+test("an unterminated opener in the source is not front matter, so mirroring it is fine", () => {
+  const src = "---\npublished: 2025-08-19\n\n# T\n";
+  assert.equal(frontMatterViolation(src, src), null);
+});
+
+test("…but closing a block the source never closes is out of step", () => {
+  const src = "---\npublished: 2025-08-19\n\n# T\n";
+  assert.equal(frontMatterViolation(src, SRC).code, "mismatch");
+});
+
+test("frontMatterRegion isolates the block, so a body edit is not a block edit", () => {
+  assert.equal(frontMatterRegion(SRC), "---\npublished: 2025-08-19\n---");
+  assert.equal(frontMatterRegion(`${SRC}more body\n`), frontMatterRegion(SRC));
+});
+
+test("frontMatterRegion captures the mangled remains of a block", () => {
+  assert.equal(frontMatterRegion("bipụtara: 2025-08-19\n---\n\nbody\n"), "bipụtara: 2025-08-19\n---");
+});
+
+test("frontMatterRegion is empty for a page with no front matter of any shape", () => {
+  assert.equal(frontMatterRegion("# Title\n\nbody\n"), "");
+});
+
+test("frontMatterRegion distinguishes two different broken blocks of the same kind", () => {
+  const a = "---\nwotintimii: 2024-01-12\n---\n\n# T\n";
+  const b = "---\nwotintimii: 9999-99-99\n---\n\n# T\n";
+  assert.equal(frontMatterViolation(SRC, a).code, frontMatterViolation(SRC, b).code);
+  assert.notEqual(frontMatterRegion(a), frontMatterRegion(b));
 });


### PR DESCRIPTION
## Why

On 2026-08-14 a resync gave 260 translated pages a leading `---` their English source does not have. Jekyll reads a leading `---` as a front-matter opener, scans to the next `---` far down the page, and fails the build for the **whole site**. `pages build and deployment` failed on every push from that day, and https://zechub.github.io/zechub/ served a build from 2026-08-14 13:49 GMT for four days.

Nothing in CI could have stopped it, for two reasons that are both still true today:

- **The Pages build runs only on push to `main`, never on a pull request.** The merge that broke it (#1960) was green.
- **Three of the four damage shapes break no build at all**, so nothing reports them. They just corrupt the page.

The four shapes, all of them real, 314 pages between them (repaired in #1975):

| shape | what the reader sees |
|---|---|
| a `---` the source does not have | the entire site build fails |
| an empty block ahead of the real one | the date becomes a setext H2 heading |
| the key itself translated — `wotae:`, `iliyochapishwa:`, `wotintimii:`, `bipụtara:` | the date is unreadable to anything |
| the opening delimiter lost, the closing one surviving | no front matter; the line becomes a heading |

## What this adds

The rule the corpus already follows: **a translated page declares the same leading YAML block as its English source, copied verbatim.** Nothing about a publication date changes between languages.

- **`translation/lib/frontmatter.mjs`** — `parseFrontMatter()` and `frontMatterViolation()`. BOM-aware, because Jekyll strips U+FEFF *before* matching front matter, so `﻿---` is an opener to it. Blind to line endings. Delimiters anchored at column 1, as Jekyll anchors them. It also rejects a block that is not flat `key: value`: two files can share a block Jekyll cannot parse (`published: [`, an unquoted `: ` in a value) and comparing them for parity alone would pass it.
- **`scripts/check-frontmatter.mjs`** — with `--base`, only a violation *this change introduced* is blocking; anything already broken prints as a notice, exactly like `check-protected-terms.mjs`. Editing an English page does not make old damage in its 17 translations your problem. Run it bare for a whole-tree sweep.
- **`frontmatter-parity` job** — scoped on a pull request; a **full sweep** on push to `main`, so damage arriving by force-push, or by a merge whose own PR predated this job, cannot sit unreported on the branch Pages builds from.
- **`docs/translation-contributor-workflow.md`** — the rule, the reason, and the local command.

Tests are in `translation/lib/frontmatter.test.mjs` and are picked up by the existing `hash-lib-tests` job, which already globs `translation/lib/*.test.mjs`: **77 pass** across the four lib modules.

## Verified

- Scoped run on this branch: green, with the 314 pre-existing pages reported as a notice — so this PR is mergeable on its own and reddens nothing.
- Editing `site/Zcash_Tech/Blossom.md`, whose Arabic translation is one of the 314: still exits 0, that page in the notice.
- Adding a stray `---` to a clean page (`translations/ak/site/Glossary_and_FAQs/FAQ.md`): exits 1 and names it.
- Unscoped run on `main`: fails with exactly 314 pages — 260 stray openers, 24 duplicated, 18 key mismatches, 12 dropped.
- The other four jobs are unaffected.

## Merge order

Either order works. Merging #1975 first leaves this job green on `main`; merging this first means the push-to-`main` run correctly reports the 314 pages still to be repaired.

Companion: the generator that produced the damage had a guard that compared only the *first line*, which is blind whenever the source legitimately has front matter. That has been tightened separately to compare the parsed block — but the generator is not the only writer (177 pages were hand-fixed on 2026-08-12 and regenerated broken two days later), which is why the check belongs here too.

## Second commit — review corrections

Adversarial review found the "already broken, not your problem" rule too coarse: it compared only the *kind* of violation, so a page could have its block rewritten into a different broken block of the same kind and pass as inherited. Since a resync re-damaging pages is exactly the 2026-08-14 shape, and all 314 pages sit in that state until #1975 lands, the gap was open precisely where it mattered. The block itself must now be unchanged before damage counts as somebody else's.

Four narrower corrections, each one a page Jekyll accepts that the check rejected, or the reverse: a non-ASCII key (`bipụtara:`) is valid YAML and now reads as a key mismatch rather than an unparseable block; an empty front-matter block is valid and is only a duplicated opener when the source declares something; `-` and `?` added to the indicators Psych rejects; and an opener the source never closes is not front matter at all, so a translation mirroring it is not a stray opener.

Scope also narrows to the translations a change touched — adding front matter to an English page is the sync pipeline's work, not 17 red X's for whoever edited the English page.

86 tests pass.
