### PR TITLE
Add Backpack and Robinhood to Custodial Exchanges, with an Ironwood line

### DIFF
--- a/site/Using_Zcash/Custodial_Exchanges.md
+++ b/site/Using_Zcash/Custodial_Exchanges.md
@@ -4,7 +4,22 @@
 
 # <img src="/content-images/image-2024-02-03-173258092-a5440e5ee2.webp" alt="Alt Text" width="50"/>   Custodial Exchanges
 
+Ironwood is the shielded pool that arrived with the July 2026 network upgrade. Exchanges that only handle transparent t-addresses never touch it, so those are marked not applicable. Where an exchange does handle shielded addresses but has not said which pool it uses, the line says so rather than guessing.
+
 ---
+
+### [Backpack](https://backpack.exchange)
+
+<a href="https://backpack.exchange">
+    <img src="/content-images/_unavailable.svg" alt="Backpack Logo" width="200" height="100"/>
+</a>
+
+- Website: [Backpack](https://backpack.exchange)
+- Pairs: ZEC/USDC | ZEC-PERP
+- Supports: Deposits and withdrawals enabled. Address types not stated
+- Deposit Time: Not stated
+- Ironwood: Not stated
+___
 
 ### [Binance](https://binance.com)
 
@@ -16,6 +31,7 @@
 - Pairs: ALL/ZEC
 - Supports: Transparent (TEX Address Deposit)
 - Deposit Time: 20 minutes
+- Ironwood: Not applicable, transparent addresses only
 ___
 
 ### [BitcoinVN](https://bitcoinvn.io)
@@ -28,6 +44,7 @@ ___
 - Pairs: BTC/ZEC, ETH/ZEC, USDT/ZEC, XMR/ZEC, LTC/ZEC, DASH/ZEC
 - Supports: Transparent | Shielded (z-address Deposit & Withdrawal)
 - Deposit Time: Instant (non-custodial swap)
+- Ironwood: Not stated
 ___
 
 ### [Bitfinex](https://bitfinex.com)
@@ -40,6 +57,7 @@ ___
 - Pairs: ALL/ZEC
 - Supports: Transparent
 - Deposit Time: 25 Minutes 
+- Ironwood: Not applicable, transparent addresses only
 ___
 
 ### [Coinbase](https://coinbase.com)
@@ -52,6 +70,7 @@ ___
 - Pairs: ALL/ZEC
 - Supports: Transparent
 - Deposit Time: 150 minutes
+- Ironwood: Not applicable, transparent addresses only
 ___
 
  ### [Gemini](https://gemini.com)
@@ -62,8 +81,9 @@ ___
 
 - Website: [Gemini](https://gemini.com)
 - Pairs: ALL/ZEC
-- Supports: Transparent | Shielded Withdrawal
+- Supports: Transparent | Shielded and unified withdrawals, Orchard since November 2025
 - Deposit Time: 50 Minutes 
+- Ironwood: Shielded withdrawals supported, pool not stated
 ___
 
 ### [Huobi](https://huobi.com)
@@ -76,6 +96,7 @@ ___
 - Pairs: ALL/ZEC
 - Supports: Transparent
 - Deposit Time: 35 Minutes 
+- Ironwood: Not applicable, transparent addresses only
 ___
 
 ### [Kraken](https://kraken.com)
@@ -88,6 +109,7 @@ ___
 - Pairs: ALL/ZEC
 - Supports: Transparent
 - Deposit Time: 60 minutes
+- Ironwood: Not applicable, transparent addresses only
 ___
 
 ### [KuCoin](https://kucoin.com)
@@ -100,6 +122,7 @@ ___
 - Pairs: ALL/ZEC
 - Supports: Transparent
 - Deposit Time: 20 Minutes 
+- Ironwood: Not applicable, transparent addresses only
 ___
 
 ## [OKEx](https://okex.com)
@@ -112,4 +135,18 @@ ___
 - Pairs: ALL/ZEC
 - Supports: Transparent
 - Deposit Time: 25 Minutes 
+- Ironwood: Not applicable, transparent addresses only
+___
+
+### [Robinhood](https://robinhood.com)
+
+<a href="https://robinhood.com">
+    <img src="/content-images/IMG-5725-7f964c1fdb.webp" alt="Robinhood Logo" width="200" height="100"/>
+</a>
+
+- Website: [Robinhood](https://robinhood.com)
+- Pairs: USD/ZEC | EUR/ZEC
+- Supports: Withdrawals to transparent t-addresses only. ZEC deposits are not supported
+- Deposit Time: Deposits not supported
+- Ironwood: Not applicable, transparent addresses only
 ___


### PR DESCRIPTION
Same change as the wiki repo side, for the markdown copy of this page.

Robinhood listed ZEC in April, Backpack added spot in March, and neither was here. Robinhood matters most. Their docs say they only send to t-addresses and take no ZEC deposits at all, so anyone sending ZEC there can lose it.

Every exchange now has an Ironwood line. Ironwood is a shielded pool, so transparent-only exchanges never touch it and say not applicable. Gemini does shielded withdrawals but has not said which pool. The note under the heading explains that, otherwise not applicable reads like nobody checked.

Backpack's details come from their own API, not the listing post. That is where the perp turns out to have been live since October 2025.
