### PR TITLE
Repoint dead merchant links and add four ZEC-native services to Places to Spend ZEC

### DIFF
--- a/site/Using_Zcash/Spend_Zcash/Top_10_Places_to_spend_ZEC.md
+++ b/site/Using_Zcash/Spend_Zcash/Top_10_Places_to_spend_ZEC.md
@@ -37,7 +37,7 @@ Particularly, in Venezuela, there are a bunch of places (physical places and onl
 
 1.  **Sheila Vargas**  | Foodie | Blogger | Entrepreneur | Mentorship 
 
-[@SheEmprende_ on Social Media](https://www.sheemprende.com/enlaces-sheemprende/). She jumped into the stage thanks to her famous (and delicious) **[Galletas de la FeliZidad](https://free2z.cash/SheEmprende/zpage/galletas-zcash)**
+[@SheEmprende_ on Social Media](https://twitter.com/SheEmprende_). She jumped into the stage thanks to her famous (and delicious) **[Galletas de la FeliZidad](https://free2z.cash/SheEmprende/zpage/galletas-zcash)**
 
 Besides her cookies, she offers other services and the best of all is this: you can pay with ZEC!
 
@@ -61,7 +61,7 @@ So, if you are a cookie monster..,
 
 now you know where to spend your ZEC!
 
-**Website**: [Sheemprende.com](http://Sheemprende.com) 
+**Website**: sheemprende.com has been retired and no longer resolves. Reach her on [Free2z](https://free2z.cash/SheEmprende) | [X Platform](https://twitter.com/SheEmprende_)
 
 **Zcash Unified Address:** 
 
@@ -85,7 +85,7 @@ Rosa smiles proudly showing that she accepts **Zcash.**
 
 ![Screenshot_20230829-232755.png](/content-images/_unavailable.svg)
 
-**Website**: [https://somosdulceros.com/](https://somosdulceros.com/) 
+**Website**: somosdulceros.com has been retired and no longer resolves. Use the social links below.
 
 **Social media:** [Instagram](https://www.instagram.com/somos_dulceros) | [X Platform](https://twitter.com/RosaMRangel) | [Free2z](https://free2z.cash/Criptodulceros/zpage/criptodulceros-01)
 
@@ -310,6 +310,54 @@ u10jd0tcj24p9rcju047lymtp9nx38h90j09rnr4ru6e8476822saywgn6phe373q78myrf2ew2j6kst
 
 ---
 
+**[Online | Global | Digital goods, marketplaces & VPNs]**
+
+Everything above is a person or a small business you can reach in Venezuela. These four are online, open to anyone with a wallet and a connection, and settle in ZEC directly.
+
+1. **ZecBuy** | Digital goods | eSIM data | VPN access
+
+ZecBuy sells private digital goods for ZEC: eSIM data plans for travel and Mullvad VPN accounts. There is no sign-up and no email address to hand over. You pick the product, pay in ZEC, and get the code.
+
+**Website**: [zecbuy.com](https://zecbuy.com/)
+
+🌐 Online | Worldwide
+
+---
+
+1. **ZEC Market** | Peer-to-peer marketplace
+
+A non-custodial marketplace where buyers and sellers deal with each other directly. Prices are shown in dollars and settled wallet to wallet in Zcash, shielded by default. The platform charges no fee and never holds anyone's funds, which makes it the place to look when what you want to buy is not on a list like this one.
+
+**Website**: [zecmarket.org](https://zecmarket.org/)
+
+More ecosystem projects like it: [Community Projects](/zcash-community/community-projects)
+
+🌐 Online | Worldwide
+
+---
+
+1. **NymVPN** | Decentralized VPN and mixnet
+
+NymVPN routes traffic through a decentralized network of nodes, with a mixnet mode that adds cover traffic so packet timing and size stop working as a fingerprint. Signing up asks for no personal information, and payment is accepted in privacy coins including Zcash, so paying for the service does not undo the privacy of using it.
+
+**Website**: [nym.com](https://nym.com/)
+
+Background reading: [VPNs and dVPNs](/privacy-tools/vpn-and-dvpn)
+
+🌐 Online | Worldwide
+
+---
+
+1. **Meile dVPN** | Decentralized VPN on the Sentinel network
+
+Meile is a dVPN client from the MathNodes team that runs on the Sentinel network, where the nodes are operated by community members rather than by a single company. Subscription plans are paid inside the app, and shielded ZEC payments are handled through BTCPay. Builds are available for Windows, macOS and Linux alongside the mobile client.
+
+**Website**: [Meile dVPN on MathNodes](https://mathnodes.com/index.php/meile-dvpn-client-linux-os-x/) (meile.app redirects here)
+
+🌐 Online | Worldwide
+
+---
+
 **[Fast food | Italian**]
 
 Bonus : **Allegrini Ristorante** 🇪🇸 | Pizza Place | Italian food | **Accepting Zcash soon.** 
@@ -318,7 +366,7 @@ Delivery service | Take away | Reservations
 
 ![BackgroundEraser_20230901_114615839.png](/content-images/_unavailable.svg)
 
-**Website**: [www.alleginiristorante.com](http://www.alleginiristorante.com) (in construction)
+**Website**: none. The announced site at alleginiristorante.com was never completed and the domain no longer resolves. Use the social links below.
 
 **Social media** 
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>What this fixes</h2>
<p><code>site/Using_Zcash/Spend_Zcash/Top_10_Places_to_spend_ZEC.md</code> is the page a new holder is most likely to open when they want to actually use ZEC. Four of its link targets pointed at hosts with no A record, so a reader following them got a browser error rather than a merchant.</p>
<p>DNS checked on 2026-09-02 with a resolver control in the same run (<code>google.com</code>, <code>github.com</code> both resolving):</p>
<pre><code>NXDOMAIN  www.sheemprende.com          line 40
NXDOMAIN  sheemprende.com              line 64
NXDOMAIN  somosdulceros.com            line 88
NXDOMAIN  www.alleginiristorante.com   line 321
</code></pre>
<p>For completeness, the correctly-spelled variants are dead too: <code>alleginiristorante.com</code>, <code>allegriniristorante.com</code> and <code>www.allegriniristorante.com</code> all return NXDOMAIN, so this is not a typo that can be corrected into a live site.</p>
<p>NXDOMAIN is not a bot block or a rate limit: there is no server to answer, so none of these is a false positive.</p>
<h2>What changed</h2>
<p><strong>Dead targets, repointed or retired.</strong> Each business still has a live presence, so nothing is silently deleted:</p>

Line | Was | Now
-- | -- | --
40 | www.sheemprende.com/enlaces-sheemprende/ | twitter.com/SheEmprende_ (200)
64 | Sheemprende.com | retirement note + Free2z (200) and X (200)
88 | somosdulceros.com | retirement note; the Instagram / X / Free2z links already on the entry are live
321 | www.alleginiristorante.com | retirement note; the announced site was never built, so there is nothing to repoint to


<p><strong>Four ZEC-native services added.</strong> Everything on the page was a person or shop reachable in Venezuela, which leaves a reader anywhere else with nothing to do. The new section covers four services that are online, worldwide, and settle in ZEC directly. Each claim is taken from the service's own site, checked 2026-09-02:</p>
<ul>
<li><strong>ZecBuy</strong>: <a href="https://zecbuy.com/">zecbuy.com</a>, "Private digital goods, paid in ZEC". eSIM data plans and Mullvad VPN access, no account and no email address.</li>
<li><strong>ZEC Market</strong>: <a href="https://zecmarket.org/">zecmarket.org</a>, non-custodial P2P marketplace, priced in dollars and settled wallet to wallet, shielded by default, no platform fee. Already listed on <a href="https://claude.ai/zcash-community/community-projects">Community Projects</a>, now cross-linked.</li>
<li><strong>NymVPN</strong>: <a href="https://nym.com/">nym.com</a>, decentralized VPN with a mixnet mode; the site states it accepts privacy coins including Zcash. Cross-linked to <a href="https://claude.ai/privacy-tools/vpn-and-dvpn">VPNs and dVPNs</a>, which already covers Nym.</li>
<li><strong>Meile dVPN</strong>: dVPN client on the Sentinel network from MathNodes; its site advertises "Shielded ZEC Payments via BTCPay".</li>
</ul>
<p>Two of those needed a canonical URL rather than the obvious one: <code>nymvpn.com</code> returns 404 and <code>nymtech.net</code> 301s to <code>nym.com</code>, and <code>meile.app</code> 301s to the MathNodes project page. Both are linked at their final destination so the page does not ship a redirect chain.</p>
<h2>Scope: English page only, deliberately</h2>
<p>This page is curated (<code>translation/curated-pages.txt:58</code>) and has 18 translated copies carrying the same dead hosts. Those are <strong>not</strong> touched here, for a reason worth stating rather than leaving as an apparent omission:</p>
<p><code>NymVPN</code> is a protected term. Adding it to the English source while also touching a translation that does not contain it makes <code>check-protected-terms</code> classify the result as <code>introduced</code>; a hard failure; unless the four new entries are hand-translated into all 18 locales in the same PR. Leaving the translations alone instead changes the English source hash, marks all 18 pairs stale, and lets the sync pipeline re-translate the page with the link fixes included. That is the mechanism the pipeline exists for.</p>
<p>The expected consequence, disclosed up front so it is not mistaken for a regression: <code>check-protected-terms</code> reports 18 new <code>NymVPN</code> notices under "pre-existing violation(s) not caused by this change … 18 from English pages edited since a translation was last synced". Those are staleness, tracked on the dashboard, and the gate still exits 0.</p>
<h2>Verification</h2>
<p>All five gates run against the real commit on the branch, with <code>$BASE</code> = <code>upstream/main</code>:</p>
<pre><code>check-protected-terms --base $BASE   exit 0   passed for 3762 translated page(s)
gen-menu-titles --check              exit 0   manifests up to date (19 files)
check-invariants --base $BASE        exit 0   209 curated pages, 18 locales
check-frontmatter                    exit 0   parity holds for 3762 page(s)
node --test translation/lib/*        86 pass, 0 fail
</code></pre>
<p>Link health, scoped to this page after the change:</p>
<pre><code>findings on page: 16  (0 broken, 0 dns)
</code></pre>
<p>The 16 remaining are redirects (Instagram and Free2z canonicalisation, the <code>pin.it</code> shortlink, the per-page GitHub edit badge) plus one duplicate, <code>twitter.com/SheEmprende_</code>, which is now referenced from two places on the entry by design.</p>
<p>Every other external link on the page was checked with a browser user-agent and is live. Instagram returns 429 and Facebook occasionally 400 to command-line clients; control checks against <code>instagram.com/instagram</code> and <code>facebook.com/Meta</code> return the same codes, so those are systematic bot responses rather than dead pages, and <code>facebook.com/tecnopapapi</code> returns 200 on retry.</p>