### PR TITLE
Fix the MetaMask Snap page's dead RPC URL and the section around it

### DIFF
--- a/site/Using_Zcash/Metamask_Snap.md
+++ b/site/Using_Zcash/Metamask_Snap.md
@@ -46,11 +46,10 @@ MetaMask now supports **shielded Zcash (ZEC)** via the **ChainSafe-developed Zca
 
 ---
 
-## **2. (Optional) Add Zcash Network**
+## **2. (Optional) Add BNB Smart Chain**
 
-In MetaMask, choose **Add Network** and enter:
+MetaMask's **Add Network** dialog only accepts EVM chains, so it cannot be used to add Zcash. Zcash support comes from the Snap you installed in step 1. If you want BNB Smart Chain available for swapping into ZEC, add it here:
 
-For **BNB SmartChain**;
 ```markdown
 -  Name: BNB Smart Chain
 -  RPC URL: https://bsc-dataseed.binance.org
@@ -61,18 +60,18 @@ For **BNB SmartChain**;
 This enables network info and explorer links.
 ![Add-a-custom-Net....](/content-images/S1hq7f2Oel-e1ca8b9044.webp)
 
-For **Zcash Mainnet**;
-```markdown
-- Name: Zcash Mainnet  
-- RPC URL: https://mainnet.lightwalletd.com:9067 
-- Symbol: ZEC
-```
+> **There is no Zcash network to add here.** An earlier version of this page listed a "Zcash Mainnet" entry with an RPC URL of `mainnet.lightwalletd.com:9067`. That host no longer resolves, and the entry could not have worked regardless: a lightwalletd server speaks gRPC, not the EVM JSON-RPC that MetaMask's Add Network expects.
+>
+> The Snap reaches Zcash through a lightwalletd gRPC-web proxy hosted by ChainSafe at `zcash-mainnet.chainsafe.dev`, which forwards to the [zec.rocks](https://zec.rocks) lightwalletd service, run by @emersonian and funded by Zcash Community Grants. You do not configure this yourself. Per the [WebZjs documentation](https://github.com/ChainSafe/WebZjs), an unproxied endpoint such as `https://zec.rocks` will not work from a browser, so substituting one by hand will not help.
 
 ---
 
 ## **3. Connect to ChainSafe WebZjs Wallet**
 
 1. Visit [webzjs.chainsafe.dev](https://webzjs.chainsafe.dev).  
+
+> **Note:** this host was returning HTTP 503 when this page was last checked. The Snap itself is still maintained, so if the hosted wallet is unavailable you can run the WebZjs web wallet locally from the [ChainSafe/WebZjs](https://github.com/ChainSafe/WebZjs) repository.
+
 2. Click **Connect MetaMask Snap**.  
 
 ![Zcash-web-wallet](/content-images/Sk8nSz3dgl-98ce36cc67.webp)
@@ -157,7 +156,7 @@ For **Zcash Mainnet**;
 > Shielded proofs may take time, WebAssembly handles computation in-browser.  
 > Recovery is simple,install MetaMask and the Snap, then import your existing seed.  
 > The Snap defaults to **shielded ZEC**, transparent addresses are **not the focus**.  
-> Use [zcashblockexplorer.com](https://zcashblockexplorer.com) for transaction confirmations.
+> Use [mainnet.zcashexplorer.app](https://mainnet.zcashexplorer.app) for transaction confirmations.
 
 
 

--- a/site/Using_Zcash/Metamask_Snap.md
+++ b/site/Using_Zcash/Metamask_Snap.md
@@ -14,7 +14,7 @@ For a full walkthrough and visual explanation, watch this [**YouTube guide**](ht
 </div>
      
 
-MetaMask now supports **shielded Zcash (ZEC)** via the **ChainSafe-developed Zcash Snap**, allowing you to send, receive, and manage private ZEC directly in your browser wallet. Audited by **Hacken** and listed in the **official MetaMask Snaps Directory**, it requires **no separate Zcash software** - only MetaMask and the Snap.
+MetaMask now supports **shielded Zcash (ZEC)** via the **ChainSafe-developed Zcash Snap**, allowing you to send, receive, and manage private ZEC directly in your browser wallet. Audited by **Hacken** and listed in the **official MetaMask Snaps Directory**, it requires **no separate Zcash software** - only MetaMask and the Snap. ChainSafe describes the design and its funding, from Zcash Community Grants and the MetaMask Grants DAO, in [Zcash in the browser: bringing shielded ZEC to MetaMask](https://blog.chainsafe.io/zcash-in-the-browser-bringing-shielded-zec-to-metamask/).
 
 ---
 


### PR DESCRIPTION
`site/Using_Zcash/Metamask_Snap.md`

The page gave readers a setup block to copy with the RPC URL
`https://mainnet.lightwalletd.com:9067`. That host returns NXDOMAIN — confirmed today,
five lookups against 8.8.8.8.

Swapping in a live lightwalletd server would not have fixed it, because the instruction
itself was wrong in two further ways:

1. **MetaMask's Add Network only accepts EVM chains.** You cannot add Zcash there at all.
   Zcash support comes from the Snap installed in step 1, which is why the section was
   marked optional.
2. **A lightwalletd server speaks gRPC, not EVM JSON-RPC.** Even a live endpoint pasted
   into that dialog would fail.

There is a further trap worth recording. The WebZjs README states that a browser needs a
gRPC-web *proxy* and that "using an unproxied URL (e.g. https://zec.rocks) will NOT work."
So the obvious substitution — swapping the dead host for the well-known `zec.rocks` — would
have shipped a second value that does not work.

What actually serves this stack, traced through the WebZjs source:

- `packages/web-wallet/src/config/constants.ts` sets the default proxy to
  `https://zcash-mainnet.chainsafe.dev` (resolves, live today)
- `traefik/dynamic.yml` shows that proxy forwarding to `https://zec.rocks:443`
- zec.rocks is operated by @emersonian and funded by Zcash Community Grants, per zec.rocks

The section now explains that there is no Zcash network to add, records what the old entry
was and why it could not work, and names the proxy and the operator behind it — without
asking the reader to configure anything, since they do not.

Two other things fixed on the same page while confirming the above:

- Step 3 sends readers to `webzjs.chainsafe.dev`, which returned HTTP 503 on three
  consecutive checks. A note records this and points at running the web wallet locally. The
  Snap itself is still maintained — npm `@chainsafe/webzjs-zcash-snap` is at 0.3.0 and the
  repository was last pushed in April 2026 — so the page is not marked historical.
- The closing "Additional Notes" linked `zcashblockexplorer.com` for transaction
  confirmations. That domain resolves but fails TLS on every attempt. Repointed at
  `mainnet.zcashexplorer.app`, which the page already uses in step 7 and which returns 200.

Every endpoint named in this PR was verified on the day of submission.
