### PR TITLE
fix: exit with error when --root directory does not exist

### DIFF
--- a/link-health/check-links.mjs
+++ b/link-health/check-links.mjs
@@ -289,6 +289,19 @@ const ACTIONS = {
 // ── main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
+  // === ADDED CHECK: verify that the root path exists and is a directory ===
+  try {
+    const rootStat = await stat(ROOT);
+    if (!rootStat.isDirectory()) {
+      console.error(`Error: The provided --root path "${ROOT}" is a file, not a directory.`);
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(`Error: The provided --root directory "${ROOT}" does not exist or cannot be accessed.`);
+    process.exit(1);
+  }
+  // ========================================================================
+
   const startedAt = new Date().toISOString();
 
   let allowlist = [];

--- a/link-health/check-links.test.mjs
+++ b/link-health/check-links.test.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { test } from "node:test";
+import assert from "node:assert";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const execAsync = promisify(exec);
+
+test("exits with nonzero code and clear error when --root does not exist", async () => {
+  // Create a unique name for a deliberately non-existent directory
+  const nonexistentDir = join(tmpdir(), `zechub-missing-content-${Date.now()}`);
+  
+  try {
+    await execAsync(`node link-health/check-links.mjs --offline --root ${nonexistentDir}`);
+    // If we reach this line, the process exited with code 0, which is an error
+    assert.fail("Expected the command to throw an error and exit with nonzero code");
+  } catch (err) {
+    // Verify that the exit code is not 0
+    assert.notEqual(err.code, 0, `Expected nonzero exit code, but got ${err.code}`);
+    
+    // Verify that the error message contains a clear description of the problem
+    assert.match(
+      err.stderr, 
+      /does not exist or cannot be accessed/i, 
+      "Expected clear error message in stderr"
+    );
+  }
+});
+
+test("exits with nonzero code when --root is a file, not a directory", async () => {
+  // Create a temporary file to test the reaction to a file path instead of a directory
+  const tempDir = await mkdtemp(join(tmpdir(), "zechub-test-"));
+  const tempFile = join(tempDir, "fake-root.txt");
+  await writeFile(tempFile, "test");
+
+  try {
+    await execAsync(`node link-health/check-links.mjs --offline --root ${tempFile}`);
+    assert.fail("Expected the command to throw an error for a file path");
+  } catch (err) {
+    assert.notEqual(err.code, 0, "Expected nonzero exit code for file path");
+    assert.match(err.stderr, /is a file, not a directory/i, "Expected 'not a directory' error message");
+  } finally {
+    // Clean up temporary files
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/translation/menu-titles/en.json
+++ b/translation/menu-titles/en.json
@@ -99,6 +99,7 @@
   "Zcash_Organizations/Obscura_Labs.md": "Obscura Labs",
   "Zcash_Organizations/Shielded_Labs.md": "Shielded Labs",
   "Zcash_Organizations/Sovright.md": "Sovright",
+  "Zcash_Organizations/Valar_Group.md": "Valar Group",
   "Zcash_Organizations/ZKAV.md": "ZKAV Club",
   "Zcash_Organizations/ZODL.md": "ZODL (Zcash Open Development Lab)",
   "Zcash_Organizations/Zcash_Community_Grants.md": "Zcash Community Grants",


### PR DESCRIPTION
This PR fixes the issue where running the link checker with a nonexistent --root exits successfully and reports no broken links. It now returns a nonzero exit code with a clear error and includes a regression test.
https://bounties.zechub.wiki/home?bounty=cmtocv24j000icvvkhlv7sici

- Add validation to check if the provided --root path exists and is a directory.
- Exit with code 1 and a clear error message to prevent generating empty clean reports.
- Add regression tests to verify the behavior for missing paths and file paths.

My Zcash address:
u1jn0vcvdaglq4cyuek7kh5pqmkyk4aph8lxnlyd4wq76alucwq5empshjkr0gfgs6k2xm7dg667zz7243s2gdczm6l863426a30v0gelz7aezv55zglf8vn3khqkvk0vlvj59nm3xn92sm9dhr9rrkstfss7uhze3tukw2eukzyy3gktz