### PR TITLE
Remove Google tracking redirect from the Encifher Swaps page

### DIFF
--- a/site/Using_Zcash/Encifher_Swaps.md
+++ b/site/Using_Zcash/Encifher_Swaps.md
@@ -51,7 +51,7 @@ Navigate to the **Wrap** section. Choose **SOL** or **USDC**, enter the amount, 
 ---
 
 ###  Step 3: Prepare Your Zodl Wallet  
-Download [**Zodl**](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://play.google.com/store/apps/details%3Fid%3Dco.electriccoin.zcash%26hl%3Den%26referrer%3Dutm_source%253Dgoogle%2526utm_medium%253Dorganic%2526utm_term%253Ddownload%2Bzashi%26pcampaignid%3DAPPU_1_BU7zaJ3oL8CEhbIP373a0Qs&ved=2ahUKEwjd_p7KqK2QAxVAQkEAHd-eNroQ5YQBegQIDRAC&usg=AOvVaw2x5eoefTu-3dkuC3ujc4cn), the official Zcash wallet by Electric Coin Co. Copy your **Unified Address** from the Receive tab - it supports both transparent and shielded ZEC. Save your seed phrase securely before proceeding.  
+Download [**Zodl**](https://zodl.com), the official Zcash wallet by Electric Coin Co. Copy your **Unified Address** from the Receive tab - it supports both transparent and shielded ZEC. Save your seed phrase securely before proceeding.  
 
 
 ![img7](/content-images/SykjhpgRll-60d19f6979.webp)

--- a/site/Using_Zcash/Encifher_Swaps.md
+++ b/site/Using_Zcash/Encifher_Swaps.md
@@ -51,7 +51,7 @@ Navigate to the **Wrap** section. Choose **SOL** or **USDC**, enter the amount, 
 ---
 
 ###  Step 3: Prepare Your Zodl Wallet  
-Download [**Zodl**](https://zodl.com), the official Zcash wallet by Electric Coin Co. Copy your **Unified Address** from the Receive tab - it supports both transparent and shielded ZEC. Save your seed phrase securely before proceeding.  
+Download [**Zodl**](https://zodl.com), the Zcash wallet maintained by ZODL. Copy your **Unified Address** from the Receive tab - it supports both transparent and shielded ZEC. Save your seed phrase securely before proceeding.  
 
 
 ![img7](/content-images/SykjhpgRll-60d19f6979.webp)


### PR DESCRIPTION
## Summary

The Zodl download link on `site/Using_Zcash/Encifher_Swaps.md` line 54 routed through `google.com/url`, sending anyone who clicked it to Google before the wallet.

## The link

The wrapped destination decoded to a Play Store URL for `co.electriccoin.zcash` carrying `utm_source`, `utm_medium`, `utm_term`, `pcampaignid`, plus Google's own `ved` and `usg` click-tracking parameters.

Replaced with `https://zodl.com` — already used in 10 places across the English wiki, platform-neutral rather than Android-only, and free of tracking parameters.

## Also included

The same sentence described Zodl as "the official Zcash wallet by Electric Coin Co." The wiki's own `site/Zcash_Organizations/ZODL.md` records that the Zashi wallet was rebranded to Zodl under ZODL (Zcash Open Development Lab) after the ECC engineering team departed in January 2026. Corrected to match. Separate commit — happy to drop it if you'd rather keep this PR to the link.

## Scope

This was the only `google.com/url` link under `site/`. Two more exist in `newsletter/ZecWeekly89.md`, wrapping 2024 news articles — I've left those alone as archived newsletter content rather than live wiki pages, but say the word if you'd like them cleaned up too.

18 locales carry the same redirect in translated copies of this page under `translations/`. Those are pipeline-generated, so I've left them for the translation workflow rather than hand-editing.

## Verification

Wrapped URL decoded to confirm the destination and parameters. Repository searched with grep to establish scope. Replacement link loaded in a browser.