### PR TITLE
Update and standardize Crosslink Protocol page

### DIFF
--- a/site/Zcash_Tech/Crosslink_Protocol.md
+++ b/site/Zcash_Tech/Crosslink_Protocol.md
@@ -1,55 +1,71 @@
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Tech/Crosslink_Protocol.md" target="_blank">
+  <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
+</a>
 
+# Crosslink Protocol
 
-### Crosslink Protocol
+## TL;DR
 
-#### **Introduction: Zcash Hybrid PoS and the Crosslink Protocol**
+* The Crosslink protocol is a proposed design for Zcash's hybrid Proof-of-Work/Proof-of-Stake (PoW/PoS) stage. It integrates PoW with a Byzantine Fault Tolerance (BFT) protocol, enabling assured finality as long as either PoW or PoS remains secure.
+* Hybrid PoS introduces notaries who validate blocks based on staked ZEC — initially static, later elected based on staked ZEC.
+* Crosslink aims to provide two ledgers: a **finalized ledger (LOG_fin)** for rollback safety, and a **lower-latency ledger (LOG_ba)** that extends it by no more than *L* blocks.
+* A **Safety Mode** activates if the finalized ledger falls behind by more than *L* blocks: PoW continues, but economic activities pause until the issue is resolved.
+* Over time, PoS validators will receive a growing share of rewards, reducing PoW miners' earnings; the protocol introduces changes gradually.
+* The protocol is being developed by Shielded Labs, with a roadmap for integrating Crosslink 2* into Zcash's Zebra client.
+
+## Core Explanation
+
+### Introduction: Zcash Hybrid PoS and the Crosslink Protocol
 
 The Crosslink Protocol is a landmark development in Zcash evolution, steering it towards a **Hybrid Proof-of-Stake (PoS)** and **Proof-of-Work (PoW)** model. Traditional PoW, while reliable for ensuring network security, faces criticism for energy consumption and centralization risks associated with industrial mining. Crosslink introduces a hybrid system, merging the proven robustness of PoW with the efficiency and governance advantages of PoS.
 
 ![image](/content-images/a2ffb19d-e570-4723-b669-a66e14fc6b71-a727c958de.webp)
 
-This transition aligns with global trends in blockchain innovation, where projects are shifting to environmentally sustainable and decentralized mechanisms. Crosslinks dual consensus model ensures Zcash maintains its strong cryptographic privacy guarantees while evolving to meet contemporary challenges.
+This transition aligns with global trends in blockchain innovation, where projects are shifting to environmentally sustainable and decentralized mechanisms. Crosslinks' dual consensus model ensures Zcash maintains its strong cryptographic privacy guarantees while evolving to meet contemporary challenges.
 
-The hybrid Proof-of-Stake (PoS) approach combines traditional Proof-of-Work (PoW) with PoS, aiming to address vulnerabilities like 51% attacks while maintaining decentralization and reducing energy consumption. Hybrid PoS introduces notaries who validate blocks based on staked ZEC. This mechanism is designed to improve chain security and checkpoint validation, offering a more robust alternative to pure PoW systems​.
+The hybrid Proof-of-Stake (PoS) approach combines traditional Proof-of-Work (PoW) with PoS, aiming to address vulnerabilities like 51% attacks while maintaining decentralization and reducing energy consumption. Hybrid PoS introduces notaries who validate blocks based on staked ZEC. This mechanism is designed to improve chain security and checkpoint validation, offering a more robust alternative to pure PoW systems.
 
-Why Hybrid PoS/PoW as first test?
-It makes progress towards pure PoS
-It enables concurrent mining and staking use cases and ecosystem crossover.
-It mitigates possible security issues with the PoS protocol until it has greater validator stake and confidence.
-The general approach has been demonstrated by Ethereum in Production
+### Why Hybrid PoS/PoW as first test?
 
----
+* It makes progress towards pure PoS.
+* It enables concurrent mining and staking use cases and ecosystem crossover.
+* It mitigates possible security issues with the PoS protocol until it has greater validator stake and confidence.
+* The general approach has been demonstrated by Ethereum in Production.
 
+### What Crosslink is
 
