### PR TITLE
docs: repair Portuguese links in Zakura and ZECD guides

### DIFF
--- a/site/Zcash_Tech/ZECD.md
+++ b/site/Zcash_Tech/ZECD.md
@@ -4,7 +4,7 @@
 
 # ZECD — Shielded-First Wallet Server
 
-> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/zcashtech/zecd)
+> 🇧🇷 [Versão em Português](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/zcashtech/zecd.md)
 
 ZECD is a shielded-first wallet server for Zcash, built on [librustzcash](https://github.com/zcash/librustzcash) and exposed through Bitcoin Core's JSON-RPC dialect. It gives developers and payment integrators a familiar, Bitcoin-compatible API for interacting with Zcash — while making Orchard (the most private pool) the default. Developed by [zec.rocks](https://zec.rocks), ZECD is designed to replace `zcashd`'s wallet functionality in modern, cloud-native deployments.
 

--- a/site/Zcash_Tech/Zakura_Node.md
+++ b/site/Zcash_Tech/Zakura_Node.md
@@ -4,7 +4,7 @@
 
 # Zakura Node
 
-> 🇧🇷 [Versão em Português](/zechubglobal/zcashbrasil/zcashtech/zakura)
+> 🇧🇷 [Versão em Português](https://github.com/ZecHub/zechub/blob/main/site/zechubglobal/zcashbrasil/zcashtech/zakura.md)
 
 Zakura is a free, open-source full node implementation for Zcash, built for scale. Forked from [Zebra](Zebra_Full_Node.md) and developed through a collaboration between **Valar Group** and **Project Tachyon**, Zakura delivers dramatically faster synchronization, native block pruning, and a compatibility layer for legacy `zcashd` tooling. Version 1.0.0 was released on July 15, 2026.
 


### PR DESCRIPTION
The Portuguese-version links on the Zakura and ZECD guides point to wiki routes that do not resolve. Link directly to the existing Portuguese Markdown pages on GitHub so readers can reach the translations from either the wiki or the repository.

Addresses the two Portuguese-version entries in the link-health dashboard (#1923), without closing the dashboard issue.

Validation:

- Confirmed the case-transformed source paths used by the old routes return HTTP 404 on GitHub.
- Both replacement links return HTTP 200 and contain the corresponding Portuguese guide with its English-version backlink.
- `git diff --check` passes. Only the two link destinations change; prose, line endings, and translations are preserved.
- The offline checker was also run, but its filesystem lookup on this case-insensitive macOS checkout does not reproduce the case-sensitive route failures shown in the Linux dashboard; it is not used as proof of this fix.

AI-assisted documentation maintenance. Please consider these two repaired references under the current contributing guide's 0.005 ZEC per accepted broken-link fix rate, subject to review and eligibility. A payout Unified Address will be provided before any approved tip is sent.

Miroslav Strisko
