### PR TITLE
docs: repair Yoruba ZecWeekly 46 release link

### DIFF
--- a/site/zechubglobal/zcashnigeria/zecweekly46.md
+++ b/site/zechubglobal/zcashnigeria/zecweekly46.md
@@ -34,7 +34,7 @@ Ka oju-iwe [yii](https://zechub.wiki/privacy-tools/tor-and-i2p)
 
 [Ifiweranṣẹ Buloogi - FROST Awọn ilọsiwaju isodipupo olona asakale](https://zfnd.org/speeding-up-frost-with-multi-scalar-multiplication/) 
 
-[Itusilẹ ZF 🦓 Zebra 1.0.0-rc.9 fun idanwo!](https://github.com/ZcashFoundation/zebra/releases/tag/1.0.0-rc.9) 
+[Itusilẹ ZF 🦓 Zebra 1.0.0-rc.9 fun idanwo!](https://github.com/ZcashFoundation/zebra/releases/tag/v1.0.0-rc.9)
 
 [IPade osososu egbe ZF A/V ti wa ninu fidio](https://free2z.com/ZFAVClub/zpage/podcasting-for-privacy-insights-from-zcash-foundation-audiovisual-club-april-2023) 
 


### PR DESCRIPTION
Correct the Zebra 1.0.0-rc.9 release link in the Yoruba ZecWeekly 46 archive. The old URL returns 404 because the actual release tag includes a `v` prefix; the replacement opens the same release named in the existing text. The translated wording is unchanged.

Validation: checked the old URL (404) and exact release page (200), confirmed the release title/tag, reviewed current competing contribution files, and passed `git diff --check`. Removed one existing trailing space on the changed line. No application build is needed for this link-only change.

AI assistance: prepared with Codex and reviewed by an independent AI reviewer.

Unified receiving address (same as my existing contributions):
u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq
