### PR TITLE
State Ironwood's activation as completed on both pages

### DIFF
--- a/site/Start_Here/Network_Upgrades.md
+++ b/site/Start_Here/Network_Upgrades.md
@@ -16,6 +16,6 @@ For the visual story of how Zcash's privacy has evolved across these upgrades, s
 | [NU6](../zcash-tech/nu6) | November 23, 2024 | 2,726,400 | c8e71055 | The Deferred Dev Fund Lockbox and a new development funding split |
 | [NU6.1](../zcash-tech/nu6-1) | November 24, 2025 | 3,146,400 | 4dec4df0 | Community and coin-holder governance of that funding |
 | [NU6.2](../zcash-tech/nu6-2) | June 3, 2026 | 3,364,600 | 5437f330 | An emergency fix that corrected the Orchard circuit |
-| [Ironwood (NU6.3)](../zcash-tech/ironwood) | ~July 28, 2026 | 3,428,143 | 37a5165b | The Ironwood pool and a public turnstile that lets anyone audit the supply |
+| [Ironwood (NU6.3)](../zcash-tech/ironwood) | July 28, 2026 | 3,428,143 | 37a5165b | The Ironwood pool and a public turnstile that lets anyone audit the supply |
 
-Dates are shown in UTC. Some dashboards show them in local time, which is the same block and the same moment. Ironwood's date is an estimate from its activation block height, which is the fixed trigger, so the exact day may shift slightly. A future upgrade, NU7, is still in planning and is not the same as Ironwood.
+Dates are shown in UTC. Some dashboards show them in local time, which is the same block and the same moment. The fixed trigger for every upgrade is its activation block height, not the calendar date: Ironwood activated at block 3,428,143. A future upgrade, NU7, is still in planning and is not the same as Ironwood.

--- a/site/Zcash_Tech/Ironwood.md
+++ b/site/Zcash_Tech/Ironwood.md
@@ -4,7 +4,7 @@
 
 # Ironwood
 
-> Ironwood activates on Zcash mainnet at block 3,428,143, expected around July 28, 2026 UTC.
+> Ironwood activated on Zcash mainnet at block 3,428,143 on July 28, 2026 UTC, and has been live since.
 
 What you'll take away: what Ironwood changes, why a bug in hidden money is serious, and how the turnstile lets anyone confirm that no ZEC was forged.
 
@@ -34,7 +34,7 @@ Importantly, there is no evidence the bug was ever exploited, no evidence of imp
 
 The Zcash community shipped fixes in stages rather than all at once.
 
-![Ironwood response timeline: the Orchard bug is found in May 2026, the pool is paused in June 2026, the circuit is fixed in NU6.2, and Ironwood activates around July 28, 2026](https://raw.githubusercontent.com/ZecHub/zechub/main/site/Zcash_Tech/assets/ironwood-timeline.png)
+![Ironwood response timeline: the Orchard bug is found in May 2026, the pool is paused in June 2026, the circuit is fixed in NU6.2, and Ironwood activated at block 3,428,143 on July 28, 2026](https://raw.githubusercontent.com/ZecHub/zechub/main/site/Zcash_Tech/assets/ironwood-timeline.png)
 
 1. In early June 2026, a temporary measure disabled the Orchard pool while a full fix was prepared.
 2. The NU6.2 upgrade corrected the Orchard circuit itself, closing the underlying soundness vulnerability.
@@ -46,7 +46,7 @@ The Zcash community shipped fixes in stages rather than all at once.
 
 NU6.2 secured the Orchard circuit for all new transactions, but value created under the old rules still sits in the Orchard pool. Ironwood gives that value a clean destination and a way to audit it as it moves.
 
-The Ironwood pool is a new shielded value pool created when NU6.3 activates. It is built on the corrected circuit and uses a quantum-recoverable note format (a design that lets funds be recovered if [quantum computers](../zcash-tech/post-quantum-security) ever break today's cryptography), defined in [ZIP 2005](https://zips.z.cash/zip-2005).
+The Ironwood pool is the shielded value pool created by NU6.3 at block 3,428,143. It is built on the corrected circuit and uses a quantum-recoverable note format (a design that lets funds be recovered if [quantum computers](../zcash-tech/post-quantum-security) ever break today's cryptography), defined in [ZIP 2005](https://zips.z.cash/zip-2005).
 
 1. After activation, the old Orchard pool becomes spend-only, so no new value may enter it.
 2. Newly shielded value flows into Ironwood instead.


### PR DESCRIPTION
## Two pages still describe Ironwood as an upcoming upgrade three weeks after it activated

`site/Zcash_Tech/Ironwood.md` line 7 read "expected around July 28, 2026 UTC", and `site/Start_Here/Network_Upgrades.md` dated Ironwood "~July 28, 2026" in a table where every other upgrade carries a settled date, then explained on line 21 that "the exact day may shift slightly".

Block 3,428,143 was mined on 28 July 2026. Verified against [[ZIP 258](https://zips.z.cash/zip-0258)](https://zips.z.cash/zip-0258), which specifies mainnet activation height 3428143 and branch ID 0x37A5165B, matching the value already in the table. The chain is at height 3,459,948 as I write this — 31,805 blocks past activation. The date is settled and the hedging language is wrong on both pages.

The [[Shielded Pools page](https://claude.ai/using-zcash/shielded-pools)](/using-zcash/shielded-pools) had the same defect corrected earlier this month in `4d99514c`, which states the activation as a completed event: "It activated on 28 July 2026 at block 3,428,143 as part of the NU6.3 network upgrade." These two pages now match that treatment.

### What changed

**`site/Start_Here/Network_Upgrades.md`**

- The table row loses the `~` and reads `July 28, 2026`, the same settled format as every other row.
- The note below the table no longer calls the date an estimate that may shift. It now states the general rule — the fixed trigger for every upgrade is its activation block height, not the calendar date — and anchors Ironwood to block 3,428,143.

**`site/Zcash_Tech/Ironwood.md`**

- Line 7 states the activation as completed and anchored to the block height.
- Two further instances on the same page used the future tense and are corrected alongside it: the timeline image alt text, which said Ironwood "activates around July 28, 2026", and the pool description on line 49, which read "created when NU6.3 activates". Leaving either would have meant the page still described the activation as pending in the places a screen-reader user and a skimming reader hit first.

A sweep of the rest of the English wiki found no other page describing Ironwood as expected, estimated or upcoming, so these two were the full set.

### Acceptance criteria

- Neither page describes the activation as expected, estimated or upcoming: `grep -inE "expect|upcoming|estimat|~July|around July|may shift|activates"` across both pages returns nothing.
- The activation block height is stated on both pages.
- Blocking checks pass: `manifest-invariants`, `protected-terms`, `frontmatter-parity` and `hash-lib-tests` are all green, verified on a real commit against the PR base rather than a dirty working tree. Neither page appears in the protected-terms warnings. `git diff --check` is clean.

`menu-titles-fresh` is red, but it fails identically on a clean checkout of main: the drift comes from `Zcash_Tech/Crosslink_Protocol.md` and `guides/Verifying_Zcash_Releases.md`, two English pages added upstream last week whose `en.json` entries were never regenerated. Unrelated to this PR and left alone deliberately.

Only English pages are touched, so no translation manifest entries change.