### PR TITLE
docs: repair ZODL GitHub references

### DIFF
--- a/site/Zcash_Organizations/ZODL.md
+++ b/site/Zcash_Organizations/ZODL.md
@@ -4,7 +4,7 @@
 
 # <img src="/content-images/198608b2-9059-4cb7-aeb8-9354971376fd-d67c2d46f5.webp" alt="ZODL Logo" width="50"/> ZODL (Zcash Open Development Lab)
 
-[Website](https://zodl.com/) - [GitHub](https://github.com/AgoraCyber) - [X/Twitter](https://x.com/zodl_app) - [Discord](https://discord.gg/zodl)
+[Website](https://zodl.com/) - [GitHub](https://github.com/zodl-inc) - [X/Twitter](https://x.com/zodl_app) - [Discord](https://discord.gg/zodl)
 
 ## Mission Statement
 
@@ -48,7 +48,7 @@ Zodl is a self-custodial mobile wallet designed for private Zcash transactions. 
 - [iOS (App Store)](https://apps.apple.com/app/zodl/id6444974742)
 - [Android (Play Store)](https://play.google.com/store/apps/details?id=co.electriccoin.zcash)
 - [F-Droid](https://f-droid.org/en/packages/co.electriccoin.zcash.foss/)
-- [GitHub](https://github.com/AgoraCyber)
+- [GitHub](https://github.com/zodl-inc)
 
 **Key Features:**
 


### PR DESCRIPTION
The ZODL page sends both GitHub links to `github.com/AgoraCyber`, which returns 404. Update those two occurrences to the organization listed by [Zodl’s official support page](https://support.zodl.com/article/14-how-do-i-obtain-support-for-zodl): `github.com/zodl-inc`.

Credit to DanielDerefaka, who previously noted this unfixed ZODL reference in #1931. That PR changed the separate ECC page; this patch changes only the two URLs in `site/Zcash_Organizations/ZODL.md`, preserving its labels, prose and formatting.

Validation on September 7, 2026:

- Normal GET: old organization URL 404; replacement organization and official support page 200.
- Replacement organization identifies itself as Zcash Open Development Lab (ZODL) and links to `zodl.com`.
- Exact byte comparison confirms only two URL substitutions; line endings and final newline are preserved. `git diff --check` passes.

AI-assisted documentation maintenance. Conservatively treating the repeated URL as one repaired reference under the current contributing guide’s conditional 0.005 ZEC rate; subject to maintainer acceptance. Curated translations and their provenance manifest are left to the existing staleness workflow.

Unified address for any accepted contribution tip:

`u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
