### PR TITLE
Link a working TAZ faucet on Developer Resources

### DIFF
--- a/site/Start_Here/Developer_Resources.md
+++ b/site/Start_Here/Developer_Resources.md
@@ -78,7 +78,7 @@ Testnet is a separate chain with valueless coins, called TAZ. Both Zebra and Zak
 
 [testnet.zcashexplorer.app](https://testnet.zcashexplorer.app/) is a working testnet block explorer, with a mainnet counterpart at [mainnet.zcashexplorer.app](https://mainnet.zcashexplorer.app/).
 
-Getting TAZ is the awkward part. Public faucets appear and disappear, and the ones linked from older documentation were not responding when this page was written. The reliable route is to ask in the Zcash R&D Discord, which is what the Zcash documentation itself suggests.
+Getting TAZ is the awkward part, because the faucets linked from older documentation have stopped responding. [zcashfaucet.jinolabs.xyz](https://zcashfaucet.jinolabs.xyz) is a community-run faucet that runs "its own node, wallet and miner", pays "shielded z2z drips", and gates claims with "browser proof of work instead of a captcha vendor". It is open source under MIT. If it is unavailable, ask in the Zcash R&D Discord, which is what the Zcash documentation itself suggests.
 
 ## General documentation
 


### PR DESCRIPTION
Follow-up to #1992. That page said to ask in Discord for TAZ, because the faucets linked from the Zcash documentation have stopped responding. faucet.zecpages.com times out with port 443 filtered, and faucet.testnet.z.cash fails the TLS handshake.

There is a community faucet that does work, posted on the forum in August and still being maintained. It runs its own node, wallet and miner, and sends the drip as a shielded transaction rather than transparent, which is a nicer default for anyone testing shielded flows.

I checked it before linking rather than taking the forum post at its word. Its status endpoint reports the node synced at testnet height 4,325,417, a balance of 1804.9 TAZ and the miner running, and the page renders a working claim form. Source is MIT. Discord stays in the paragraph as the fallback for when it is down, since that is the failure mode this section already had once.