-### CROSSLINK
-The Crosslink protocol is a proposed design for Zcash hybrid Proof-of-Work/Proof-of-Stake (PoW/PoS) stage. It integrates PoW with a Byzantine Fault Tolerance (BFT) protocol, enabling assured finality as long as either PoW or PoS remains secure. The design aims to strengthen network security and decentralization by incorporating staked validation while maintaining miner participation. A key feature of the proposal, called Crosslink 2, simplifies the architecture by unifying BFT proposers and miners. This streamlined approach minimizes structural changes and allows the use of a "dummy" BFT layer, making it easier to prototype and deploy while maintaining high-security standards.
+The Crosslink protocol is a proposed design for Zcash's hybrid Proof-of-Work/Proof-of-Stake (PoW/PoS) stage. It integrates PoW with a Byzantine Fault Tolerance (BFT) protocol, enabling assured finality as long as either PoW or PoS remains secure. The design aims to strengthen network security and decentralization by incorporating staked validation while maintaining miner participation. A key feature of the proposal, called Crosslink 2, simplifies the architecture by unifying BFT proposers and miners. This streamlined approach minimizes structural changes and allows the use of a "dummy" BFT layer, making it easier to prototype and deploy while maintaining high-security standards.
 
-The implementation plan includes a roadmap with estimated engineering costs for integrating Crosslink 2* into Zcash's Zebra client. This phased deployment focuses on balancing stakeholder incentives, reducing disruption, and aligning with Zcash goals for scalability, usability, and decentralization. Growing confidence in the protocol's robust security properties further solidifies its potential as a key step in Zcash evolution. By addressing energy efficiency and enhancing consensus mechanisms, Crosslink offers a forward looking solution to evolving blockchain challenges. For more details, refer to the [GitHub repository](https://github.com/ShieldedLabs/crosslink-deployment) and the [Zcash Community Forum](https://forum.zcashcommunity.com).
+The implementation plan includes a roadmap with estimated engineering costs for integrating Crosslink 2* into Zcash's Zebra client. This phased deployment focuses on balancing stakeholder incentives, reducing disruption, and aligning with Zcash goals for scalability, usability, and decentralization. Growing confidence in the protocol's robust security properties further solidifies its potential as a key step in Zcash evolution. By addressing energy efficiency and enhancing consensus mechanisms, Crosslink offers a forward-looking solution to evolving blockchain challenges. For more details, refer to the [GitHub repository](https://github.com/ShieldedLabs/crosslink-deployment) and the [Zcash Community Forum](https://forum.zcashcommunity.com).
 
-![image](/content-images/b34afda4-fe33-448f-b0dd-279fd6cef1f5-73f58cdcc6.webp)
-
-
-#### **Aims and Objectives of Crosslink**
+### Aims and Objectives of Crosslink
 
 The Crosslink Protocol is designed to address several strategic goals crucial for the future of Zcash:
 
 1. **Decentralization**:
-   - By incorporating PoS, Zcash reduces reliance on specialized PoW hardware (ASICs), which often concentrates mining power among a few large operators.
-   - PoS allows participation from a broader community, where coinholders stake their assets to secure the network, ensuring a more distributed consensus.
-   - By introducing staked validation, the protocol ensures that economic participants play an active role in consensus, reducing reliance on mining alone.
-
+   * By incorporating PoS, Zcash reduces reliance on specialized PoW hardware (ASICs), which often concentrates mining power among a few large operators.
+   * PoS allows participation from a broader community, where coinholders stake their assets to secure the network, ensuring a more distributed consensus.
+   * By introducing staked validation, the protocol ensures that economic participants play an active role in consensus, reducing reliance on mining alone.
 2. **Enhanced Governance**:
-   - Coinholders gain voting rights through staking, enabling them to influence decisions about network upgrades, funding allocations, and ecosystem priorities. This democratic mechanism aligns the protocol's evolution with community interests.
-
+   * Coinholders gain voting rights through staking, enabling them to influence decisions about network upgrades, funding allocations, and ecosystem priorities. This democratic mechanism aligns the protocol's evolution with community interests.
 3. **Energy Efficiency**:
-   - Transitioning partially to PoS significantly lowers energy demands, aligning Zcash with global sustainability initiatives. PoS is inherently less resource-intensive compared to the computationally heavy PoW. Hybrid systems aim to lower energy use compared to PoW-only systems while maintaining high security​
-
+   * Transitioning partially to PoS significantly lowers energy demands, aligning Zcash with global sustainability initiatives. PoS is inherently less resource-intensive compared to the computationally heavy PoW. Hybrid systems aim to lower energy use compared to PoW-only systems while maintaining high security.
 4. **Economic Security and Sustainability**:
-   - Combining PoW and PoS diversifies the economic incentives for network participants, ensuring robust security without over-reliance on a single mechanism.
-   - Staking also introduces a predictable reward model for participants, creating an attractive proposition for long term investors.
- 
-5. Increased Security: Crosslink aims to enhance the resilience of the network against chain reorganization attacks by integrating PoS alongside PoW.
+   * Combining PoW and PoS diversifies the economic incentives for network participants, ensuring robust security without over-reliance on a single mechanism.
+   * Staking also introduces a predictable reward model for participants, creating an attractive proposition for long-term investors.
+5. **Increased Security**: Crosslink aims to enhance the resilience of the network against chain reorganization attacks by integrating PoS alongside PoW.
 
+## Visual / Analogy
+
+![image](/content-images/b34afda4-fe33-448f-b0dd-279fd6cef1f5-73f58cdcc6.webp)
+
+Think of a parcel service that issues two different documents for the same delivery. The first is a tracking scan: it appears quickly, tells you where the parcel most likely is, and is occasionally corrected. The second is a signed delivery receipt: it arrives later, but once it exists nobody disputes it.
+
+The lower-latency ledger is the tracking scan, and the finalized ledger is the signed receipt. Both describe the same chain of events; they differ in how quickly they appear and how firmly they hold.
+
+Safety Mode is what the depot does when signed receipts stop arriving while scans keep piling up. Parcels still move through the building — but the office stops paying out against scans alone until the signatures catch up.
+
+## Deep Dive
 
 ### Security and Performance Goals of Crosslink
 
@@ -59,52 +75,64 @@ The lower-latency ledger extends the finalized ledger by no more than *L* blocks
 
 ![image](/content-images/fd039664-4852-4fb0-8c88-0615f1ed116e-41459b81dc.webp)
 
-
 ### Bounded Availability and Safety Mode
 
 Crosslink incorporates a **Safety Mode** to address risks associated with the lower-latency ledger running far ahead of the finalized ledger. This prevents discrepancies, such as imbalanced account states or unverified security gaps in temporary solutions by service providers. Safety Mode is activated if the finalized ledger falls behind by more than a constant *L* blocks. During this state, the blockchain continues PoW operations (ensuring basic security), but economic activities are paused until the issue is resolved. This mechanism is designed to recover from exceptional conditions like major attacks while supporting governance-based rollback policies.
 
-
----
-
-#### **Impact on PoW Miners' Revenue**
-
-Crosslink acknowledges the foundational role of PoW miners in Zcash early development while preparing for a gradual shift:
-
-- **Reduced Block Rewards**:
-   - Over time, PoS validators will receive a growing share of rewards, reducing the earnings of PoW miners. This redistribution reflects the diminishing role of PoW in the hybrid model.
-   
-- **Fair Transition**:
-   - The protocol introduces changes gradually, ensuring miners have sufficient time to adapt or explore new roles within the Zcash ecosystem, such as transitioning to staking or contributing to other network services.
-
-- **Mitigating Centralization Risks**:
-   - PoS staking pools are designed to prevent concentration of power, offering smaller players a chance to participate on equal footing. This inclusive approach counters the current concentration seen in ASIC-based mining.
-
-- PoW miners will experience reduced revenue as part of the block reward is reallocated to PoS validators. This reallocation ensures a balanced incentive system, rewarding both miners and stakers for securing the network.
-- A gradual transition is planned to mitigate the economic impact on miners while fostering stakeholder participation​
-
----
-
-#### **Technical Details and Deployment**
+### Technical Details and Deployment
 
 The Crosslink Protocol is being actively developed and deployed by Shielded Labs in collaboration with key ecosystem partners such as Zodl. The protocol's implementation includes:
-- Establishing secure staking mechanisms for PoS participants.
-- Modifying the reward structure to balance incentives between miners and stakers.
-- Ensuring backward compatibility and a seamless user experience during the transition.
-- Notary System: The protocol incorporates notaries who sign off on blocks. Initially, static notaries are used, transitioning to a dynamic system where notaries are elected based on staked ZEC.​
-- Activation Logic: The introduction of Crosslink requires changes to the Zcash consensus rules, including defining the stake distribution process and updating network protocol rules to support hybrid consensus​
-- Phased Deployment: The protocol will roll out in stages to ensure network stability and community adaptation. Initial phases focus on technical implementation, followed by governance integration for selecting notaries​.
+
+* Establishing secure staking mechanisms for PoS participants.
+* Modifying the reward structure to balance incentives between miners and stakers.
+* Ensuring backward compatibility and a seamless user experience during the transition.
+* Notary System: The protocol incorporates notaries who sign off on blocks. Initially, static notaries are used, transitioning to a dynamic system where notaries are elected based on staked ZEC.
+* Activation Logic: The introduction of Crosslink requires changes to the Zcash consensus rules, including defining the stake distribution process and updating network protocol rules to support hybrid consensus.
+* Phased Deployment: The protocol will roll out in stages to ensure network stability and community adaptation. Initial phases focus on technical implementation, followed by governance integration for selecting notaries.
 
 You can explore the technical details and track its progress via the [Crosslink Deployment Repository on GitHub](https://github.com/ShieldedLabs/crosslink-deployment).
 
----
+## Practical Implications
 
-#### **Additional Resources**
+### Impact on PoW Miners' Revenue
+
+Crosslink acknowledges the foundational role of PoW miners in Zcash early development while preparing for a gradual shift:
+
+* **Reduced Block Rewards**:
+  * Over time, PoS validators will receive a growing share of rewards, reducing PoW miners' earnings. This redistribution reflects the diminishing role of PoW in the hybrid model.
+* **Fair Transition**:
+  * The protocol introduces changes gradually, ensuring miners have sufficient time to adapt or explore new roles within the Zcash ecosystem, such as transitioning to staking or contributing to other network services.
+* **Mitigating Centralization Risks**:
+  * PoS staking pools are designed to prevent concentration of power, offering smaller players a chance to participate on equal footing. This inclusive approach counters the current concentration seen in ASIC-based mining.
+* PoW miners will experience reduced revenue as part of the block reward is reallocated to PoS validators. This reallocation ensures a balanced incentive system, rewarding both miners and stakers for securing the network.
+* A gradual transition is planned to mitigate the economic impact on miners while fostering stakeholder participation.
+
+This dual-consensus mechanism reinforces Zcash's commitment to privacy, sustainability, and decentralization, positioning it as a forward-looking leader in the blockchain space.
+
+## Common Mistakes
+
+**Reading Crosslink as an active consensus rule**. This page describes a proposed design with a phased deployment plan. Introducing it requires changes to the Zcash consensus rules, which is what the roadmap and the Zebra integration work are for.
+
+**Assuming PoS replaces mining**. Crosslink is a hybrid design: PoW block production continues alongside staked validation. Even in Safety Mode, the blockchain continues PoW operations while economic activities are paused.
+
+**Treating "finality" as faster confirmation**. The finalized ledger is designed for a latency slightly more than double that of the current Zcash blockchain for equivalent block confirmations. What it adds is rollback safety, not speed — the lower-latency ledger is the fast view.
+
+**Confusing the two ledgers**. LOG_ba is not a separate chain: it extends the finalized ledger by no more than *L* blocks, and in the Crosslink 2* design it functions as a PoW chain.
+
+## Related Pages
+
+- [Zebra Full Node](/zcash-tech/zebra-full-node) — the client Crosslink 2* is planned to be integrated into.
+- [Full Nodes](/zcash-tech/full-nodes) — how nodes validate consensus rules today, before any hybrid consensus change.
+- [Network Upgrades](/start-here/network-upgrades) — how consensus rule changes reach the Zcash network.
+- [Zcash Monetary Policy](/start-here/zcash-monetary-policy) — the block reward structure that Crosslink would redistribute.
+
+## Additional Resources
+
 - Community insights: [Zcash Community Forum - Crosslink Discussions](https://forum.zcashcommunity.com)
 - Official updates: [Electric Coin Company Blog](https://electriccoin.co)
 - Sustainability focus: [Why Hybrid PoS Matters for Zcash](https://forum.zcashcommunity.com)
 
-  Reference: 
+  Reference:
 
 <div className="my-8 w-full aspect-video max-w-3xl mx-auto rounded-2xl overflow-hidden shadow-lg bg-black">
      <iframe
@@ -116,7 +144,3 @@ You can explore the technical details and track its progress via the [Crosslink 
        loading="lazy"
      />
 </div>
-
-This dual-consensus mechanism reinforces Zcash commitment to privacy, sustainability, and decentralization, positioning it as a forward-looking leader in the blockchain space.
-
-


### PR DESCRIPTION
Structural standardization only.
All original text, links and images preserved.

Added H1, TL;DR, an analogy for the two-ledger model,
Common Mistakes and Related Pages. Merged the two duplicated intros into one
Core Explanation. Also fixed a few some mistakes.

One thing for maintainer: the page points at crosslink-deployment,
but zebra-crosslink also exists - I didn't touch it either way.