### PR TITLE
Zcash Ecosystem Digest | September 5th

### DIFF
--- a/newsletter/Digest 09-05-2026.md
+++ b/newsletter/Digest 09-05-2026.md
@@ -1,0 +1,245 @@
+# Zcash Ecosystem Digest | September 5th
+
+ZEC crosses $1,000, the NU7 coinholder vote and ZCAP poll enter their final stretch before September 14, Zakura reports that 25-second blocks are ready for NU7, ZCG publishes its August 31 meeting minutes, Vizor signs a shielded ZEC transaction on a Ledger, ZEC Market ships non-custodial escrow, ZecHub explains the Dev Fund, and Zcash communities from Brazil to Ghana keep building.
+
+Curated by [Bekirerdem](https://github.com/Bekirerdem)
+
+## ZODL, Zcash Foundation & Shielded Labs 🛠️
+
+[Zcash can scale. Zcash must scale. Zcash will scale. - @zodl_app](https://x.com/zodl_app/status/2095923186650992717)
+
+[One week in: eligible ZEC holders can still cast their vote on the NU7 coinholder poll in Zodl until September 14 - @zodl_app](https://x.com/zodl_app/status/2094831904205725893)
+
+[Ledger support coming to Zodl - @zodl_app](https://x.com/zodl_app/status/2094786250385359053)
+
+[ZODL alpha status: live, external access pending - @zodl_app](https://x.com/zodl_app/status/2095592767925727232)
+
+[Zodl CFO Tony Margarit is the featured speaker on the Proof of Privacy educational Zcash Space hosted by @CQ_Elzz - @zodl_app](https://x.com/zodl_app/status/2095263922001449366)
+
+[Privacy is the principle. Zcash is the money. Zodl is how we make it usable - @zodl_app](https://x.com/zodl_app/status/2095907923595518062)
+
+[More ways to use ZEC onchain - @zodl_co](https://x.com/zodl_co/status/2094849130023584066)
+
+[The next two weeks matter for Zcash: the CLARITY Act could help protect crypto developers, self-custody and financial privacy in the U.S. - @zodl_co](https://x.com/zodl_co/status/2095171092025409991)
+
+[AI and vibe coding are unlocking amazing velocity: watch Zodl build a new foundation with the highest standards for privacy, security and safety - @jswihart](https://x.com/jswihart/status/2095370770784670201)
+
+[ZCAP members: don't forget to vote in the 'August ZCAP NU7' SIV poll. Voting closes Monday, September 14 at 19:00 UTC - @ZcashFoundation](https://x.com/ZcashFoundation/status/2095163782272024827)
+
+[The recording of this week's Zcash Arborist Call is live - @ZcashFoundation](https://x.com/ZcashFoundation/status/2095820849521553603)
+
+[Ship faster or ship safer? Why not both. Josh Swihart, Nate and alchemydc take on speed vs security at Zcon7 - @ZcashFoundation](https://x.com/ZcashFoundation/status/2094810638270771291)
+
+[The Cypherpunk Manifesto is 30+ years old and its ideas have never been more relevant: Frank Braun, Maxime Desalle and Za discuss - @ZcashFoundation](https://x.com/ZcashFoundation/status/2095518648936869931)
+
+[ZCAP Poll Now Open: NU7 (August 2026), runs until September 14 - @ZcashFoundation](https://forum.zcashcommunity.com/t/zcap-poll-now-open-nu7-august-2026/57223)
+
+[NU7 Coinholder Vote: eligible ZEC can vote until September 14, 2026 at 19:00 UTC - @ebfull](https://forum.zcashcommunity.com/t/nu7-coinholder-vote/56912)
+
+[The age of transparent digital money is ending. The age of private digital money has arrived - @ShieldedLabs](https://x.com/ShieldedLabs/status/2095844245995143569)
+
+[Zcash is definitely winning - @ShieldedLabs](https://x.com/ShieldedLabs/status/2095559712032886892)
+
+[Zcash is ready for 25-second blocks: Zakura stress-tested a large, distributed network of nodes in the most difficult network conditions - @ZakuraZcash](https://x.com/ZakuraZcash/status/2095106920835334441)
+
+[Zakura's recent improvements have already reduced orphan rates on Mainnet - @ZakuraZcash](https://x.com/ZakuraZcash/status/2095107256300003702)
+
+[Testing 25-Second Blocks for NU7: an 80-node Zakura stressnet across 11 regions measured a 3.43% orphan rate with full 2MB blocks - Zakura](https://zakura.com/engineering/25-second-block-time-update/)
+
+[Zakura takes network health seriously for the first time in Zcash's ~10 years of Mainnet: faster block propagation, lower orphan rates, proactive security updates - @ebfull](https://x.com/ebfull/status/2095109275668689268)
+
+[Lattice-based cryptography is having its own AI apocalypse moment, but Zcash's coinholder vote anticipated this and strengthened parameters for PIR - @ebfull](https://x.com/ebfull/status/2094174007578988564)
+
+[Zakura Common: open-source cryptography libraries with 14x faster proving, 21x faster hashing and 4-8x faster verification - @Shawn](https://forum.zcashcommunity.com/t/zakura-common/57247)
+
+[The Zcash Daily, September 3: Zakura Common cuts private transaction creation from 3+ seconds to under 200ms, ZCG minutes, NU7 poll has 11 days left - @ola_olu](https://forum.zcashcommunity.com/t/the-zcash-daily/57219/6)
+
+[The Zcash Daily, September 4: Community feature wishlist, Recoverify, Forkcast pre-proposal, ZCG minutes - @ola_olu](https://forum.zcashcommunity.com/t/the-zcash-daily/57219/9)
+
+[Zcash Arborist Call recordings: all 131 editions are available at openzcash.org - @michael2xl](https://x.com/michael2xl/status/2095932028478796255)
+
+---
+
+## Zcash Community Grants 🏛️
+
+[Zcash Community Grants Meeting Minutes 8/31/2026: WalletConnect integration, BTCPayServer GraphQL client, Pretty Good Policy, Hack-to-Dark Mumbai, Zcash Arabia and ZECsy approved; Zebra test audit, Rvess Pay, Halo2 verifier testing and SHPH rejected - @ZcashCommGrants](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-8-31-2026/57394)
+
+[Our latest meeting minutes for this week's grant approvals and rejections are readable on the Zcash forum - @ZcashCommGrants](https://x.com/ZcashCommGrants/status/2095251462926299477)
+
+[Hito hardware wallet successfully submits its first real Orchard-Ironwood Zcash transaction signed on a physical device - @ZcashCommGrants](https://x.com/ZcashCommGrants/status/2095119477679562759)
+
+[Zcashers in Amsterdam ready to teach you the benefits of shielded payments - @ZcashCommGrants](https://x.com/ZcashCommGrants/status/2095898462155931966)
+
+[ZCG meeting summary in Turkish: what was approved, what remains open and what was rejected on August 31 - @ZcashTR](https://x.com/ZcashTR/status/2095795967333175616)
+
+[SHPH applicant thanks ZCG for the honest feedback on scope and track record - @mori](https://forum.zcashcommunity.com/t/zcash-community-grants-meeting-minutes-8-31-2026/57394/3)
+
+[Grant application: Zcash SeedSigner, a DIY open source air-gapped signer for shielded ZEC - forum](https://forum.zcashcommunity.com/t/grant-application-zcash-seedsigner-a-diy-open-source-air-gapped-signer-for-shielded-zec/57381)
+
+[Grant application: ZEC Invoice Preflight, ZIP-321 validation for Zcash merchants - forum](https://forum.zcashcommunity.com/t/grant-application-zec-invoice-preflight-zip-321-validation-for-zcash-merchants/57378)
+
+[Grant proposal: Colosseum Hackathon Zcash Track, a dedicated Zcash track in the Crypto World's Fair online startup competition, September 14 to October 12 - @mattytay](https://forum.zcashcommunity.com/t/grant-proposal-colosseum-hackathon-zcash-track/57405)
+
+[Grant application: Security Audit of Zaino - forum](https://forum.zcashcommunity.com/t/grant-application-security-audit-of-zaino/57265)
+
+[Grant application: Zcash Privacy Literacy Lab Canada - forum](https://forum.zcashcommunity.com/t/grant-application-zcash-privacy-literacy-lab-canada/57256)
+
+[Grant application: Zcash World, Mumbai (Devcon 8 week) - forum](https://forum.zcashcommunity.com/t/grant-application-zcash-world-mumbai-devcon-8-week/57253)
+
+[Grant application: 0xramp, a non-custodial ZEC to local fiat ramp for emerging markets - forum](https://forum.zcashcommunity.com/t/grant-application-0xramp-non-custodial-zec-local-fiat-ramp-for-emerging-markets/57271)
+
+[Grant proposal: ZecBit, NFT infrastructure for Zcash Shielded Assets - forum](https://forum.zcashcommunity.com/t/grant-proposal-zecbit-nft-infrastructure-for-zcash-shielded-assets/57280)
+
+[Grant application: Zcash Arabia (August to December 2026), approved 3-2 with a discussion about image authenticity - forum](https://forum.zcashcommunity.com/t/grant-application-zcash-arabia-august-to-december-2026/57170)
+
+[Global Ambassador Elzz August 2026 Report - @elzz-ux](https://forum.zcashcommunity.com/t/global-ambassador-elzz-august-2026-report/57390)
+
+[Zcash East Africa (August to October 2026) - forum](https://forum.zcashcommunity.com/t/zcash-east-africa-august-october-2026/57226)
+
+[Zcash Global en Español 2026 - forum](https://forum.zcashcommunity.com/t/zcash-global-en-espanol-2026/53815)
+
+[Support ZcashSA - forum](https://forum.zcashcommunity.com/t/support-zcashsa/57133)
+
+[Closing the ZCG Vulnerability Bounty Program: discussion continues - forum](https://forum.zcashcommunity.com/t/closing-the-zcg-vulnerability-bounty-program/55855)
+
+[30 Day Review Period: Coinholder-Directed Retroactive Grants Program Q3, voting September 17 to 29 - forum](https://forum.zcashcommunity.com/t/30-day-review-period-coinholder-directed-retroactive-grants-program-q3/57056)
+
+[Zcash Dev Fund Guide 2026: how the 20% Dev Fund splits between ZCG, the Lockbox and the Coinholders Fund, and how the Q3 retroactive round pays - @ZecHub](https://x.com/ZecHub/status/2095908142844649846)
+
+---
+
+## Community Projects 🌐
+
+[Zcash Shielded News | Vol.34 - @ZecHub](https://x.com/ZecHub/status/2095208439177765302)
+
+[Public service announcement: several accounts are claiming to offer Zcash Shielded NFTs. ZSA is a proposed protocol and is not live on mainnet - @ZecHub](https://x.com/ZecHub/status/2095643711145193563)
+
+[The ZEC-powered peer-to-peer economy has arrived: ZEC Market, no custodians, direct settlement, 0% platform fees, shielded by default - @ZecHub](https://x.com/ZecHub/status/2094421137266479201)
+
+[ZEC Market launches non-custodial 2-of-3 escrow after a security review, with LiveZEC, Noir Wallet, Cake Wallet and 0xRamp as sponsors - forum](https://forum.zcashcommunity.com/t/zec-market-a-private-non-custodial-marketplace-built-on-zcash/57200)
+
+[Non-custodial escrow is live on ZEC Market: the first trade was completed on Zcash mainnet with a 2-of-3 shared wallet - @ruZCASH](https://x.com/ruZCASH/status/2095369324261241210)
+
+[ZecMarket: buy and sell goods and services with ZEC at 0% fees using your shielded wallet - @zcashesp1](https://x.com/zcashesp1/status/2095907490210721836)
+
+[The Zcash community in Kenya partners with KuvarSend to enable ZEC exchange across 8 African countries - @zcashesp1](https://x.com/zcashesp1/status/2095638215051170251)
+
+[Can Zcash be used for everyday commerce without the traditional system? Zcast live on building a ZEC economy - @ZcastEsp](https://x.com/ZcastEsp/status/2095564004210929960)
+
+[Zcash turns 10 this October: the 10th Birthday Short Film Festival, 3 to 5 minute films, 5 to 15 ZEC prize pool, deadline October 16 - @ZkAv_Club](https://x.com/ZkAv_Club/status/2094405171451236381)
+
+[Working on a festival entry? The complete Zcon playlist and Zk Av Club's Top 25 most important Zcon videos - @ZkAv_Club](https://x.com/ZkAv_Club/status/2094709899204710647)
+
+[Zcash 10th Birthday Short Film Festival, prize pool 5 to 15 ZEC - forum](https://forum.zcashcommunity.com/t/zcash-10th-birthday-short-film-festival-prize-pool-5-15-zec/57228)
+
+[We are 8k voices choosing privacy as a right, not an exception. The next block has already started - @zcashbrazil](https://x.com/zcashbrazil/status/2095660906227069080)
+
+[Zakura was born from Zebra's code but is not a version of it: same origin, distinct projects - @zcashbrazil](https://x.com/zcashbrazil/status/2095193719058075730)
+
+[Shielded Magazine #34: Zakura 1.3.0 and Common, Ztreamer indexer, Zaino 0.9.0, Ledger with Zodl, Konclave private vault, cbZEC on Base - Zcash Brasil](https://zcashbrazil.substack.com/p/shielded-magazine-34)
+
+[NU7: new stressnet results for 25-second block times on Zcash, explained in Turkish - @ZcashTR](https://x.com/ZcashTR/status/2095503121422205235)
+
+[Ztreamer v0.0.1: a new high-performance Zcash indexer built on Zakura that indexes the full Mainnet history in 92 seconds - @ZcashTR](https://x.com/ZcashTR/status/2095549290982654395)
+
+[Last month Zcash Nigeria pitched ZEC payments to a Lagos restaurant that said no. Today ZEC hits $1,000 - @ZcashNigeria](https://x.com/ZcashNigeria/status/2095833555955790202)
+
+[So happy to be alive to witness ZEC hit $1000 - @ZcashNigeria](https://x.com/ZcashNigeria/status/2095828199972204711)
+
+[ZEC has just crossed $1,000: a major milestone for everyone building, using and believing in financial privacy - @ZcashGH](https://x.com/ZcashGH/status/2095850300921770012)
+
+[Zcash Privacy Developers Residency: Module 1 task and class recording, residents build a simple blockchain with SHA-256 linked blocks - @ZcashGH](https://x.com/ZcashGH/status/2095302576396808283)
+
+[Zcash Privacy Developers Residency Maiden Edition - forum](https://forum.zcashcommunity.com/t/zcash-privacy-developers-residency-maiden-edition/57193)
+
+[HUGE - @genzcash](https://x.com/genzcash/status/2094748724438392926)
+
+[Vizor wallet signs and sends a shielded ZEC transaction using a Ledger device, and will be the first Zcash wallet on Ledger at launch - @ZcashArabia](https://x.com/ZcashArabia/status/2094898050216972737)
+
+[Zcash IND Live #06: real-world ZEC transactions, how shielded payments work in everyday use, September 6 at 5:00 PM - @ZcashIND](https://x.com/ZcashIND/status/2095123717647212744)
+
+[Zcash IND is running independent light client infrastructure: a live, wallet-usable node in Mumbai, fully open source, no client-IP logging - @ZcashIND](https://x.com/ZcashIND/status/2095814634691514786)
+
+[Ladies and gentlemen, we got it working: a shielded ZEC transaction signed on a Ledger - @vizorwallet](https://x.com/vizorwallet/status/2094747602139140393)
+
+[BREAKING: Vizor has signed a shielded ZEC transaction on a Ledger. Ledger support is finally coming to Zcash - @cypherpunk](https://x.com/cypherpunk/status/2094757969720217986)
+
+[50K TPS is coming to Zcash - @cypherpunk](https://x.com/cypherpunk/status/2095278576492749064)
+
+[Zainod 0.9.0 is now available: modular design, faster indexing, greater customization - @ZingoLabs](https://x.com/ZingoLabs/status/2094423000091066607)
+
+[What's behind a wallet built with Rust and React Native? Zingo strengthens communication between both layers through the FFI - @ZingoLabs](https://x.com/ZingoLabs/status/2095573516783439915)
+
+[No app fees, no KYC, self custody, on and off ramp in 3 steps - @noir_wallet](https://x.com/noir_wallet/status/2095647859253403937)
+
+[cbZEC is now live on Base and swappable with native ZEC on Noir through Rhea Finance's cross-chain front end - @noir_wallet](https://x.com/noir_wallet/status/2094917783926833423)
+
+[In 2026, you can do anything a CEX can do on DEX rails - @leodexio](https://x.com/leodexio/status/2095502934926594257)
+
+[This is Mane 1.1.0: your crypto, spendable anywhere - @leodexio](https://x.com/leodexio/status/2095887799261995175)
+
+[Welcome to everyone who joined the Cake Wallet family this month - @cakewallet](https://x.com/cakewallet/status/2094906262987382823)
+
+[227,000 ZEC now lives on other chains such as Base, Solana and NEAR. Worth knowing: wrapped ZEC is transparent - @cipherscan_app](https://x.com/cipherscan_app/status/2095465786039046265)
+
+[Zcash network mapping on CipherScan: 338 nodes in 38 countries, 83% Zebra and 17% Zakura - @cipherscan_app](https://x.com/cipherscan_app/status/2094803214558191842)
+
+[Difficulty rising - @dismad8](https://x.com/dismad8/status/2095607787669852165)
+
+[Wait, ZEC has its own OS!? - @Zcash](https://x.com/Zcash/status/2095611843960279499)
+
+[More ZEC nodes!? Welcome and thank you - @Zcash](https://x.com/Zcash/status/2095586977739633016)
+
+[Neeraj is angry, and rightly so: people are being harmed on a vast scale by stupid laws and regulations - @zooko](https://x.com/zooko/status/2095303797686038823)
+
+[This is like something out of Kafka - @zooko](https://x.com/zooko/status/2095606773579464768)
+
+[ZEC Real-World Use + Commercial Real Estate: a Chicago developer offers commercial space to ZEC builders and accepts rent partly in ZEC - @illinoizzzec](https://forum.zcashcommunity.com/t/zec-real-world-use-commercial-real-estate/57400)
+
+[Community feature wishlist: a thread to collect the features Zcashers want to see built - @strahncryptography](https://forum.zcashcommunity.com/t/community-feature-wishlist-a-thread/57267)
+
+[Lwd-mixnet-proxy: light-wallet gRPC over the Nym mixnet, measurements and fixes continue - @Joaco](https://forum.zcashcommunity.com/t/lwd-mixnet-proxy-light-wallet-grpc-over-the-nym-mixnet-and-what-three-days-of-measuring-it-found/57000)
+
+[Announcing Nodus: one place for Light API servers - forum](https://forum.zcashcommunity.com/t/announcing-nodus-one-place-for-light-api-servers/54878)
+
+[Zcash Club Querétaro-Mexico: advancing financial privacy in Mexico - forum](https://forum.zcashcommunity.com/t/zcash-club-queretaro-mexico-advancing-financial-privacy-in-mexico/55764)
+
+[Zcash for Venezuela - forum](https://forum.zcashcommunity.com/t/zcash-for-venezuela/56445)
+
+[Crosslink: Incentivized Feature Net - forum](https://forum.zcashcommunity.com/t/crosslink-incentivized-feature-net/55210)
+
+[ZecMoon is live: a moon-hunting game on the ZecMap map with weekly ZEC prizes - @Batuhan](https://forum.zcashcommunity.com/t/zecmoon-is-live/57252)
+
+[Migration from Orchard to Ironwood in Zcash wallets - forum](https://forum.zcashcommunity.com/t/migration-from-orchard-to-ironwood-in-zcash-wallets/56790)
+
+[Shielded Coinbase with Zebra - forum](https://forum.zcashcommunity.com/t/shielded-coinbase-with-zebra/54510)
+
+[Private money in the sky - forum](https://forum.zcashcommunity.com/t/private-money-in-the-sky/57402)
+
+[Astrea: Extending ZEC into the Agentic Economy - forum](https://forum.zcashcommunity.com/t/astrea-extending-zec-into-the-agentic-economy/57210)
+
+[ZecPad: a privacy-first bonding-curve launchpad for Zcash - forum](https://forum.zcashcommunity.com/t/zecpad-a-privacy-first-bonding-curve-launchpad-for-zcash/56029)
+
+[Suggestion: Zcash addresses on forum profiles - forum](https://forum.zcashcommunity.com/t/suggestion-zcash-addresses-on-forum-profiles/51525)
+
+[Zcash Engage Server - forum](https://forum.zcashcommunity.com/t/zcash-engage-server/55358)
+
+[ZecHub 2026 update - @squirrel](https://forum.zcashcommunity.com/t/zechub-2026/53686)
+
+---
+
+## Meme of the week 😊
+
+[Can't wait for Zcash to be 4 figures, posted hours before ZEC crossed $1,000 - @zodl_co](https://x.com/zodl_co/status/2095871048776331425)
+
+---
+
+## Jobs in the Ecosystem
+
+[Careers on ZODL](https://zodl.com/careers/)
+
+[ZecHub Bounties](https://bounties.zechub.wiki/)
+
+[ZKAV Club Opportunities](https://zkav.club/opportunities/)
+
+[zkSNARKs Grants](https://zksnarks.net/grants.html)


### PR DESCRIPTION
Zcash Ecosystem Digest for the week of August 31 – September 5, 2026.

- 112 links: 64 X posts, 41 forum threads, plus Zakura, Substack and jobs links
- Community Projects section: 58 links
- Sections follow the digest template: ZODL / Zcash Foundation / Shielded Labs, Zcash Community Grants, Community Projects, Meme of the week, Jobs
- Includes this week's posts from Zcash Foundation, ZODL, Shielded Labs, ZCG, Zakura, ZecHub, Zcast, Zcash Español, Zcash Brasil, Zcash Türkiye, Zcash Nigeria, Zcash Ghana, Zcash Arabia, Zcash IND, ruZcash, genzcash and ZKAV Club

Submission for the "Zcash Ecosystem Digest | September 5th Submission" bounty.
