### PR TITLE
fix(link-health): resolve routes with case-sensitive paths

### DIFF
--- a/link-health/README.md
+++ b/link-health/README.md
@@ -34,6 +34,10 @@ app falls back on, so a link that works in production is not reported as broken.
 If the rules in the app's `src/lib/helpers.ts` change, update `transformUri` here
 to match.
 
+Path comparisons are case-sensitive on every operating system, matching the
+GitHub content paths used by the wiki. `--root` limits the pages scanned; links
+can still resolve to other pages under `site/`.
+
 Two things are deliberately not treated as broken routes:
 
 - Pages served by the app rather than by markdown, such as `/wallets` and
@@ -61,6 +65,9 @@ node link-health/check-links.mjs --concurrency 20   # more parallel requests
 ```
 
 Outputs `link-health.json` for machines and `link-health.md` for the issue body.
+
+Run the offline route regression tests with
+`node --test link-health/check-links.test.mjs`.
 
 The workflow runs on Mondays and can be started by hand from the Actions tab.
 Because a GitHub issue body is capped, the dashboard shows the first 40 rows per

--- a/link-health/check-links.mjs
+++ b/link-health/check-links.mjs
@@ -15,7 +15,6 @@
 //   --concurrency <n>   parallel external requests (default 12)
 
 import { readFile, writeFile, readdir, stat } from "node:fs/promises";
-import { existsSync } from "node:fs";
 import { join, dirname, basename, relative } from "node:path";
 
 // ── args ─────────────────────────────────────────────────────────────────────
@@ -202,7 +201,8 @@ function routeExists(route, mdFiles, appRoutes) {
   }
 
   const target = `site${transformUri(clean)}.md`;
-  if (existsSync(target)) return { ok: true, how: "exact" };
+  // GitHub content paths are case-sensitive even when this checkout is not.
+  if (mdFiles.includes(target)) return { ok: true, how: "exact" };
 
   // The app falls back to a loose match inside the same folder, so a report that
   // ignored this would flag links that actually resolve in production.
@@ -303,6 +303,8 @@ async function main() {
   const allowed = (url) => allowlist.some((p) => url.includes(p));
 
   const mdFiles = await walk(ROOT);
+  // --root limits which pages are scanned, not which site pages can be linked.
+  const routeFiles = ROOT === "site" ? mdFiles : await walk("site");
   const appRoutes = await loadAppRoutes(OFFLINE);
 
   // Assets live in the wiki app repo, so confirm them over the API when we can.
@@ -357,7 +359,7 @@ async function main() {
       }
 
       if (kind === "route") {
-        const r = routeExists(link.url, mdFiles, appRoutes);
+        const r = routeExists(link.url, routeFiles, appRoutes);
         if (!r.ok) findings.push({ kind: "route", url: link.url, file: link.file, line: link.line, detail: r.how });
         continue;
       }

--- a/link-health/check-links.mjs
+++ b/link-health/check-links.mjs
@@ -200,7 +200,7 @@ function routeExists(route, mdFiles, appRoutes) {
     return { ok: true, how: "app route" };
   }
 
-  const target = `site${transformUri(clean)}.md`;
+  const target = join("site", `${transformUri(clean)}.md`);
   // GitHub content paths are case-sensitive even when this checkout is not.
   if (mdFiles.includes(target)) return { ok: true, how: "exact" };
 

--- a/link-health/check-links.test.mjs
+++ b/link-health/check-links.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(new URL("./check-links.mjs", import.meta.url));
+
+async function scan(files, root = "site") {
+  const cwd = await mkdtemp(join(tmpdir(), "zechub-route-test-"));
+  try {
+    for (const [path, content] of Object.entries(files)) {
+      await mkdir(dirname(join(cwd, path)), { recursive: true });
+      await writeFile(join(cwd, path), content);
+    }
+    execFileSync(process.execPath, [script, "--offline", "--root", root], {
+      cwd,
+      timeout: 10000,
+      stdio: "pipe",
+    });
+    return JSON.parse(await readFile(join(cwd, "link-health.json"), "utf8"));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+test("wrong directory case is broken even on a case-insensitive filesystem", async () => {
+  const report = await scan({
+    "site/Index.md": "[Portuguese](/zechubglobal/zcashbrasil/zcashtech/zakura)",
+    "site/zechubglobal/zcashbrasil/zcashtech/zakura.md": "# Zakura",
+  });
+  assert.equal(report.totals.route, 1);
+  assert.equal(report.findings[0].url, "/zechubglobal/zcashbrasil/zcashtech/zakura");
+});
+
+test("exact routes and fuzzy filenames in the correct folder remain valid", async () => {
+  const report = await scan({
+    "site/Index.md": "[Exact](/zcash-tech/zaino)\n[Fuzzy](/zcash-tech/zecd)",
+    "site/Zcash_Tech/Zaino.md": "# Zaino",
+    "site/Zcash_Tech/ZECD_Server.md": "# ZECD",
+  });
+  assert.equal(report.totals.route, 0);
+});
+
+test("a narrowed scan can resolve exact and fuzzy routes elsewhere in site", async () => {
+  const report = await scan({
+    "site/guides/Guide.md": "[Exact](/zcash-tech/zaino)\n[Fuzzy](/zcash-tech/zecd)",
+    "site/Zcash_Tech/Zaino.md": "# Zaino",
+    "site/Zcash_Tech/ZECD_Server.md": "# ZECD",
+  }, "site/guides");
+  assert.equal(report.filesScanned, 1);
+  assert.equal(report.totals.route, 0);
+});
+
+test("missing routes remain broken and app-provided routes remain valid", async () => {
+  const report = await scan({
+    "site/Index.md": "[Missing](/zcash-tech/no-such-page)\n[Wallets](/wallets)",
+  });
+  assert.equal(report.totals.route, 1);
+  assert.equal(report.findings[0].url, "/zcash-tech/no-such-page");
+});

--- a/link-health/check-links.test.mjs
+++ b/link-health/check-links.test.mjs
@@ -39,7 +39,7 @@ test("exact routes and fuzzy filenames in the correct folder remain valid", asyn
   const report = await scan({
     "site/Index.md": "[Exact](/zcash-tech/zaino)\n[Fuzzy](/zcash-tech/zecd)",
     "site/Zcash_Tech/Zaino.md": "# Zaino",
-    "site/Zcash_Tech/ZECD_Server.md": "# ZECD",
+    "site/Zcash_Tech/Z_ECD.md": "# ZECD",
   });
   assert.equal(report.totals.route, 0);
 });
@@ -48,7 +48,7 @@ test("a narrowed scan can resolve exact and fuzzy routes elsewhere in site", asy
   const report = await scan({
     "site/guides/Guide.md": "[Exact](/zcash-tech/zaino)\n[Fuzzy](/zcash-tech/zecd)",
     "site/Zcash_Tech/Zaino.md": "# Zaino",
-    "site/Zcash_Tech/ZECD_Server.md": "# ZECD",
+    "site/Zcash_Tech/Z_ECD.md": "# ZECD",
   }, "site/guides");
   assert.equal(report.filesScanned, 1);
   assert.equal(report.totals.route, 0);


### PR DESCRIPTION
The route checker can miss broken links on a case-insensitive filesystem. For example, `/zechubglobal/zcashbrasil/zcashtech/zakura` resolves to a differently capitalized directory than the actual Portuguese content. `existsSync()` accepts that path on a default macOS filesystem, although GitHub's content endpoint returns 404.

This change compares the transformed target with the actual Markdown paths, making directory matching case-sensitive on every platform. The existing fuzzy filename fallback remains available within the correct folder. When `--root` narrows the pages scanned, route targets are still resolved across `site/`.

Validation:

- Reproduced the missed failure on macOS before the fix with an offline CLI regression test.
- `node --test link-health/check-links.test.mjs`: all four tests pass, covering wrong directory case, exact and fuzzy filenames, narrowed scans, missing routes, and app-provided routes.
- On the same 42-page local subset, the change adds exactly the two Portuguese route failures for Zakura and ZECD, with no removed findings. This was a subset comparison, not a complete repository link audit.
- Path handling was also checked with the actual resolver under `node:path.posix` and `node:path.win32`: exact and separator-normalized filenames resolve, while incorrect directory case is rejected. This is a path-semantics simulation, not a native Windows run.
- `git diff --check` passes.

AI assistance was used for implementation and automated verification. Please consider this contribution under the published approved-development contribution program and confirm eligibility and the applicable reward; no award is assumed. A public Zcash Unified Address can be supplied before any approved payout.

Miroslav Strisko

