### PR TITLE
docs: repair Free2Z guide resource links

### DIFF
--- a/site/guides/Free2z_Live.md
+++ b/site/guides/Free2z_Live.md
@@ -186,8 +186,8 @@ In conclusion, Free2z is a versatile platform for creators to showcase their abi
 [Free2z](https://free2z.cash/)  
 [Free2z documentation](https://free2z.cash/docs/)  
 [2Z Overview](https://free2z.cash/docs/2Zs/)  
-[Creating a profile](https://free2z.cash/docs/creators/creating-a-profile)  
-[What is Free2z Live?](https://free2z.cash/docs/creators/free2z-live)  
+[Creating a profile](https://free2z.cash/docs/for-creators/creating-a-profile/)  
+[What is Free2z Live?](https://free2z.cash/docs/for-creators/free2z-live/)  
 [Free2z for Supporters](https://free2z.cash/docs/category/for-supporters)
 
 ---


### PR DESCRIPTION
The “Creating a profile” and “What is Free2z Live?” resource links in the Free2Z guide return 404. Update them to the corresponding official pages under `/docs/for-creators/`, preserving their labels and formatting.

Addresses two links listed in #1923. On September 5, both original URLs returned HTTP 404; both replacements returned HTTP 200 with matching documentation titles. Verified that the diff contains only these two URL changes.

AI-assisted documentation maintenance.

Zcash unified receiving address:

`u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
