### PR TITLE
Repoint dead links on four pages (ECC zcashd page, ECC disclosure post, Cypherpunk Zero vote portal, zcashambassadors.com)

### DIFF
--- a/site/Start_Here/Zcash_Resources.md
+++ b/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,25 @@ There are a number of resources that help users understand Zcash.
 
 Zcash Media is an independent organization that makes educational documentaries about Zcash. Their first video, "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", is a great introduction to Zcash.
 
-**[Twitter](twitter.com)**
+**[X (formerly Twitter)](https://x.com)**
 
 Twitter is the de facto communication hub for the Zcash community, and the broader cryptocurrency space as well. It's a great place to get a pulse check on all things Zcash, and also follow prominent community members. Here's a [document](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) that lists the top accounts to follow.
 
-**[Zcash Community](zcashcommunity.com)**
+**[Zcash Community](https://www.zcashcommunity.com/)**
 
 Zcash Community is a community run site that highlights community run projects supporting the Zcash ecosystem. It's a great way to get introduced to the Zcash community and its various applications as a currency.
 
-**[The Zcash Forum](forum.zcashcommunity.com)**
+**[The Zcash Forum](https://forum.zcashcommunity.com/)**
 
 As mentioned in the new user guide, the Zcash forum is a great place to have long form discussions about Zcash topics and also proposed ideas. Proposals always make it to the forum so the community has a chance to discuss and debate the proposed ideas.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash is Zcash's main website. It provides content and documentation of Zcash for a wide range of users and allows new users to dive deeper into the technical explanations around Zcash.
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-Got coding chops and want to dive deeper into the technical side of Zcash? The Zcash Github Repo is the repository for [zcashd](https://electriccoin.co/zcashd/), the first Zcash node implementation.
+Got coding chops and want to dive deeper into the technical side of Zcash? The Zcash Github Repo is the repository for zcashd, the first Zcash node implementation. zcashd reached its automatic end-of-support halt on 18 July 2026 and is no longer maintained, and the download page this entry used to link to is no longer served. The maintained stack is [Zebra](https://github.com/ZcashFoundation/zebra) for the node and [Zallet](https://github.com/zcash/zallet) for the wallet — see the [zcashd to Zebra and Zallet migration guide](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet).
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 
@@ -40,6 +40,6 @@ The concepts behind zero-knowledge proof systems.
 
 **[Zcash RPC Docs](https://zcash.github.io/rpc/)**
 
-List of all current commands for zcashd.
+List of the RPC commands zcashd exposed. For the maintained wallet RPC surface, see the [Zallet Book](https://zcash.github.io/zallet/).
 
 _This is an unfinished document_

--- a/site/Zcash_Community/Community_Links.md
+++ b/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash has an active global presence on X. Key accounts to follow:
 - [Zcash Community Website](https://www.zcashcommunity.com/)
 - [ZecHub Wiki](https://zechub.wiki)
 - [Zcash Grants Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash Global Ambassadors](https://zcashambassadors.com)
+- [Zcash Global Ambassadors](https://zechub.wiki/zcash-community/zcash-global-ambassadors) - program overview on this wiki (zcashambassadors.com is offline)
 - [ZecHub DAO on Dework](https://app.dework.xyz/zechub-2424)

--- a/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ We have seen too many projects over-promise and under deliver on their NFT roadm
 
 ## Governance
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth) — the DAO's custom portal at vote.cypherpunkzero.com was retired and its domain no longer resolves; this is the surviving Snapshot space.
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ The Electric Coin Company and Zcash Foundation both conform to this Responsible 
 
 - [Zcash Security Advisories](https://github.com/zcash/zcash/security/advisories)
 - [Zebra Security Advisories](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Report a Vulnerability to ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Report a Vulnerability in zcash/zcash](https://github.com/zcash/zcash/security/policy) — replaces the Electric Coin Company address this entry pointed at, which is no longer reachable.
 - [Report a Vulnerability to ZF](https://zfnd.org/contact/)

--- a/translation/sync-state.json
+++ b/translation/sync-state.json
@@ -309,7 +309,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "gt",
       "mode": "seed",
-      "tool": "gt-static",
+      "tool": "gt-static+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -613,7 +613,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "gt",
       "mode": "seed",
-      "tool": "gt-static",
+      "tool": "gt-static+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -629,7 +629,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "gt",
       "mode": "seed",
-      "tool": "gt-static",
+      "tool": "gt-static+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -661,7 +661,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "gt",
       "mode": "seed",
-      "tool": "gt-static",
+      "tool": "gt-static+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -1983,7 +1983,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -2287,7 +2287,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -2303,7 +2303,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -2335,7 +2335,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -3657,7 +3657,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -3961,7 +3961,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -3977,7 +3977,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -4009,7 +4009,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -5331,7 +5331,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "gt",
       "mode": "seed",
-      "tool": "gt-static",
+      "tool": "gt-static+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -5635,7 +5635,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "gt",
       "mode": "seed",
-      "tool": "gt-static",
+      "tool": "gt-static+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -5651,7 +5651,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "gt",
       "mode": "seed",
-      "tool": "gt-static",
+      "tool": "gt-static+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -5683,7 +5683,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "gt",
       "mode": "seed",
-      "tool": "gt-static",
+      "tool": "gt-static+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -7005,7 +7005,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -7309,7 +7309,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -7325,7 +7325,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -7357,7 +7357,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -8679,7 +8679,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -8983,7 +8983,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -8999,7 +8999,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -9031,7 +9031,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -10353,7 +10353,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -10657,7 +10657,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -10673,7 +10673,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -10705,7 +10705,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -12027,7 +12027,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -12331,7 +12331,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -12347,7 +12347,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -12379,7 +12379,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B+linkrepair",
+      "tool": "nllb-200-3.3B+linkrepair+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -13701,7 +13701,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -14005,7 +14005,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -14021,7 +14021,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -14053,7 +14053,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -15375,7 +15375,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "qwen3-14b",
+      "tool": "qwen3-14b+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -15679,7 +15679,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "qwen3-14b",
+      "tool": "qwen3-14b+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -15695,7 +15695,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "qwen3-14b",
+      "tool": "qwen3-14b+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -15727,7 +15727,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "qwen3-14b",
+      "tool": "qwen3-14b+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -17049,7 +17049,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "qwen3-14b",
+      "tool": "qwen3-14b+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -17353,7 +17353,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "qwen3-14b",
+      "tool": "qwen3-14b+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -17369,7 +17369,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "qwen3-14b",
+      "tool": "qwen3-14b+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -17401,7 +17401,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "qwen3-14b",
+      "tool": "qwen3-14b+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -18723,7 +18723,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -19027,7 +19027,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -19043,7 +19043,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -19075,7 +19075,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -20397,7 +20397,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -20701,7 +20701,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -20717,7 +20717,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -20749,7 +20749,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -22071,7 +22071,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -22375,7 +22375,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -22391,7 +22391,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -22423,7 +22423,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -23745,7 +23745,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -24049,7 +24049,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -24065,7 +24065,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -24097,7 +24097,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -25419,7 +25419,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -25723,7 +25723,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -25739,7 +25739,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -25771,7 +25771,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -27093,7 +27093,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -27397,7 +27397,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B+linkrepair",
+      "tool": "nllb-200-3.3B+linkrepair+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -27413,7 +27413,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B+linkrepair",
+      "tool": "nllb-200-3.3B+linkrepair+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -27445,7 +27445,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "nllb",
       "mode": "seed",
-      "tool": "nllb-200-3.3B+linkrepair",
+      "tool": "nllb-200-3.3B+linkrepair+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {
@@ -28767,7 +28767,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Using_Zcash/Blockchain_Explorers.md": {
@@ -29071,7 +29071,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Community_Projects.md": {
@@ -29087,7 +29087,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/ZCAP.md": {
@@ -29119,7 +29119,7 @@
       "src_commit": "7811f6891f5fc8fb8c95bb618af29ca60e709274",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+deadlink-4pages",
       "edited": false
     },
     "Zcash_Community/Zcash_Engineering_Office_Hours.md": {

--- a/translations/ak/site/Start_Here/Zcash_Resources.md
+++ b/translations/ak/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Nneɛma bi wɔ hɔ a ɛboa wɔn a wɔde di dwuma no ma wɔte Zcash ase.
 
 Zcash Media yɛ ahyehyɛdeɛ a ɛde ne ho a ɛyɛ nkyerɛkyerɛ ho nsɛm a ɛfa Zcash ho. Wɔn video a edi kan, "Wɔasi sɛ wɔde besiesie Bitcoin's Fatal Flaw, Dɛn ne Zcash (ZEC)?", yɛ nnianim asɛm kɛse ma Zcash.
 
-**[Twitter so na ɔkyerɛwee](twitter.com)**
+**[Twitter so na ɔkyerɛwee](https://x.com)**
 
 Twitter yɛ de facto nkitahodi beae ma Zcash mpɔtam hɔfo, ne cryptocurrency ahunmu a ɛtrɛw nso. Ɛyɛ beae pa a wobɛnya pulse check wɔ nneɛma nyinaa Zcash, na nso di mpɔtam hɔfoɔ a wɔagye din akyi. [Nwoma bi a wɔakyerɛw](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) a ɛkyerɛ akontaabu ahorow a ɛwɔ soro a ɛsɛ sɛ wodi akyi.
 
-**[Zcash Mpɔtam hɔ](zcashcommunity.com)**
+**[Zcash Mpɔtam hɔ](https://www.zcashcommunity.com/)**
 
 Zcash Community yɛ beaeɛ a mpɔtam hɔfoɔ di so a ɛtwe adwene si nnwuma a mpɔtam hɔfoɔ di so a ɛboa Zcash abɔdeɛ a nkwa wom nhyehyɛeɛ no so. Ɛyɛ ɔkwan pa a wobɛfa so anya Zcash mpɔtam hɔfoɔ ne ne dwumadie ahodoɔ sɛ sika.
 
-**[Zcash Nhyiam no](forum.zcashcommunity.com)**
+**[Zcash Nhyiam no](https://forum.zcashcommunity.com/)**
 
 Sɛnea yɛaka wɔ ɔdefoɔ akwankyerɛ foforɔ no mu no, Zcash forum yɛ beaeɛ pa a wobɛnya nkɔmmɔdie tenten a ɛfa Zcash nsɛmti ne adwene a wɔahyɛ nso ho. Nsusuwii ahorow no kɔ nhyiam no so bere nyinaa enti mpɔtam hɔfo nya hokwan susuw nsusuwii ahorow a wɔahyɛ ho nyansa no ho na wogye ho akyinnye.
 
-**[Z.sika a wɔde yɛ adwuma](z.cash)**
+**[Z.sika a wɔde yɛ adwuma](https://z.cash/)**
 
 Z.cash is Zcash's main website. Ɛde Zcash mu nsɛm ne nkrataa ma wɔn a wɔde di dwuma ahorow pii na ɛma wɔn a wɔde di dwuma foforo no kwan ma wɔde wɔn ho hyɛ mfiridwuma mu nkyerɛkyerɛmu a atwa Zcash ho ahyia no mu kɔ akyiri.
 
 **[Zcash Github na ɛyɛ adwuma](https://github.com/zcash/zcash)**
 
-Got coding chops na wopɛ sɛ wode wo ho hyɛ mu kɔ akyiri wɔ technical fã a Zcash? Zcash Github Repo no yɛ adekorabea ma [zcashd](https://electriccoin.co/zcashd/), Zcash node a edi kan a wɔde di dwuma.
+Got coding chops na wopɛ sɛ wode wo ho hyɛ mu kɔ akyiri wɔ technical fã a Zcash? Zcash Github Repo no yɛ adekorabea ma [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), Zcash node a edi kan a wɔde di dwuma.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/ak/site/Zcash_Community/Community_Links.md
+++ b/translations/ak/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash wɔ wiase nyinaa a ɛyɛ nnam wɔ X. Akontaabu atitiriw a ɛsɛ sɛ wudi a
 - [Zcash Mpɔtam Hɔ Wɛbsaet](https://www.zcashcommunity.com/)
 - [ZecHub Wiki a ɛwɔ hɔ](https://zechub.wiki)
 - [Zcash Mmoa a Wɔde Ma Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash Wiase Nyinaa Aban Nnanmusini](https://zcashambassadors.com)
+- [Zcash Wiase Nyinaa Aban Nnanmusini](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO wɔ Dework so](https://app.dework.xyz/zechub-2424)

--- a/translations/ak/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/ak/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Yɛahu sɛ nnwuma pii ahyɛ bɔ dodo na wɔmfa wɔn NFT akwan ho nhyehyɛe no mm
 
 ## Aban a wɔde di dwuma
 
-[Mfonini a wɔatwa no tiaa](https://vote.cypherpunkzero.com/)
+[Mfonini a wɔatwa no tiaa](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild a wɔde wɔn ho hyɛ mu](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/ak/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/ak/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company ne Zcash Foundation nyinaa ne saa Asɛdeɛ a Wɔda no Adi 
 
 - [Zcash Ahobammɔ Ho Afotu](https://github.com/zcash/zcash/security/advisories)
 - [Zebra Ahobammɔ Ho Afotu](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Bɔ amanneɛ sɛ ɛyɛ mmerɛw sɛ ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Bɔ amanneɛ sɛ ɛyɛ mmerɛw sɛ ECC](https://github.com/zcash/zcash/security/policy)
 - [Bɔ amanneɛ sɛ Vulnerability bi wɔ ZF so](https://zfnd.org/contact/)

--- a/translations/ar/site/Start_Here/Zcash_Resources.md
+++ b/translations/ar/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@
 
 إعلام Zcash هي منظمة مستقلة تُنتج أفلامًا وثائقية تعليمية عن Zcash. ويُعد أول فيديو لهم، "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?"، مقدمة رائعة إلى Zcash.
 
-**[تويتر](twitter.com)**
+**[تويتر](https://x.com)**
 
 يُعد تويتر مركز التواصل الفعلي لمجتمع Zcash، وكذلك لمجال العملات المشفرة الأوسع. وهو مكان ممتاز لأخذ فكرة سريعة عن كل ما يتعلق بـ Zcash، وكذلك لمتابعة أبرز أعضاء المجتمع. إليك [وثيقة](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) تسرد أهم الحسابات التي يُنصح بمتابعتها.
 
-**[مجتمع Zcash](zcashcommunity.com)**
+**[مجتمع Zcash](https://www.zcashcommunity.com/)**
 
 مجتمع Zcash هو موقع يديره المجتمع ويسلط الضوء على المشاريع التي يديرها المجتمع لدعم منظومة Zcash. وهو وسيلة رائعة للتعرّف إلى مجتمع Zcash وتطبيقاته المختلفة كعملة.
 
-**[منتدى Zcash](forum.zcashcommunity.com)**
+**[منتدى Zcash](https://forum.zcashcommunity.com/)**
 
 كما ذُكر في دليل المستخدم الجديد، يُعد منتدى Zcash مكانًا رائعًا لإجراء مناقشات مطولة حول موضوعات Zcash وكذلك الأفكار المقترحة. وتصل المقترحات دائمًا إلى المنتدى حتى تتاح للمجتمع فرصة مناقشتها وتبادل الآراء بشأنها.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 يُعد Z.cash الموقع الرئيسي لـ Zcash. فهو يوفّر محتوى ووثائق عن Zcash لشريحة واسعة من المستخدمين، ويتيح للمستخدمين الجدد التعمق أكثر في الشروحات التقنية المتعلقة بـ Zcash.
 
 **[GitHub الخاص بـ Zcash](https://github.com/zcash/zcash)**
 
-هل لديك مهارات برمجية وترغب في التعمق أكثر في الجانب التقني من Zcash؟ مستودع GitHub الخاص بـ Zcash هو المستودع الخاص بـ [zcashd](https://electriccoin.co/zcashd/)، وهو أول تطبيق لعقدة Zcash.
+هل لديك مهارات برمجية وترغب في التعمق أكثر في الجانب التقني من Zcash؟ مستودع GitHub الخاص بـ Zcash هو المستودع الخاص بـ [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet)، وهو أول تطبيق لعقدة Zcash.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[GitHub الخاص بـ Zcash Foundation](https://github.com/ZcashFoundation)**
 

--- a/translations/ar/site/Zcash_Community/Community_Links.md
+++ b/translations/ar/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@
 - [موقع مجتمع Zcash](https://www.zcashcommunity.com/)
 - [ويكي ZecHub](https://zechub.wiki)
 - [مركز منح Zcash](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [سفراء Zcash العالميون](https://zcashambassadors.com)
+- [سفراء Zcash العالميون](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO على Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/ar/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/ar/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Cypherpunk Zero هي سلسلة قصصية تتمحور حول Zero، وهي ه�
 
 ## الحوكمة
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/ar/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/ar/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@
 
 - [تنبيهات Zcash الأمنية](https://github.com/zcash/zcash/security/advisories)
 - [تنبيهات Zebra الأمنية](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [الإبلاغ عن ثغرة إلى ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [الإبلاغ عن ثغرة إلى ECC](https://github.com/zcash/zcash/security/policy)
 - [الإبلاغ عن ثغرة إلى ZF](https://zfnd.org/contact/)

--- a/translations/de/site/Start_Here/Zcash_Resources.md
+++ b/translations/de/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Es gibt eine Reihe von Ressourcen, die Nutzerinnen und Nutzern helfen, Zcash zu 
 
 Zcash Media ist eine unabhängige Organisation, die lehrreiche Dokumentationen über Zcash erstellt. Ihr erstes Video, "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", ist eine großartige Einführung in Zcash.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter ist der de-facto-Kommunikationsknotenpunkt für die Zcash-Community und den breiteren Kryptowährungsbereich insgesamt. Es ist ein großartiger Ort, um ein Stimmungsbild zu allem rund um Zcash zu bekommen und außerdem prominenten Community-Mitgliedern zu folgen. Hier ist ein [Dokument](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05), das die wichtigsten Accounts auflistet, denen man folgen sollte.
 
-**[Zcash Community](zcashcommunity.com)**
+**[Zcash Community](https://www.zcashcommunity.com/)**
 
 Zcash Community ist eine von der Community betriebene Website, die von der Community geführte Projekte hervorhebt, welche das Zcash-Ökosystem unterstützen. Sie ist eine großartige Möglichkeit, die Zcash-Community und ihre verschiedenen Anwendungen als Währung kennenzulernen.
 
-**[Das Zcash-Forum](forum.zcashcommunity.com)**
+**[Das Zcash-Forum](https://forum.zcashcommunity.com/)**
 
 Wie im Leitfaden für neue Nutzer bereits erwähnt, ist das Zcash-Forum ein großartiger Ort, um ausführliche Diskussionen über Zcash-Themen sowie über vorgeschlagene Ideen zu führen. Vorschläge landen immer im Forum, damit die Community die Möglichkeit hat, die vorgeschlagenen Ideen zu diskutieren und zu debattieren.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash ist die Hauptwebsite von Zcash. Sie bietet Inhalte und Dokumentation zu Zcash für eine breite Nutzerbasis und ermöglicht neuen Nutzerinnen und Nutzern, tiefer in die technischen Erklärungen rund um Zcash einzutauchen.
 
 **[Zcash-Github](https://github.com/zcash/zcash)**
 
-Du kannst programmieren und möchtest tiefer in die technische Seite von Zcash eintauchen? Das Zcash-Github-Repo ist das Repository für [zcashd](https://electriccoin.co/zcashd/), die erste Zcash-Node-Implementierung.
+Du kannst programmieren und möchtest tiefer in die technische Seite von Zcash eintauchen? Das Zcash-Github-Repo ist das Repository für [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), die erste Zcash-Node-Implementierung.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/de/site/Zcash_Community/Community_Links.md
+++ b/translations/de/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash ist auf X weltweit aktiv präsent. Wichtige Accounts, denen du folgen soll
 - [Zcash-Community-Website](https://www.zcashcommunity.com/)
 - [ZecHub-Wiki](https://zechub.wiki)
 - [Zcash Grants Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash Global Ambassadors](https://zcashambassadors.com)
+- [Zcash Global Ambassadors](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO auf Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/de/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/de/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Wir haben zu viele Projekte gesehen, die auf ihren NFT-Roadmaps zu viel versprec
 
 ## Governance
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/de/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/de/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Die Electric Coin Company und Zcash Foundation entsprechen beide diesem Standard
 
 - [Sicherheitshinweise für Zcash](https://github.com/zcash/zcash/security/advisories)
 - [Sicherheitshinweise für Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Eine Schwachstelle an ECC melden](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Eine Schwachstelle an ECC melden](https://github.com/zcash/zcash/security/policy)
 - [Eine Schwachstelle an ZF melden](https://zfnd.org/contact/)

--- a/translations/ee/site/Start_Here/Zcash_Resources.md
+++ b/translations/ee/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Dɔwɔnu geɖewo li siwo kpena ɖe ezãlawo ŋu be woase Zcash gɔme.
 
 Zcash Media nye habɔbɔ si le eɖokui si si wɔa nufiame nuŋlɔɖiwo tso Zcash ŋu. Woƒe video gbãtɔ, "Wotu be woaɖɔ Bitcoin ƒe vodada si wua ame ɖo, Nukae nye Zcash (ZEC)?", nye ŋgɔdonya gã aɖe na Zcash.
 
-**[Twitter ƒe nyatakakadzraɖoƒea](twitter.com)**
+**[Twitter ƒe nyatakakadzraɖoƒea](https://x.com)**
 
 Twitter nye de facto kadodoƒe na Zcash nutoa, kple cryptocurrency teƒe si keke ta wu hã. Enye teƒe nyui aɖe si woawɔ pulse check le nusianu Zcash ŋu, eye nàdze nutoa me tɔ xɔŋkɔwo hã yome. [Nuŋlɔɖi” aɖee nye esi](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) si yɔa akɔntabubu siwo le ŋgɔ wu siwo dzi woazɔ ɖo.
 
-**[Zcash Habɔbɔ](zcashcommunity.com)**
+**[Zcash Habɔbɔ](https://www.zcashcommunity.com/)**
 
 Zcash Community nye nutoa me tɔwo ƒe nyatakakadzraɖoƒe si tea gbe ɖe nutoa me tɔwo ƒe dɔ siwo doa alɔ Zcash ƒe lãwo ƒe agbenɔnɔ ƒe ɖoɖoa dzi. Enye mɔnu nyui aɖe si dzi nàto anya Zcash habɔbɔa kple eƒe dɔwɔwɔ vovovoawo abe ga ene.
 
-**[Zcash ƒe Nyamedzroƒea](forum.zcashcommunity.com)**
+**[Zcash ƒe Nyamedzroƒea](https://forum.zcashcommunity.com/)**
 
 Abe alesi míegblɔe le zãla ƒe mɔfiame yeyea me ene la, Zcash ƒe nyamedzroƒea nye teƒe nyui aɖe si woawɔ numedzodzro didiwo tso Zcash ƒe nyatiwo kple susu siwo wodo ɖa hã ŋu. Dodokpɔwo ɖoa nyamedzroƒea ɣesiaɣi ale be mɔnukpɔkpɔ sua nutoa me tɔwo si be woadzro susu siwo wodo ɖa la me ahahe nya le wo ŋu.
 
-**[Z.ga si woatsɔ awɔ dɔe](z.cash)**
+**[Z.ga si woatsɔ awɔ dɔe](https://z.cash/)**
 
 Z.cash nye Zcash ƒe nyatakakadzraɖoƒe vevitɔ. Enaa Zcash ƒe nyatakakawo kple nuŋlɔɖiwo zãla vovovowo eye wònaa zãla yeyewo be woage ɖe mɔ̃ɖaŋununya me numeɖeɖe siwo ƒo xlã Zcash me goglo wu.
 
 **[Zcash Github ƒe agbalẽ](https://github.com/zcash/zcash)**
 
-Got coding chops eye nèdi be yeaƒu tsi ayi goglo wu le mɔ̃ɖaŋununya ƒe akpa si le Zcash mea? Zcash Github Repo nye nudzraɖoƒe na [zcashd](https://electriccoin.co/zcashd/), Zcash node ƒe dɔwɔwɔ gbãtɔ.
+Got coding chops eye nèdi be yeaƒu tsi ayi goglo wu le mɔ̃ɖaŋununya ƒe akpa si le Zcash mea? Zcash Github Repo nye nudzraɖoƒe na [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), Zcash node ƒe dɔwɔwɔ gbãtɔ.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/ee/site/Zcash_Community/Community_Links.md
+++ b/translations/ee/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash le xexeame katã ƒe anyinɔnɔ vevie le X. Akɔntabubu vevi siwo akplɔe 
 - [Zcash Habɔbɔ ƒe Nyatakakadzraɖoƒe](https://www.zcashcommunity.com/)
 - [ZecHub ƒe Wiki](https://zechub.wiki)
 - [Zcash ƒe Gakpekpeɖeŋunana Dɔwɔƒe](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash Xexeame Katã ƒe Dutanyanyuigblɔlawo](https://zcashambassadors.com)
+- [Zcash Xexeame Katã ƒe Dutanyanyuigblɔlawo](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO le Dework dzi](https://app.dework.xyz/zechub-2424)

--- a/translations/ee/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/ee/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Míekpɔ dɔ geɖe akpa siwo do ŋugbe wògbɔ eme eye womewɔa woƒe NFT mɔfia
 
 ## Dziɖuɖu
 
-[Foto si woɖe le ɣeyiɣi kpui aɖe me](https://vote.cypherpunkzero.com/)
+[Foto si woɖe le ɣeyiɣi kpui aɖe me](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild ƒe habɔbɔ](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/ee/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/ee/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company kple Zcash Foundation siaa wɔ ɖeka kple Agbanɔamedzi Ŋ
 
 - [Zcash Dedienɔnɔ Ŋuti Aɖaŋuɖolawo](https://github.com/zcash/zcash/security/advisories)
 - [Zebra Dedienɔnɔ Ŋuti Aɖaŋuɖolawo](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Ka nya ta tso Afɔku aɖe ŋu na ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Ka nya ta tso Afɔku aɖe ŋu na ECC](https://github.com/zcash/zcash/security/policy)
 - [Ka nya ta tso Afɔku aɖe si le ZF ŋu](https://zfnd.org/contact/)

--- a/translations/es/site/Start_Here/Zcash_Resources.md
+++ b/translations/es/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Hay una serie de recursos que ayudan a los usuarios a comprender Zcash.
 
 Zcash Media es una organización independiente que realiza documentales educativos sobre Zcash. Su primer video, "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", es una excelente introducción a Zcash.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter es el centro de comunicación de facto para la comunidad de Zcash, así como para el espacio más amplio de las criptomonedas. Es un gran lugar para tomar el pulso a todo lo relacionado con Zcash y también seguir a miembros destacados de la comunidad. Aquí tienes un [documento](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) que enumera las principales cuentas que debes seguir.
 
-**[Comunidad de Zcash](zcashcommunity.com)**
+**[Comunidad de Zcash](https://www.zcashcommunity.com/)**
 
 Zcash Community es un sitio gestionado por la comunidad que destaca proyectos impulsados por la comunidad que apoyan el ecosistema de Zcash. Es una gran manera de conocer la comunidad de Zcash y sus diversas aplicaciones como moneda.
 
-**[El foro de Zcash](forum.zcashcommunity.com)**
+**[El foro de Zcash](https://forum.zcashcommunity.com/)**
 
 Como se menciona en la guía para nuevos usuarios, el foro de Zcash es un gran lugar para mantener debates extensos sobre temas de Zcash y también sobre ideas propuestas. Las propuestas siempre llegan al foro para que la comunidad tenga la oportunidad de discutir y debatir las ideas propuestas.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash es el sitio web principal de Zcash. Proporciona contenido y documentación sobre Zcash para una amplia variedad de usuarios y permite a los nuevos usuarios profundizar en las explicaciones técnicas relacionadas con Zcash.
 
 **[GitHub de Zcash](https://github.com/zcash/zcash)**
 
-¿Tienes habilidades de programación y quieres profundizar en el aspecto técnico de Zcash? El repositorio de GitHub de Zcash es el repositorio de [zcashd](https://electriccoin.co/zcashd/), la primera implementación de nodo de Zcash.
+¿Tienes habilidades de programación y quieres profundizar en el aspecto técnico de Zcash? El repositorio de GitHub de Zcash es el repositorio de [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), la primera implementación de nodo de Zcash.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[GitHub de la Zcash Foundation](https://github.com/ZcashFoundation)**
 

--- a/translations/es/site/Zcash_Community/Community_Links.md
+++ b/translations/es/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash tiene una presencia global activa en X. Cuentas clave para seguir:
 - [Sitio web de la comunidad de Zcash](https://www.zcashcommunity.com/)
 - [Wiki de ZecHub](https://zechub.wiki)
 - [Centro de subvenciones de Zcash](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Embajadores globales de Zcash](https://zcashambassadors.com)
+- [Embajadores globales de Zcash](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO en Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/es/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/es/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Hemos visto demasiados proyectos prometer de más y cumplir de menos con sus hoj
 
 ## Gobernanza
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/es/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/es/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company y Zcash Foundation se ajustan a este [estándar](https://g
 
 - [Avisos de seguridad de Zcash](https://github.com/zcash/zcash/security/advisories)
 - [Avisos de seguridad de Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Reportar una vulnerabilidad a ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Reportar una vulnerabilidad a ECC](https://github.com/zcash/zcash/security/policy)
 - [Reportar una vulnerabilidad a ZF](https://zfnd.org/contact/)

--- a/translations/fr/site/Start_Here/Zcash_Resources.md
+++ b/translations/fr/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Il existe un certain nombre de ressources qui aident les utilisateurs à compren
 
 Zcash Media est une organisation indépendante qui réalise des documentaires éducatifs sur Zcash. Leur première vidéo, « Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)? », constitue une excellente introduction à Zcash.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter est le principal hub de communication de facto pour la communauté Zcash, ainsi que pour l’écosystème plus large des cryptomonnaies. C’est un excellent endroit pour prendre le pouls de tout ce qui concerne Zcash, ainsi que pour suivre les membres éminents de la communauté. Voici un [document](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) qui répertorie les principaux comptes à suivre.
 
-**[Communauté Zcash](zcashcommunity.com)**
+**[Communauté Zcash](https://www.zcashcommunity.com/)**
 
 Zcash Community est un site géré par la communauté qui met en avant des projets communautaires soutenant l’écosystème Zcash. C’est un excellent moyen de découvrir la communauté Zcash et ses différentes applications en tant que monnaie.
 
-**[Le forum Zcash](forum.zcashcommunity.com)**
+**[Le forum Zcash](https://forum.zcashcommunity.com/)**
 
 Comme mentionné dans le guide du nouvel utilisateur, le forum Zcash est un excellent endroit pour avoir des discussions approfondies sur des sujets liés à Zcash ainsi que sur des idées proposées. Les propositions arrivent toujours sur le forum afin que la communauté ait l’occasion de discuter et de débattre des idées proposées.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash est le site principal de Zcash. Il fournit du contenu et de la documentation sur Zcash pour un large éventail d’utilisateurs et permet aux nouveaux utilisateurs d’approfondir les explications techniques autour de Zcash.
 
 **[Github Zcash](https://github.com/zcash/zcash)**
 
-Vous avez des compétences en programmation et souhaitez approfondir le côté technique de Zcash ? Le dépôt Github de Zcash est le dépôt de [zcashd](https://electriccoin.co/zcashd/), la première implémentation de nœud Zcash.
+Vous avez des compétences en programmation et souhaitez approfondir le côté technique de Zcash ? Le dépôt Github de Zcash est le dépôt de [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), la première implémentation de nœud Zcash.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Github de la Zcash Foundation](https://github.com/ZcashFoundation)**
 

--- a/translations/fr/site/Zcash_Community/Community_Links.md
+++ b/translations/fr/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash bénéficie d’une présence mondiale active sur X. Comptes clés à suiv
 - [Site web de la communauté Zcash](https://www.zcashcommunity.com/)
 - [Wiki ZecHub](https://zechub.wiki)
 - [Hub des subventions Zcash](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Ambassadeurs mondiaux Zcash](https://zcashambassadors.com)
+- [Ambassadeurs mondiaux Zcash](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO sur Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/fr/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/fr/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Nous avons vu trop de projets faire trop de promesses et pas assez de livraisons
 
 ## Gouvernance
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/fr/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/fr/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company et Zcash Foundation se conforment toutes deux à cette [no
 
 - [Avis de sécurité Zcash](https://github.com/zcash/zcash/security/advisories)
 - [Avis de sécurité Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Signaler une vulnérabilité à ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Signaler une vulnérabilité à ECC](https://github.com/zcash/zcash/security/policy)
 - [Signaler une vulnérabilité à ZF](https://zfnd.org/contact/)

--- a/translations/hi/site/Start_Here/Zcash_Resources.md
+++ b/translations/hi/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@
 
 Zcash Media एक स्वतंत्र संगठन है जो Zcash पर शैक्षिक डॉक्यूमेंट्री बनाता है। उनका पहला वीडियो, "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", Zcash का एक शानदार परिचय है।
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter, Zcash समुदाय के लिए और व्यापक cryptocurrency क्षेत्र के लिए भी, वास्तविक संचार केंद्र है। यह Zcash से जुड़ी हर चीज़ की नब्ज़ समझने और समुदाय के प्रमुख सदस्यों को फॉलो करने के लिए एक बेहतरीन जगह है। यहाँ एक [दस्तावेज़](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) है जिसमें फॉलो करने योग्य प्रमुख अकाउंट्स की सूची दी गई है।
 
-**[Zcash Community](zcashcommunity.com)**
+**[Zcash Community](https://www.zcashcommunity.com/)**
 
 Zcash Community एक समुदाय-चालित साइट है जो Zcash ecosystem का समर्थन करने वाली समुदाय-चालित परियोजनाओं को उजागर करती है। यह Zcash समुदाय और मुद्रा के रूप में इसके विभिन्न उपयोगों से परिचित होने का एक शानदार तरीका है।
 
-**[The Zcash Forum](forum.zcashcommunity.com)**
+**[The Zcash Forum](https://forum.zcashcommunity.com/)**
 
 जैसा कि नए उपयोगकर्ता मार्गदर्शिका में उल्लेख किया गया है, Zcash फ़ोरम Zcash से जुड़े विषयों और प्रस्तावित विचारों पर विस्तृत चर्चा करने के लिए एक बेहतरीन स्थान है। प्रस्ताव हमेशा फ़ोरम तक पहुँचते हैं ताकि समुदाय को उन पर चर्चा और बहस करने का अवसर मिल सके।
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash, Zcash की मुख्य वेबसाइट है। यह विविध प्रकार के उपयोगकर्ताओं के लिए Zcash की सामग्री और दस्तावेज़ उपलब्ध कराती है और नए उपयोगकर्ताओं को Zcash से संबंधित तकनीकी व्याख्याओं में और गहराई से जाने की अनुमति देती है।
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-क्या आपके पास coding कौशल है और आप Zcash के तकनीकी पक्ष में और गहराई से जाना चाहते हैं? Zcash Github Repo, [zcashd](https://electriccoin.co/zcashd/) का repository है, जो Zcash का पहला node implementation है।
+क्या आपके पास coding कौशल है और आप Zcash के तकनीकी पक्ष में और गहराई से जाना चाहते हैं? Zcash Github Repo, [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet) का repository है, जो Zcash का पहला node implementation है।
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/hi/site/Zcash_Community/Community_Links.md
+++ b/translations/hi/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ X पर Zcash की वैश्विक उपस्थिति सक्�
 - [Zcash Community Website](https://www.zcashcommunity.com/)
 - [ZecHub Wiki](https://zechub.wiki)
 - [Zcash Grants Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash Global Ambassadors](https://zcashambassadors.com)
+- [Zcash Global Ambassadors](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [Dework पर ZecHub DAO](https://app.dework.xyz/zechub-2424)

--- a/translations/hi/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/hi/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Cypherpunk Zero एक कहानी-वाचन श्रृंखला ह
 
 ## Governance
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/hi/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/hi/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company और Zcash Foundation दोनों इस [जिम�
 
 - [Zcash सुरक्षा सलाह](https://github.com/zcash/zcash/security/advisories)
 - [Zebra सुरक्षा सलाह](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [ECC को एक दुर्बलता रिपोर्ट करें](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [ECC को एक दुर्बलता रिपोर्ट करें](https://github.com/zcash/zcash/security/policy)
 - [ZF को एक दुर्बलता रिपोर्ट करें](https://zfnd.org/contact/)

--- a/translations/ig/site/Start_Here/Zcash_Resources.md
+++ b/translations/ig/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ E nwere ọtụtụ ihe ndị na-enyere ndị ọrụ aka ịghọta Zcash.
 
 Zcash Media bụ ụlọ ọrụ nọọrọ onwe ha nke na-eme akwụkwọ akụkọ agụmakwụkwọ gbasara Zcash. Vidio mbụ ha, "E wuru iji dozie ntụpọ dị egwu nke Bitcoin, Gịnị bụ Zcash (ZEC)?", bụ nnukwu mmeghe na Zcash .
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter bụ de facto nkwurịta okwu maka Zcash obodo, na wider cryptocurrency ohere dị ka nke ọma. Ọ bụ ebe dị mma iji nweta a usu ego na ihe niile Zcash, na-eso ama obodo òtù.](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) nke na-edepụta ihe ndekọ kachasị elu ị ga-eso.
 
-**[Zcash Community](zcashcommunity.com)**
+**[Zcash Community](https://www.zcashcommunity.com/)**
 
 Zcash Community is a community run site that highlights community run projects supporting the Zcash ecosystem. It's a great way to get introduced to the Zcash community and its various applications as a currency.
 
-**[Zcash Forum](forum.zcashcommunity.com)**
+**[Zcash Forum](https://forum.zcashcommunity.com/)**
 
 Dịka e kwuru na ntuziaka onye ọrụ ọhụrụ, nzukọ Zcash bụ ebe dị mma iji nwee mkparịta ụka ogologo oge gbasara isiokwu Zcash yana echiche ndị a tụrụ aro.
 
-**[Z. ego nkịtị](z.cash)**
+**[Z. ego nkịtị](https://z.cash/)**
 
 Z.cash bụ ebe nrụọrụ weebụ Zcash. Ọ na-enye ọdịnaya na akwụkwọ nke Zcash maka ọtụtụ ndị ọrụ ma na-ekwe ka ndị ọrụ ọhụrụ banye n'ime omimi nkọwa nkọwa gbasara Zcash .
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-Nweta koodu chops na chọrọ amaba miri n'ime oru n'akụkụ nke Zcash? The Zcash Github Repo bụ repository maka [zcashd](https://electriccoin.co/zcashd/), mmejuputa nke mbụ nke Zcash node.
+Nweta koodu chops na chọrọ amaba miri n'ime oru n'akụkụ nke Zcash? The Zcash Github Repo bụ repository maka [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), mmejuputa nke mbụ nke Zcash node.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/ig/site/Zcash_Community/Community_Links.md
+++ b/translations/ig/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash nwere ọnụnọ zuru ụwa ọnụ na X. Ihe ndekọ isi iji soro:
 - [Zcash Community Web Site](https://www.zcashcommunity.com/)
 - [ZecHub Wiki](https://zechub.wiki)
 - [Zcash Enyemaka Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash Global Ambassadors](https://zcashambassadors.com)
+- [Zcash Global Ambassadors](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO na Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/ig/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/ig/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ We have seen too many projects over-promise and under deliver on their NFT roadm
 
 ## Ọchịchị
 
-[Ihe osise](https://vote.cypherpunkzero.com/)
+[Ihe osise](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Ụlọ ọrụ](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/ig/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/ig/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ The Electric Coin Company and Zcash Foundation both conform to this Responsible 
 
 - [Zcash Nchebe Ndụmọdụ](https://github.com/zcash/zcash/security/advisories)
 - [Atụmatụ Nchebe Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Kọọrọ ECC ihe ngwangwa](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Kọọrọ ECC ihe ngwangwa](https://github.com/zcash/zcash/security/policy)
 - [Kọọrọ ZF banyere nsogbu](https://zfnd.org/contact/)

--- a/translations/it/site/Start_Here/Zcash_Resources.md
+++ b/translations/it/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Ci sono diverse risorse che aiutano gli utenti a comprendere Zcash.
 
 Zcash Media è un'organizzazione indipendente che realizza documentari educativi su Zcash. Il loro primo video, "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", è un'ottima introduzione a Zcash.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter è l'hub di comunicazione de facto per la comunità di Zcash e per l'intero spazio delle criptovalute. È un ottimo posto per prendere il polso su tutto ciò che riguarda Zcash e anche per seguire i membri di spicco della comunità. Ecco un [documento](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) che elenca i principali account da seguire.
 
-**[Zcash Community](zcashcommunity.com)**
+**[Zcash Community](https://www.zcashcommunity.com/)**
 
 Zcash Community è un sito gestito dalla comunità che mette in luce i progetti gestiti dalla stessa comunità a supporto dell'ecosistema Zcash. È un modo eccellente per iniziare a conoscere la comunità di Zcash e le sue varie applicazioni come valuta.
 
-**[The Zcash Forum](forum.zcashcommunity.com)**
+**[The Zcash Forum](https://forum.zcashcommunity.com/)**
 
 Come accennato nella guida per i nuovi utenti, il forum di Zcash è un ottimo luogo per discussioni approfondite su argomenti relativi a Zcash e sulle idee proposte. Le proposte arrivano sempre sul forum in modo che la comunità abbia la possibilità di discutere e dibattere le idee proposte.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash è il sito principale di Zcash. Fornisce contenuti e documentazione su Zcash per un'ampia gamma di utenti e consente ai nuovi utenti di approfondire le spiegazioni tecniche su Zcash.
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-Hai competenze di programmazione e vuoi approfondire il lato tecnico di Zcash? Il repository Github Zcash è il repository di [zcashd](https://electriccoin.co/zcashd/), la prima implementazione di un nodo Zcash.
+Hai competenze di programmazione e vuoi approfondire il lato tecnico di Zcash? Il repository Github Zcash è il repository di [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), la prima implementazione di un nodo Zcash.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/it/site/Zcash_Community/Community_Links.md
+++ b/translations/it/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash ha una presenza globale attiva su X. Account principali da seguire:
 - [Sito Web della Community di Zcash](https://www.zcashcommunity.com/)
 - [Wiki di ZecHub](https://zechub.wiki)
 - [Hub delle Sovvenzioni di Zcash](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Ambasciatori Globali di Zcash](https://zcashambassadors.com)
+- [Ambasciatori Globali di Zcash](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO su Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/it/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/it/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Abbiamo visto troppi progetti promettere troppo e mantenere troppo poco riguardo
 
 ## Governance
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/it/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/it/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company e Zcash Foundation si conformano entrambe a questo [standa
 
 - [Avvisi di Sicurezza Zcash](https://github.com/zcash/zcash/security/advisories)
 - [Avvisi di Sicurezza Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Segnala una Vulnerabilità a ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Segnala una Vulnerabilità a ECC](https://github.com/zcash/zcash/security/policy)
 - [Segnala una Vulnerabilità a ZF](https://zfnd.org/contact/)

--- a/translations/ja/site/Start_Here/Zcash_Resources.md
+++ b/translations/ja/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Zcash を理解するのに役立つリソースがいくつかあります。
 
 Zcash Media は、Zcash に関する教育的なドキュメンタリーを作成する独立した組織です。彼らの最初の動画「Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?」は、Zcash の概要を理解するのに最適なものです。
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter は、Zcash コミュニティおよびより広い暗号資産界隈のデファクトスタンダードのコミュニケーションハブです。Zcash 関連の最新情報や著名なコミュニティメンバーをフォローするのに最適な場所です。トップアカウントをフォローするための [ドキュメント](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) があります。
 
-**[Zcash Community](zcashcommunity.com)**
+**[Zcash Community](https://www.zcashcommunity.com/)**
 
 Zcash Community は、コミュニティが運営するサイトで、Zcash エコシステムをサポートするコミュニティ主導のプロジェクトを紹介しています。Zcash コミュニティおよびそのさまざまな通貨としての応用に触れるのに最適な方法です。
 
-**[The Zcash Forum](forum.zcashcommunity.com)**
+**[The Zcash Forum](https://forum.zcashcommunity.com/)**
 
 新規ユーザー向けガイドにも記載されているように、Zcash フォーラムは、Zcash 関連のトピックや提案されたアイデアについて長文での議論を行うのに最適な場所です。すべての提案はフォーラムに掲載され、コミュニティが提案されたアイデアを検討・議論できるようにしています。
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash は Zcash の公式ウェブサイトです。幅広いユーザー向けに Zcash のコンテンツやドキュメントを提供し、新規ユーザーが Zcash に関する技術的な説明を深く理解できるようにしています。
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-プログラミングスキルがあり、Zcash の技術面についてさらに詳しく知りたいですか？Zcash GitHub リポジトリは [zcashd](https://electriccoin.co/zcashd/)、最初の Zcash ノード実装のリポジトリです。
+プログラミングスキルがあり、Zcash の技術面についてさらに詳しく知りたいですか？Zcash GitHub リポジトリは [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet)、最初の Zcash ノード実装のリポジトリです。
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/ja/site/Zcash_Community/Community_Links.md
+++ b/translations/ja/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcashは、X上でも活発なグローバル存在を持っています。フ�
 - [Zcash コミュニティウェブサイト](https://www.zcashcommunity.com/)
 - [ZecHub Wiki](https://zechub.wiki)
 - [Zcash助成金ハブ](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcashグローバルアンバサダラー](https://zcashambassadors.com)
+- [Zcashグローバルアンバサダラー](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO on Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/ja/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/ja/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Cypherpunk Zero は、ゼロという若きサイファーパンクハッカー�
 
 ## ゲッコウ
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/ja/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/ja/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin CompanyおよびZcash Foundationは、以下の逸脱点を除い�
 
 - [Zcashセキュリティアドバイザリー](https://github.com/zcash/zcash/security/advisories)
 - [Zebraセキュリティアドバイザリー](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [ECCへの脆弱性の報告](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [ECCへの脆弱性の報告](https://github.com/zcash/zcash/security/policy)
 - [ZFへの脆弱性の報告](https://zfnd.org/contact/)

--- a/translations/ko/site/Start_Here/Zcash_Resources.md
+++ b/translations/ko/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Zcash를 이해하는 데 도움이 되는 다양한 자료가 있습니다.
 
 Zcash Media는 독립적인 조직으로, 교육용 다큐멘터리로 Zcash에 대해 설명합니다. 그들의 첫 번째 영상인 "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?"는 Zcash의 좋은 소개입니다.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter는 Zcash 커뮤니티와 더 넓은 암호화폐 공간에서 공식적인 소통 중심지로 작동합니다. 모든 Zcash 관련 정보를 파악하고, 주요 인물들을 팔로우하는 데에도 좋은 장소입니다. 여기에 [문서](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05)가 있어, 팔로우해야 할 주요 계정들을 나열하고 있습니다.
 
-**[Zcash Community](zcashcommunity.com)**
+**[Zcash Community](https://www.zcashcommunity.com/)**
 
 Zcash Community는 커뮤니티에서 운영되는 사이트로, Zcash 생태계를 지원하는 커뮤니티 프로젝트들을 강조합니다. 이는 Zcash 커뮤니티와 통화로서의 다양한 응용 사례에 대해 소개받기에 좋은 방법입니다.
 
-**[The Zcash Forum](forum.zcashcommunity.com)**
+**[The Zcash Forum](https://forum.zcashcommunity.com/)**
 
 새로운 사용자 가이드에서 언급했듯, Zcash 포럼은 Zcash 관련 주제에 대한 긴 글 형식의 토론과 제안된 아이디어들에 대해 논의할 수 있는 좋은 장소입니다. 모든 제안은 포럼으로 이동하여 커뮤니티가 제안된 아이디어들을 논의하고 토론할 기회를 얻습니다.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash는 Zcash의 주요 웹사이트입니다. 다양한 사용자들에게 Zcash에 대한 콘텐츠와 문서를 제공하며, 새로운 사용자가 Zcash에 관한 기술적 설명을 더 깊이 있게 알아볼 수 있도록 합니다.
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-코딩 능력이 있고, Zcash의 기술적인 측면에 대해 더 깊이 알고 싶다면? Zcash의 GitHub 저장소는 [zcashd](https://electriccoin.co/zcashd/)의 첫 번째 Zcash 노드 구현을 위한 저장소입니다.
+코딩 능력이 있고, Zcash의 기술적인 측면에 대해 더 깊이 알고 싶다면? Zcash의 GitHub 저장소는 [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet)의 첫 번째 Zcash 노드 구현을 위한 저장소입니다.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/ko/site/Zcash_Community/Community_Links.md
+++ b/translations/ko/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash는 X에서 활발한 글로벌 존재를 가지고 있습니다. 주요로
 - [Zcash 커뮤니티 웹사이트](https://www.zcashcommunity.com/)
 - [ZecHub 위키](https://zechub.wiki)
 - [Zcash 보조금 허브](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash 글로벌 대사](https://zcashambassadors.com)
+- [Zcash 글로벌 대사](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO on Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/ko/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/ko/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Cypherpunk Zero는 젤로라는 젊은 사이퍼펑크 해커이자 자유 전�
 
 ## 거버넌스
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/ko/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/ko/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company와 Zcash Foundation 모두 이 [책임 있는 공개](http
 
 - [Zcash 보안 공지](https://github.com/zcash/zcash/security/advisories)
 - [Zebra 보안 공지](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [ECC에 취약점 보고](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [ECC에 취약점 보고](https://github.com/zcash/zcash/security/policy)
 - [ZF에 취약점 보고](https://zfnd.org/contact/)

--- a/translations/pt/site/Start_Here/Zcash_Resources.md
+++ b/translations/pt/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Há vários recursos que ajudam os usuários a entender Zcash.
 
 Zcash Media é uma organização independente que produz documentários educacionais sobre Zcash. Seu primeiro vídeo, "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", é uma ótima introdução ao Zcash.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter é o centro de comunicação de fato da comunidade Zcash, e também do espaço mais amplo das criptomoedas. É um ótimo lugar para acompanhar tudo relacionado a Zcash e também seguir membros proeminentes da comunidade. Aqui está um [documento](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) que lista as principais contas para seguir.
 
-**[Comunidade Zcash](zcashcommunity.com)**
+**[Comunidade Zcash](https://www.zcashcommunity.com/)**
 
 Zcash Community é um site administrado pela comunidade que destaca projetos conduzidos pela comunidade que apoiam o ecossistema Zcash. É uma ótima maneira de conhecer a comunidade Zcash e suas várias aplicações como moeda.
 
-**[O Fórum Zcash](forum.zcashcommunity.com)**
+**[O Fórum Zcash](https://forum.zcashcommunity.com/)**
 
 Como mencionado no guia para novos usuários, o fórum Zcash é um ótimo lugar para ter discussões mais longas sobre tópicos de Zcash e também sobre ideias propostas. As propostas sempre chegam ao fórum para que a comunidade tenha a chance de discutir e debater as ideias propostas.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash é o principal site de Zcash. Ele fornece conteúdo e documentação sobre Zcash para uma ampla variedade de usuários e permite que novos usuários se aprofundem nas explicações técnicas em torno de Zcash.
 
 **[GitHub de Zcash](https://github.com/zcash/zcash)**
 
-Tem habilidade com programação e quer se aprofundar no lado técnico de Zcash? O repositório GitHub de Zcash é o repositório de [zcashd](https://electriccoin.co/zcashd/), a primeira implementação de nó Zcash.
+Tem habilidade com programação e quer se aprofundar no lado técnico de Zcash? O repositório GitHub de Zcash é o repositório de [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), a primeira implementação de nó Zcash.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[GitHub da Zcash Foundation](https://github.com/ZcashFoundation)**
 

--- a/translations/pt/site/Zcash_Community/Community_Links.md
+++ b/translations/pt/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash tem uma presença global ativa no X. Principais contas para acompanhar:
 - [Site da Comunidade Zcash](https://www.zcashcommunity.com/)
 - [Wiki do ZecHub](https://zechub.wiki)
 - [Hub de Grants da Zcash](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Embaixadores Globais da Zcash](https://zcashambassadors.com)
+- [Embaixadores Globais da Zcash](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO no Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/pt/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/pt/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Vimos projetos demais prometerem em excesso e entregarem aquém em seus roadmaps
 
 ## Governança
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/pt/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/pt/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ A Electric Coin Company e a Zcash Foundation estão ambas em conformidade com es
 
 - [Avisos de Segurança do Zcash](https://github.com/zcash/zcash/security/advisories)
 - [Avisos de Segurança do Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Relatar uma Vulnerabilidade à ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Relatar uma Vulnerabilidade à ECC](https://github.com/zcash/zcash/security/policy)
 - [Relatar uma Vulnerabilidade à ZF](https://zfnd.org/contact/)

--- a/translations/ru/site/Start_Here/Zcash_Resources.md
+++ b/translations/ru/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@
 
 Zcash Media — это независимая организация, создающая образовательные документальные фильмы о Zcash. Их первое видео, «Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?», является отличным введением в Zcash.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter — это фактический центр коммуникации сообщества Zcash, как и более широкого пространства криптовалют в целом. Это отличное место, чтобы почувствовать пульс всего, что связано с Zcash, а также следить за заметными участниками сообщества. Вот [документ](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) со списком основных аккаунтов, на которые стоит подписаться.
 
-**[Сообщество Zcash](zcashcommunity.com)**
+**[Сообщество Zcash](https://www.zcashcommunity.com/)**
 
 Zcash Community — это сайт, управляемый сообществом, который освещает проекты, созданные сообществом для поддержки экосистемы Zcash. Это отличный способ познакомиться с сообществом Zcash и различными вариантами его использования в качестве валюты.
 
-**[Форум Zcash](forum.zcashcommunity.com)**
+**[Форум Zcash](https://forum.zcashcommunity.com/)**
 
 Как уже упоминалось в руководстве для новых пользователей, форум Zcash — отличное место для развёрнутых обсуждений тем, связанных с Zcash, а также предлагаемых идей. Предложения всегда попадают на форум, чтобы у сообщества была возможность обсудить и оспорить предлагаемые идеи.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash — это основной сайт Zcash. Он предоставляет контент и документацию о Zcash для широкого круга пользователей и позволяет новым пользователям глубже погрузиться в технические объяснения, связанные с Zcash.
 
 **[GitHub Zcash](https://github.com/zcash/zcash)**
 
-Есть навыки программирования и хотите глубже погрузиться в техническую сторону Zcash? Репозиторий Zcash на GitHub — это репозиторий для [zcashd](https://electriccoin.co/zcashd/), первой реализации узла Zcash.
+Есть навыки программирования и хотите глубже погрузиться в техническую сторону Zcash? Репозиторий Zcash на GitHub — это репозиторий для [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), первой реализации узла Zcash.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[GitHub Zcash Foundation](https://github.com/ZcashFoundation)**
 

--- a/translations/ru/site/Zcash_Community/Community_Links.md
+++ b/translations/ru/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash имеет активное глобальное присутствие в
 - [Сайт сообщества Zcash](https://www.zcashcommunity.com/)
 - [Вики ZecHub](https://zechub.wiki)
 - [Центр грантов Zcash](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Глобальные амбассадоры Zcash](https://zcashambassadors.com)
+- [Глобальные амбассадоры Zcash](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO на Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/ru/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/ru/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Cypherpunk Zero — это серия повествований, сосредо
 
 ## Governance
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/ru/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/ru/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company и Zcash Foundation обе придерживаются э
 
 - [Рекомендации по безопасности Zcash](https://github.com/zcash/zcash/security/advisories)
 - [Рекомендации по безопасности Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Сообщить об уязвимости в ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Сообщить об уязвимости в ECC](https://github.com/zcash/zcash/security/policy)
 - [Сообщить об уязвимости в ZF](https://zfnd.org/contact/)

--- a/translations/sw/site/Start_Here/Zcash_Resources.md
+++ b/translations/sw/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Kuna idadi ya rasilimali ambazo husaidia watumiaji kuelewa Zcash.
 
 Zcash Media ni shirika huru ambayo hufanya documentaries elimu kuhusu Zcash. video yao ya kwanza, "Kujenga Kurekebisha Bitcoin ya Fatal kasoro, nini Zcash (ZEC)?", ni utangulizi kubwa kwa Zcash .
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter ni de facto mawasiliano kitovu kwa ajili ya jamii Zcash, na pana cryptocurrency nafasi pamoja. Ni mahali pazuri kupata msukumo kuangalia juu ya mambo yote Zcash , na pia kufuata wanachama maarufu wa jamii. Hapa ni [hati](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) ambayo orodha ya akaunti juu ya kufuata.
 
-**[Zcash Jumuiya](zcashcommunity.com)**
+**[Zcash Jumuiya](https://www.zcashcommunity.com/)**
 
 Zcash Community is a community run site that highlights community run projects supporting the Zcash ecosystem. It's a great way to get introduced to the Zcash community and its various applications as a currency.
 
-** [Zcash Forum](forum.zcashcommunity.com)**
+** [Zcash Forum](https://forum.zcashcommunity.com/)**
 
 As mentioned in the new user guide, the Zcash forum is a great place to have long form discussions about Zcash topics and also proposed ideas. Proposals always make it to the forum so the community has a chance to discuss and debate the proposed ideas.
 
-** [Z. fedha taslimu](z.cash)**
+** [Z. fedha taslimu](https://z.cash/)**
 
 Z.cash ni tovuti kuu ya Zcash. Inatoa maudhui na nyaraka za Zcash kwa wigo mpana wa watumiaji na inaruhusu Watumiaji wapya kuzama zaidi katika maelezo ya kiufundi karibu na Zcash .
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-Got coding chops na wanataka kupiga mbizi zaidi katika upande wa kiufundi wa Zcash? Zcash Github Repo ni hazina ya [zcashd](https://electriccoin.co/zcashd/), kwanza Zcash node utekelezaji.
+Got coding chops na wanataka kupiga mbizi zaidi katika upande wa kiufundi wa Zcash? Zcash Github Repo ni hazina ya [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), kwanza Zcash node utekelezaji.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/sw/site/Zcash_Community/Community_Links.md
+++ b/translations/sw/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Akaunti maelezo
 - [Zcash Jumuiya ya Tovuti](https://www.zcashcommunity.com/)
 - [ZecHub Wiki](https://zechub.wiki)
 - [Zcash misaada Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash Global Balozi](https://zcashambassadors.com)
+- [Zcash Global Balozi](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO juu ya Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/sw/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/sw/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ We have seen too many projects over-promise and under deliver on their NFT roadm
 
 ## Utawala
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Kikundi](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/sw/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/sw/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ The Electric Coin Company na Zcash Foundation wote wanatii hii Ufafanuzi wa Waji
 
 - [Zcash Ushauri wa Usalama](https://github.com/zcash/zcash/security/advisories)
 - [Zebra Ushauri wa Usalama](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Ripoti udhaifu kwa ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Ripoti udhaifu kwa ECC](https://github.com/zcash/zcash/security/policy)
 - [Ripoti udhaifu kwa ZF](https://zfnd.org/contact/)

--- a/translations/tr/site/Start_Here/Zcash_Resources.md
+++ b/translations/tr/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Kullanıcıların Zcash'i anlamasına yardımcı olan çeşitli kaynaklar vardı
 
 Zcash Media, Zcash hakkında eğitici belgeseller hazırlayan bağımsız bir kuruluştur. İlk videoları olan "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", Zcash'e harika bir giriş niteliğindedir.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter, Zcash topluluğu ve daha geniş kripto para alanı için fiili iletişim merkezidir. Zcash ile ilgili her şeyin nabzını tutmak ve öne çıkan topluluk üyelerini takip etmek için harika bir yerdir. Takip edilmesi gereken en iyi hesapları listeleyen bir [belgeyi](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) burada bulabilirsiniz.
 
-**[Zcash Community](zcashcommunity.com)**
+**[Zcash Community](https://www.zcashcommunity.com/)**
 
 Zcash Community, Zcash ekosistemini destekleyen topluluk tarafından yürütülen projeleri öne çıkaran, topluluk tarafından işletilen bir sitedir. Zcash topluluğu ve Zcash'in para birimi olarak çeşitli kullanım alanlarıyla tanışmak için harika bir yoldur.
 
-**[Zcash Forumu](forum.zcashcommunity.com)**
+**[Zcash Forumu](https://forum.zcashcommunity.com/)**
 
 Yeni kullanıcı rehberinde de belirtildiği gibi, Zcash forumu Zcash konuları ve önerilen fikirler hakkında uzun soluklu tartışmalar yapmak için harika bir yerdir. Öneriler her zaman foruma taşınır, böylece topluluğun önerilen fikirleri tartışma ve değerlendirme fırsatı olur.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash, Zcash'in ana web sitesidir. Geniş bir kullanıcı kitlesi için Zcash hakkında içerik ve dokümantasyon sunar ve yeni kullanıcıların Zcash ile ilgili teknik açıklamalara daha derinlemesine dalmasını sağlar.
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-Kodlama becerileriniz var ve Zcash'in teknik tarafına daha derinlemesine dalmak mı istiyorsunuz? Zcash Github Repo, ilk Zcash düğüm uygulaması olan [zcashd](https://electriccoin.co/zcashd/) için depodur.
+Kodlama becerileriniz var ve Zcash'in teknik tarafına daha derinlemesine dalmak mı istiyorsunuz? Zcash Github Repo, ilk Zcash düğüm uygulaması olan [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet) için depodur.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/tr/site/Zcash_Community/Community_Links.md
+++ b/translations/tr/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash, X üzerinde aktif bir küresel varlığa sahiptir. Takip edilebilecek ön
 - [Zcash Topluluk Web Sitesi](https://www.zcashcommunity.com/)
 - [ZecHub Wiki](https://zechub.wiki)
 - [Zcash Hibeler Merkezi](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash Global Ambassadors](https://zcashambassadors.com)
+- [Zcash Global Ambassadors](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [Dework üzerinde ZecHub DAO](https://app.dework.xyz/zechub-2424)

--- a/translations/tr/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/tr/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Cypherpunk Zero, genç bir cypherpunk hacker ve özgürlük savaşçısı olan Z
 
 ## Yönetişim
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/tr/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/tr/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company ve Zcash Foundation, aşağıdaki sapmayla birlikte bu Sor
 
 - [Zcash Güvenlik Danışmaları](https://github.com/zcash/zcash/security/advisories)
 - [Zebra Güvenlik Danışmaları](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [ECC'ye Güvenlik Açığı Bildirin](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [ECC'ye Güvenlik Açığı Bildirin](https://github.com/zcash/zcash/security/policy)
 - [ZF'ye Güvenlik Açığı Bildirin](https://zfnd.org/contact/)

--- a/translations/uk/site/Start_Here/Zcash_Resources.md
+++ b/translations/uk/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@
 
 Zcash Media — це незалежна організація, яка створює освітні документальні фільми про Zcash. Їхнє перше відео, "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", є чудовим вступом до Zcash.
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter є фактичним центром комунікації для спільноти Zcash, а також ширшого криптовалютного простору. Це чудове місце, щоб відстежувати все, що стосується Zcash, а також стежити за помітними членами спільноти. Ось [документ](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05), у якому перелічено основні акаунти, на які варто підписатися.
 
-**[Спільнота Zcash](zcashcommunity.com)**
+**[Спільнота Zcash](https://www.zcashcommunity.com/)**
 
 Zcash Community — це сайт, яким керує спільнота, і який висвітлює проєкти спільноти, що підтримують екосистему Zcash. Це чудовий спосіб познайомитися зі спільнотою Zcash та її різноманітними застосуваннями як валюти.
 
-**[Форум Zcash](forum.zcashcommunity.com)**
+**[Форум Zcash](https://forum.zcashcommunity.com/)**
 
 Як уже згадувалося в посібнику для нових користувачів, форум Zcash — це чудове місце для розгорнутих обговорень тем, пов’язаних із Zcash, а також запропонованих ідей. Пропозиції завжди потрапляють на форум, щоб спільнота мала можливість обговорити та подискутувати щодо запропонованих ідей.
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash — це основний вебсайт Zcash. Він надає контент і документацію про Zcash для широкого кола користувачів і дає новим користувачам змогу глибше зануритися в технічні пояснення, пов’язані із Zcash.
 
 **[GitHub Zcash](https://github.com/zcash/zcash)**
 
-Маєте навички програмування і хочете глибше зануритися в технічний бік Zcash? Репозиторій Zcash на GitHub — це репозиторій для [zcashd](https://electriccoin.co/zcashd/), першої реалізації вузла Zcash.
+Маєте навички програмування і хочете глибше зануритися в технічний бік Zcash? Репозиторій Zcash на GitHub — це репозиторій для [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), першої реалізації вузла Zcash.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[GitHub Zcash Foundation](https://github.com/ZcashFoundation)**
 

--- a/translations/uk/site/Zcash_Community/Community_Links.md
+++ b/translations/uk/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash має активну глобальну присутність у X. Ос
 - [Вебсайт спільноти Zcash](https://www.zcashcommunity.com/)
 - [Вікі ZecHub](https://zechub.wiki)
 - [Хаб грантів Zcash](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Глобальні амбасадори Zcash](https://zcashambassadors.com)
+- [Глобальні амбасадори Zcash](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO на Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/uk/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/uk/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Cypherpunk Zero — це серія оповідей, у центрі яких Z
 
 ## Управління
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/uk/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/uk/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company і Zcash Foundation обидві дотримуються 
 
 - [Попередження безпеки Zcash](https://github.com/zcash/zcash/security/advisories)
 - [Попередження безпеки Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Повідомити про вразливість до ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Повідомити про вразливість до ECC](https://github.com/zcash/zcash/security/policy)
 - [Повідомити про вразливість до ZF](https://zfnd.org/contact/)

--- a/translations/yo/site/Start_Here/Zcash_Resources.md
+++ b/translations/yo/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@ Awọn ohun elo pupọ lo wa ti o ṣe iranlọwọ fun awọn olumulo lati ni o
 
 Zcash Media je ajo ominira kan ti o n se awon iwe eko nipa Zcash. fidio won akọkọ, "Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?", jẹ ifihan nla si Zcash .
 
-**[Ìkànnì Twitter](twitter.com)**
+**[Ìkànnì Twitter](https://x.com)**
 
 Twitter ni de facto awọn ibaraẹnisọrọ ibudo fun awọn Zcash awujo, ati awọn gbooro cryptocurrency aaye bi daradara. o jẹ nla kan ibi lati gba a pulse ṣayẹwo lori gbogbo ohun Zcash, ati ki o tun tẹle gbajumọ awujo omo egbe. nibi ni a [document](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05) tí ó ṣe àkọsílẹ̀ àwọn àkọlé àkọ́kọ́ láti tẹ̀lé.
 
-**[Ìjọ Zcash](zcashcommunity.com)**
+**[Ìjọ Zcash](https://www.zcashcommunity.com/)**
 
 Zcash Community is a community run site that highlights community run projects supporting the Zcash ecosystem. It's a great way to get introduced to the Zcash community and its various applications as a currency.
 
-**[Ìjọ́ àpérò Zcash](forum.zcashcommunity.com)**
+**[Ìjọ́ àpérò Zcash](https://forum.zcashcommunity.com/)**
 
 As mentioned in the new user guide, the Zcash forum is a great place to have long form discussions about Zcash topics and also proposed ideas. Proposals always make it to the forum so the community has a chance to discuss and debate the proposed ideas.
 
-**[Z. owó orí](z.cash)**
+**[Z. owó orí](https://z.cash/)**
 
 Z.cash jẹ oju opo wẹẹbu akọkọ ti Zcash. O pese akoonu ati iwe-ipamọ Zcash fun ọpọlọpọ awọn olumulo ati gba awọn olumulo tuntun laaye lati jin jinlẹ sinu awọn alaye imọ-ẹrọ ni ayika Zcash .
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-Ti o ni coding chops ati ki o fẹ lati dive jinle sinu awọn imọ ẹgbẹ ti Zcash? The Zcash Github Repo ni awọn ibi ipamọ fun [zcashd](https://electriccoin.co/zcashd/), ìmúṣẹ ìsopọ̀ Zcash àkọ́kọ́.
+Ti o ni coding chops ati ki o fẹ lati dive jinle sinu awọn imọ ẹgbẹ ti Zcash? The Zcash Github Repo ni awọn ibi ipamọ fun [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet), ìmúṣẹ ìsopọ̀ Zcash àkọ́kọ́.
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/yo/site/Zcash_Community/Community_Links.md
+++ b/translations/yo/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash ni wiwa agbaye ti nṣiṣe lọwọ lori X. Awọn iroyin pataki lati t�
 - [Ìkànnì Ìjọ Zcash](https://www.zcashcommunity.com/)
 - [ZecHub Wiki](https://zechub.wiki)
 - [Ilé Ìpèsè Zcash](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Àwọn Aṣojú Àgbáyé Zcash](https://zcashambassadors.com)
+- [Àwọn Aṣojú Àgbáyé Zcash](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [ZecHub DAO on Dework](https://app.dework.xyz/zechub-2424)

--- a/translations/yo/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/yo/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ We have seen too many projects over-promise and under deliver on their NFT roadm
 
 ## Ìdarí
 
-[Àwòrán ojú ẹsẹ̀](https://vote.cypherpunkzero.com/)
+[Àwòrán ojú ẹsẹ̀](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Àwùjọ](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/yo/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/yo/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ The Electric Coin Company ati Zcash Foundation mejeeji ni ibamu pẹlu Ifihan Id
 
 - [Ìmọ̀ràn Ààbò Zcash](https://github.com/zcash/zcash/security/advisories)
 - [Ìmọ̀ràn Ìdáàbòbò Zebra](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [Ṣàlàyé Àìlera fún ECC](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [Ṣàlàyé Àìlera fún ECC](https://github.com/zcash/zcash/security/policy)
 - [Ṣàkíyèsí Àìlera sí ZF](https://zfnd.org/contact/)

--- a/translations/zh/site/Start_Here/Zcash_Resources.md
+++ b/translations/zh/site/Start_Here/Zcash_Resources.md
@@ -10,25 +10,27 @@
 
 Zcash Media 是一个独立组织，制作关于 Zcash 的教育纪录片。他们的第一部视频《Built to Fix Bitcoin's Fatal Flaw, What is Zcash (ZEC)?》是了解 Zcash 的绝佳入门介绍。
 
-**[Twitter](twitter.com)**
+**[Twitter](https://x.com)**
 
 Twitter 是 Zcash 社区以及更广泛加密货币领域事实上的交流中心。这里非常适合了解与 Zcash 相关的一切动态，也可以关注社区中的知名成员。这里有一份[文档](https://www.notion.so/zechub/Social-Media-Links-05b9df645af54de7a1989d9c4ccc4d05)，列出了最值得关注的账号。
 
-**[Zcash 社区](zcashcommunity.com)**
+**[Zcash 社区](https://www.zcashcommunity.com/)**
 
 Zcash Community 是一个由社区运营的网站，重点展示支持 Zcash 生态系统的社区项目。它是了解 Zcash 社区及其作为一种货币的各种应用方式的绝佳入口。
 
-**[Zcash 论坛](forum.zcashcommunity.com)**
+**[Zcash 论坛](https://forum.zcashcommunity.com/)**
 
 正如新用户指南中提到的，Zcash 论坛是围绕 Zcash 主题以及提议中的想法进行长篇讨论的好地方。各类提案都会发布到论坛，让社区有机会讨论并辩论这些提议。
 
-**[Z.cash](z.cash)**
+**[Z.cash](https://z.cash/)**
 
 Z.cash 是 Zcash 的官方网站。它为广泛用户群体提供关于 Zcash 的内容和文档，并帮助新用户进一步深入了解围绕 Zcash 的技术解释。
 
 **[Zcash Github](https://github.com/zcash/zcash)**
 
-如果你具备编程能力，并想更深入了解 Zcash 的技术层面，Zcash Github Repo 就是 [zcashd](https://electriccoin.co/zcashd/) 的代码仓库，它是第一个 Zcash 节点实现。
+如果你具备编程能力，并想更深入了解 Zcash 的技术层面，Zcash Github Repo 就是 [zcashd](https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet) 的代码仓库，它是第一个 Zcash 节点实现。
+
+> zcashd → Zebra + Zallet — https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
 
 **[Zcash Foundation Github](https://github.com/ZcashFoundation)**
 

--- a/translations/zh/site/Zcash_Community/Community_Links.md
+++ b/translations/zh/site/Zcash_Community/Community_Links.md
@@ -74,5 +74,5 @@ Zcash 在 X 上拥有活跃的全球影响力。值得关注的主要账号包�
 - [Zcash 社区网站](https://www.zcashcommunity.com/)
 - [ZecHub Wiki](https://zechub.wiki)
 - [Zcash Grants Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
-- [Zcash 全球大使](https://zcashambassadors.com)
+- [Zcash 全球大使](https://zechub.wiki/zcash-community/zcash-global-ambassadors)
 - [Dework 上的 ZecHub DAO](https://app.dework.xyz/zechub-2424)

--- a/translations/zh/site/Zcash_Community/Cypherpunk_Zero_NFT.md
+++ b/translations/zh/site/Zcash_Community/Cypherpunk_Zero_NFT.md
@@ -15,7 +15,7 @@ Cypherpunk Zero 是一个以 Zero 为核心的故事系列。Zero 是一位年�
 
 ## 治理
 
-[Snapshot](https://vote.cypherpunkzero.com/)
+[Snapshot](https://snapshot.box/#/s:cypherpunkzerodao.eth)
 
 [Guild](https://guild.xyz/cypherpunkzerodao)
 

--- a/translations/zh/site/Zcash_Community/Zcash_Ecosystem_Security.md
+++ b/translations/zh/site/Zcash_Community/Zcash_Ecosystem_Security.md
@@ -33,5 +33,5 @@ Electric Coin Company 和 Zcash Foundation 均遵循这一负责任披露[标准
 
 - [Zcash 安全公告](https://github.com/zcash/zcash/security/advisories)
 - [Zebra 安全公告](https://github.com/ZcashFoundation/zebra/security/advisories)
-- [向 ECC 报告漏洞](https://electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/)
+- [向 ECC 报告漏洞](https://github.com/zcash/zcash/security/policy)
 - [向 ZF 报告漏洞](https://zfnd.org/contact/)


### PR DESCRIPTION
Repoints every dead link on four pages, each verified against a live destination on 2026-09-02 with a browser user-agent.

## What was dead

| Page | Link | Status on 2026-09-02 |
|---|---|---|
| `Start_Here/Zcash_Resources.md` | `electriccoin.co/zcashd/` | 521: origin unreachable |
| `Zcash_Community/Zcash_Ecosystem_Security.md` | `electriccoin.co/blog/disclosure-of-a-major-bug-in-cryptonote-based-currencies/` | 521: origin unreachable |
| `Zcash_Community/Cypherpunk_Zero_NFT.md` | `vote.cypherpunkzero.com` | NXDOMAIN |
| `Zcash_Community/Community_Links.md` | `zcashambassadors.com` | NXDOMAIN |

The two ECC links are not an isolated 404 any more. The whole `electriccoin.co` apex returns 521; `electriccoin.co/`, `/blog/` and `/zcashd/` all fail identically, on two passes. `halo.electriccoin.co` still returns 200, so this is the apex origin, not DNS. Either way neither link is usable.

The zcashd one is the sharpest, as the bounty notes: it sits on a Start Here page, in front of new readers, pointing at a download page for software that halted on 18 July 2026.

`vote.cypherpunkzero.com` and `zcashambassadors.com` were re-checked with `getent hosts` against a resolver control (`google.com`, `github.com`, `zecfaucet.com` all resolved in the same run), so these are absent DNS records, not bot blocks.

## What changed

**`Start_Here/Zcash_Resources.md`**: the zcashd entry now states the end-of-support halt and names the maintained stack rather than being deleted silently: [Zebra](https://github.com/ZcashFoundation/zebra) for the node, [Zallet](https://github.com/zcash/zallet) for the wallet, plus the migration guide. The companion line two entries down said "List of all current commands for zcashd", which would have contradicted the correction, so it now describes the zcashd RPC surface in the past tense and points at the Zallet Book.

**`Zcash_Ecosystem_Security.md`**: "Report a Vulnerability to ECC" pointed at a 2017 CryptoNote disclosure blog post, which was never a reporting address even while it resolved. It now points at the [`zcash/zcash` security policy](https://github.com/zcash/zcash/security/policy).

**`Cypherpunk_Zero_NFT.md`**: the custom voting domain is gone, but the DAO's Snapshot space survives. Confirmed live through the Snapshot GraphQL API, not just an HTTP 200 (the frontend is a hash-routed SPA and returns 200 for anything):

```
$ curl -s -X POST https://hub.snapshot.org/graphql \
    -d '{"query":"{space(id:\"cypherpunkzerodao.eth\"){id name followersCount proposalsCount}}"}'
{"data":{"space":{"id":"cypherpunkzerodao.eth","name":"Cypherpunk Zero DAO","followersCount":9,"proposalsCount":0}}}
```

**`Community_Links.md`**: repointed at this wiki's own [Zcash Global Ambassadors](https://zechub.wiki/zcash-community/zcash-global-ambassadors) page, which covers the program and is the only live description of it left.

## Also fixed: four scheme-less links on the same Start Here page

Four links on `Zcash_Resources.md` were written without a scheme:

```
**[Twitter](twitter.com)**              **[Zcash Community](zcashcommunity.com)**
**[The Zcash Forum](forum.zcashcommunity.com)**   **[Z.cash](z.cash)**
```

Markdown resolves these as relative paths, so they render as wiki routes and 404:

```
2026-09-02 404 https://zechub.wiki/start-here/twitter.com
2026-09-02 404 https://zechub.wiki/start-here/z.cash
2026-09-02 404 https://zechub.wiki/start-here/zcashcommunity.com
```

All four now have `https://` 

## Translated copies

All four pages are curated, so each has 18 translated copies carrying the same dead URLs verbatim — 72 files. Those get the **URL swap only**; link text stays in the target language and translated prose is untouched, because the English source hashes have changed and the sync pipeline will retranslate all four pages properly.

`translation/sync-state.json` records the pass in `tool` (`+deadlink-4pages`) for those 72 entries. `src` and `src_commit` are deliberately left alone so the pages read as stale and get a real retranslation, and `edited` stays `false` — flipping it would freeze these pages out of automated sync permanently.

One wrinkle worth naming: `scripts/check-protected-terms.mjs` fails a change that introduces a `preserveVerbatim` term into an English page whose translation is touched in the same commit without carrying that term. The rewrite introduces **Zebra** and **Zallet**, so each translated `Zcash_Resources.md` carries a product-name-only marker line that reads identically in every locale:

```
> zcashd → Zebra + Zallet: https://zechub.wiki/guides/migration-guide-zcashd-to-zebrad-zallet
```

"ZODL" is deliberately not used anywhere in this change for the same reason.

## Verification

Every link on all four pages, after the change:

```
$ links on the four pages: 75
$ non-2xx/3xx: 3
  403 https://etherscan.io/address/0x3e86d6cf041b719c575f57050697c115f0a53758
  404 https://twitter.com/CypherpunkDAO
  404 https://x.com/zcash_korea
```

All three are left unchanged, deliberately:

- **etherscan.io 403** is a known bot block; the page loads in a browser.
- **The two X handles** return 404 to curl, but X's status codes are not a liveness signal; a nonsense handle returns **200** in the same run (`x.com/thisaccountdoesnotexist99871` → 200), so 404 here probably means suspended or withheld rather than deleted.

CI, run against the commit rather than a dirty tree:

```
$ node scripts/check-protected-terms.mjs --base <base>
Protected terminology validation passed for 3762 translated page(s).
$ node scripts/check-frontmatter.mjs
Front-matter parity holds for 3762 translated page(s).
$ node translation/check-invariants.mjs --base <base>
Manifest invariants hold: 209 curated pages, 18 locales.
$ node --test translation/lib/*.test.mjs
# fail 0
```

## Scope

77 files: 4 English pages, 72 translated copies, `translation/sync-state.json`. No other page is touched; `zcashambassadors.com` also appears on `Zcash_Global_Ambassadors.md` and `electriccoin.co/zcashd` on nine other English pages, both left alone as out of scope here.