### PR TITLE
docs: repair reference and contents links

### DIFF
--- a/site/Research/ZK_Shielded_Asset_Platforms.md
+++ b/site/Research/ZK_Shielded_Asset_Platforms.md
@@ -85,7 +85,7 @@ For example, consider an NFT listing on Solana; its public state (e.g., price) i
 
 
 
-**[Dark.fi](https://dark.fi/)**: DarkFi is an anonymous L1 based on zero-knowledge, multi-party computation, and homomorphic encryption. Anonymous proof-of-stake ensures validators are hidden. DarkFi offers an anti-fragile environment to create and run anonymous apps - **Asset Swap**: Yes - [Whitepaper](https://darkrenaissance.github.io/darkfi/) - ![Darkfi.png](/content-images/0-auQOzkLMfYdoXlRy-b10ed91da5.webp)
+**[Dark.fi](https://dark.fi/)**: DarkFi is an anonymous L1 based on zero-knowledge, multi-party computation, and homomorphic encryption. Anonymous proof-of-stake ensures validators are hidden. DarkFi offers an anti-fragile environment to create and run anonymous apps - **Asset Swap**: Yes - [Documentation](https://dark.fi/book/) - ![Darkfi.png](/content-images/0-auQOzkLMfYdoXlRy-b10ed91da5.webp)
 ***
 
 

--- a/site/guides/Raspberry_Pi_4_Full_Node.md
+++ b/site/guides/Raspberry_Pi_4_Full_Node.md
@@ -150,7 +150,7 @@ Zebra and Zallet are generally lighter on CPU during setup than compiling zcashd
 
 ## Additional resources
 - [Zebra Book](https://zebra.zfnd.org) — official Zebra documentation
-- [Zallet Book](https://zcash.github.io/wallet) — official Zallet documentation
+- [Zallet Book](https://zcash.github.io/zallet/) — official Zallet documentation
 - [zcashd End-of-Support notice](https://z.cash/support/zcashd-deprecation)
 
 ---

--- a/site/guides/ShapeShift_Zcash.md
+++ b/site/guides/ShapeShift_Zcash.md
@@ -167,7 +167,7 @@ The ShapeShift and Zcash integration represents a meaningful step forward for pr
 
 [Zodl Wallet](https://zodl.com)
 
-[ShapeShift DAO Governance (FOX Token)](https://shapeshift.com/fox-token)
+[ShapeShift DAO Governance (FOX Token)](https://shapeshift.com/dao/fox-token)
 
 [Zcash Community Grants](https://zcashcommunitygrants.org/)
 

--- a/site/guides/Visualizing_the_Zcash_Network.md
+++ b/site/guides/Visualizing_the_Zcash_Network.md
@@ -28,7 +28,7 @@ Rust -> [https://rustup.rs/](https://rustup.rs/)
 jq -> [https://jqlang.github.io/jq/download/](https://jqlang.github.io/jq/download/)
 (for displaying json information in the terminal)
 
-curl -> [https://everything.curl.dev/get/linux](https://everything.curl.dev/get/linux)
+curl -> [https://everything.curl.dev/install/linux.html](https://everything.curl.dev/install/linux.html)
 (for querying the crawler RPC)
 
 npm (with nvm) -> [https://medium.com/@iam_vinojan/how-to-install-node-js-and-npm-using-node-version-manager-nvm-143165b16ce1](https://medium.com/@iam_vinojan/how-to-install-node-js-and-npm-using-node-version-manager-nvm-143165b16ce1)

--- a/site/zechubglobal/zcashbrasil/Glossary&Faq/BibliotecaZCash.md
+++ b/site/zechubglobal/zcashbrasil/Glossary&Faq/BibliotecaZCash.md
@@ -332,7 +332,7 @@ ___
 
 | | |
 |--------------|-----------|
-| **Youtube**: | [Canal da Fundação Zcash](https://www.youtube.com/channel/UCi01v05DNTUEC_eB0c9rpgQ) / [Canal ECC](https://www.youtube.com/c/ZcashCo) / [ZECHub](https://www .youtube.com/channel/UC3-KM00kjCUheRzO5cq3PAA) / [ZF A/V Club](https://www.youtube.com/@zfavclub) / [Zcash Media](https://www.youtube.com/@ ZcashMedia) |
+| **Youtube**: | [Canal da Fundação Zcash](https://www.youtube.com/channel/UCi01v05DNTUEC_eB0c9rpgQ) / [Canal ECC](https://www.youtube.com/c/ZcashCo) / [ZECHub](https://www.youtube.com/channel/UC3-KM00kjCUheRzO5cq3PAA) / [ZF A/V Club](https://www.youtube.com/@zfavclub) / [Zcash Media](https://www.youtube.com/@ZcashMedia) |
 | **Ywallet**: | Uma carteira móvel compatível com Ycash e Zcash - [website](https://ywallet.app) |
 
 

--- a/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md
+++ b/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md
@@ -53,13 +53,13 @@ Se você achar este guia útil, considere doar ZEC para apoiar a ZecHub:
 
 ## Conteúdo:
 
-* [Prepare the SD Card](https://github.com/ZecHub/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#prepare-the-sd-card)
-* [Servidor Boot Ubuntu](https://github.com/ZecHub/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#boot-ubuntu-server)
-* [Conecte-se remotamente ao seu Raspberry Pi 4](https://github.com/ZecHub/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#connect-remotely-to-your-raspberry-pi-4)
-* [Instale *zcashd*](https://github.com/ZecHub/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#installing-zcashd)
-* [Configuração * zcashd *](https://github.com/ZecHub/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#setup-zcashd)
-* [Usando * zcashd * ](https://github.com/ZecHub/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#using-zcashd)
-* [Fontes](https://github.com/ZecHub/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#sources)
+* [Prepare the SD Card](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md#prepare-o-cartão-sd)
+* [Servidor Boot Ubuntu](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md#boot-ubuntu-server)
+* [Conecte-se remotamente ao seu Raspberry Pi 4](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md#conecte-se-remotamente-ao-seu-raspberry-pi-4)
+* [Instale *zcashd*](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md#instalando-o-zcashd)
+* [Configuração * zcashd *](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md#configuração--zcashd)
+* [Usando * zcashd * ](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md#usando--zcashd)
+* [Fontes](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/guides/RaspberryPi4TutorialFullNode.md#fontes)
 
 ### Prepare o cartão SD
 

--- a/site/zechubglobal/zcashbrasil/mídiasocialzcash/boletinsinformativos.md
+++ b/site/zechubglobal/zcashbrasil/mídiasocialzcash/boletinsinformativos.md
@@ -22,4 +22,4 @@ Use este [modelo](https://github.com/ZecHub/zechub/blob/main/newsletter/newslet
 - https://zechubrazil.substack.com/
 
 
-*Se você gostaria de adicionar ou sugerir edições a esta página wiki, vá para o [ZecHub github repo](https://github.com/ZecHub/zechub/blob/main/notionsiteonly/zcashsocialmedia/zecweeklynewsletter.md ) e envie uma solicitação pull.*
+*Se você gostaria de adicionar ou sugerir edições a esta página wiki, vá para o [ZecHub github repo](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/m%C3%ADdiasocialzcash/boletinsinformativos.md ) e envie uma solicitação pull.*

--- a/site/zechubglobal/zcashbrasil/zec/ComprandoZec.md
+++ b/site/zechubglobal/zcashbrasil/zec/ComprandoZec.md
@@ -40,11 +40,11 @@ Ao fazer isso, recomendamos o uso de uma carteira [blindada](https://electriccoi
 
 Você também pode minerar ZEC, mas isso geralmente não é possível para consumidores comuns. Mais informações [aqui](https://www.genesis-mining.com/zcash-mining-guide).
 
-- Se você gostaria de adicionar ou sugerir edições a esta página wiki, vá para o [ZecHub](https://github.com/ZecHub/zechub/blob/main/site/usingzec/buyingzec.md) 
+- Se você gostaria de adicionar ou sugerir edições a esta página wiki, vá para o [ZecHub](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/zec/ComprandoZec.md)
 
 
 https://youtu.be/W2msuzrxr3s
 
 
-- [Repositório GitHub](https://github.com/ZecHub/zechub/blob/main/site/usingzec/buyingzec.md) e enviar um Pull Request.
+- [Repositório GitHub](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/zec/ComprandoZec.md) e enviar um Pull Request.
 

--- a/site/zechubglobal/zcashbrasil/zec/Memos.Trad.Pt.md
+++ b/site/zechubglobal/zcashbrasil/zec/Memos.Trad.Pt.md
@@ -38,5 +38,5 @@ Alguém descobriu que seu parceiro havia enviado um arquivo por meio de um memor
 
 - https://youtu.be/vSLmoOd_s_8
 
-Se você gostaria de adicionar ou sugerir edições a esta página wiki, vá para o [ZecHub](https://github.com/ZecHub/zechub/blob/main/site/usingzec/memos.md) [repositório github](https://github.com/ZecHub/zechub/blob/main/site/usingzec/memos.md) e enviar uma Pull Request.
+Se você gostaria de adicionar ou sugerir edições a esta página wiki, vá para o [ZecHub](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/zec/Memos.Trad.Pt.md) [repositório github](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/zec/Memos.Trad.Pt.md) e enviar uma Pull Request.
 

--- a/site/zechubglobal/zcashesp/guides/zcashnewuserguide.md
+++ b/site/zechubglobal/zcashesp/guides/zcashnewuserguide.md
@@ -16,7 +16,7 @@ Es importante destacar que no necesitas comprar 1 ZEC completo. ZEC es divisible
 
 Después de comprar ZEC, es posible que desees transferirlo a una billetera de Zcash. [Este artículo](https://www.ledger.com/academy/not-your-keys-not-your-coins-why-it-matters) explica por qué es importante tener ZEC en una billetera.
 
-Recomendamos usar una [billetera protegida](https://github.com/ZecHub/zechub/blob/main/usingzec/wallets/mobileshieldedwallets.md) porque estas billeteras proporcionan las [funciones de privacidad](https://www.gemini.com/prices/zcash) que hacen que ZEC sea único. Aquí hay un [video](https://www.youtube.com/watch?v=AefftLsENaU) sobre cómo descargar una billetera protegida. Aquí hay un [blog](https://zechub.substack.com/p/private-vs-transparent) que explica las diferencias entre los diferentes tipos de billeteras de Zcash.
+Recomendamos usar una [billetera protegida](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashesp/usandozec/wallets.md#billeteras-m%C3%B3viles-blindadas) porque estas billeteras proporcionan las [funciones de privacidad](https://www.gemini.com/prices/zcash) que hacen que ZEC sea único. Aquí hay un [video](https://www.youtube.com/watch?v=AefftLsENaU) sobre cómo descargar una billetera protegida. Aquí hay un [blog](https://zechub.substack.com/p/private-vs-transparent) que explica las diferencias entre los diferentes tipos de billeteras de Zcash.
 
 ---
 

--- a/site/zechubglobal/zcashesp/zcashsocialmedia/podcast.md
+++ b/site/zechubglobal/zcashesp/zcashsocialmedia/podcast.md
@@ -4,11 +4,11 @@
 
 [ZL;DR](https://github.com/ZecHub/zechub/blob/main/site/zcashsocialmedia/zldr.md)
 
-[The Z2Z Podcast](https://github.com/ZecHub/zechub/blob/main/site/zcashsocialmedia/thez2zpodcast.md)
+[The Z2Z Podcast](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashesp/zcashsocialmedia/thez2zpodcast.md)
 
-[The Zcash Podcast](https://github.com/ZecHub/zechub/blob/main/site/zcashsocialmedia/thezcashpodcast.md)
+[The Zcash Podcast](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashesp/zcashsocialmedia/thezcashpodcast.md)
 
-[The ZK Podcast](https://github.com/ZecHub/zechub/blob/main/site/zcashsocialmedia/zkpodcast.md)
+[The ZK Podcast](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashesp/zcashsocialmedia/zkpodcast.md)
 
-[PGP* For Crypto](https://github.com/ZecHub/zechub/blob/main/site/zcashsocialmedia/pgpforpodcast.md)
+[PGP* For Crypto](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashesp/zcashsocialmedia/pgpforpodcast.md)
 

--- a/site/zechubglobal/zcashfrance/newsletter/zecweekly44.md
+++ b/site/zechubglobal/zcashfrance/newsletter/zecweekly44.md
@@ -19,7 +19,7 @@ La newsletter de cette semaine nous plongera dans les derniers événements de l
 
 Cette semaine, nous verrons un système décentralisé qui peut être utilisé pour stocker et partager des fichiers sur Internet via un outil connu sous le nom de système de fichiers interplanétaires (IPF).Dans ce didacticiel, vous apprendrez également comment publier votre site Web sur IPFS pour activer un processus décentralisé complet sur votre site Web.
 
-Learn more about IPFS [here](https://wiki.zechub.xyz/zfav/guides/publish-a-site-on-ipfs) 
+Learn more about IPFS [here](https://github.com/ZecHub/zechub/blob/main/site/ZFAV_Club/Guides_for_Creators/Publish_Site_on_IPFS.md) 
 
 
 

--- a/site/zechubglobal/zcashitaly/Start_Here/zcashbasics.md
+++ b/site/zechubglobal/zcashitaly/Start_Here/zcashbasics.md
@@ -3,8 +3,8 @@
 ## Ecco alcune pagine che trattano di Zcash e ZEC:
 
 
-[Cos'è Zcash? E cos'è ZEC?](https://wiki.zechub.xyz/global/italiano/nozioni-di-base-su-zcash/le-basi-di-zcash)
+[Cos'è Zcash? E cos'è ZEC?](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/whatiszecandzcash.md)
 
-[Quali sono gli aspetti economici di Zcash?](https://wiki.zechub.xyz/global/italiano/nozioni-di-base-su-zcash/fondamenti-di-zcash)
+[Quali sono gli aspetti economici di Zcash?](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/zcashmonetarypolicy.md)
 
-[Quali sono i casi d'uso di ZEC?](https://wiki.zechub.xyz/global/italiano/nozioni-di-base-su-zcash/casi-duso-di-zec)
+[Quali sono i casi d'uso di ZEC?](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/zecusecases.md)

--- a/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md
+++ b/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md
@@ -35,13 +35,13 @@ Se trovi utile questa guida, considera di donare ZEC per sostenere ZecHub:
 
 
 ## Contenuti:
-* [Preparare la scheda SD](https://github.com/dismad/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#prepare-the-sd-card)
-* [Avviare Ubuntu Server](https://github.com/dismad/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#boot-ubuntu-server)
-* [Connettersi in remoto al proprio Raspberry Pi 4](https://github.com/dismad/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#connect-remotely-to-your-raspberry-pi-4)
-* [Installare *zcashd*](https://github.com/dismad/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#installing-zcashd)
-* [Inizializzare *zcashd*](https://github.com/dismad/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#setup-zcashd)
-* [Usare *zcashd*](https://github.com/dismad/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#using-zcashd)
-* [Fonti](https://github.com/dismad/zechub/blob/main/site/guides/RaspberryPi4FullNode.md#sources)
+* [Preparare la scheda SD](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md#prepara-la-scheda-sd)
+* [Avviare Ubuntu Server](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md#avvia-ubuntu-server)
+* [Connettersi in remoto al proprio Raspberry Pi 4](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md#collegarsi-in-remoto-al-proprio-raspberry-pi-4)
+* [Installare *zcashd*](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md#installazione-di-zcashd)
+* [Inizializzare *zcashd*](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md#configurazione-di-zcashd)
+* [Usare *zcashd*](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md#using-zcashd)
+* [Fonti](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashitaly/guides/Raspberry_pi_4_Full_Node.md#fonti)
 
 ### Prepara la scheda SD
 

--- a/site/zechubglobal/zcashitaly/guides/Visualizing_the_Zcash_Network.md
+++ b/site/zechubglobal/zcashitaly/guides/Visualizing_the_Zcash_Network.md
@@ -14,7 +14,7 @@ Rust [https://rustup.rs/](https://rustup.rs/)
 jq [https://jqlang.github.io/jq/download/](https://jqlang.github.io/jq/download/)
 (per visualizzare informazioni json nel terminale)
 
-curl [https://everything.curl.dev/get/linux](https://everything.curl.dev/get/linux)
+curl [https://everything.curl.dev/install/linux.html](https://everything.curl.dev/install/linux.html)
 (per interrogare il crawler RPC)
 
 npm (con nvm) [https://medium.com/@iam_vinojan/how-to-install-node-js-and-npm-using-node-version-manager-nvm-143165b16ce1](https://medium.com/@iam_vinojan/how-to-install-node-js-and-npm-using-node-version-manager-nvm-143165b16ce1)


### PR DESCRIPTION
Repair broken reference and contents links reported in #1923 so readers reach the matching current documentation.

- Update five official references, fourteen translated Raspberry Pi contents links, four Spanish podcast references, and five Portuguese source-edit links.
- Repair the Portuguese library's two malformed channel links so Markdown recognizes their destinations.
- Restore three Italian basics-index links to their corresponding Italian documents.
- Point the Spanish new-user guide's shielded-wallet phrase to the corresponding section in the existing Spanish introduction. This restores the category explanation, not the former product catalog.
- Restore the French ZecWeekly 44 IPFS guide reference to the matching article in this repository.

The change repairs 35 link occurrences across 15 files. Link labels, guide prose, headings, line endings and final-newline states are preserved, except that the displayed curl URLs follow their corrected destinations and the DarkFi book is labeled “Documentation.” One inherited trailing space is removed from an earlier changed line.

Validation:

- September 5: the earlier 13 missing base pages returned HTTP 404 and their replacements returned HTTP 200. All fourteen translated contents fragments matched GitHub's rendered heading permalinks.
- September 6: the four additional replacements returned HTTP 200. The old Spanish GitHub URL returned 404; the three old Italian URLs failed DNS resolution. The new destinations match the retained guide subjects and languages. The Spanish fragment was verified in GitHub's rendered HTML. This checks link identity and reachability, not the accuracy of all legacy financial or wallet-product statements on destination pages.
- September 7: the French newsletter's old wiki hostname returned DNS NXDOMAIN. The matching repository guide returned HTTP 200, and its title and introduction match the retained reference. Only that URL changes; its inherited trailing space is preserved.
- Exact byte comparisons confirm the intended URL changes and the earlier noted trailing-space removal. No new whitespace is introduced; the current diff check reports the French line's unchanged, pre-existing trailing space. The patch merges cleanly with the current main branch.
- A Markdown parser recognizes both repaired channel links and neither malformed original. ZecHub's homepage links its exact channel URL; Zcash Media's handle is supported by first-party YouTube metadata from two months ago and its channel appears in the community directory. Fresh HTTP 200 responses for those two YouTube destinations were not established.

Curated translation provenance remains with the existing sync workflow; these legacy localized files are outside that manifest.

AI-assisted documentation maintenance and review.

Zcash unified receiving address:

`u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
