### PR TITLE
docs: fix BIS CBDC research link

### DIFF
--- a/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -100,7 +100,7 @@ Financial inclusion, once a beacon of hope, faces the shadows of potential discr
 ## Resources: A Map for the Digital Explorer
 
 For those venturing into the uncharted territory of CBDCs, resources become your compass.
-1. The Bank for International Settlements ([BIS](https://www.bis.org/search/index.htm?globalset_q=cbdc))
+1. The Bank for International Settlements ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. the International Monetary Fund ([IMF](https://www.imf.org/en/About))
 3. Research papers ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
 4. Academic Journals ([journal](https://www.bis.org/publ/work976.pdf))


### PR DESCRIPTION
The CBDC article's BIS reference points to a retired search endpoint that returns HTTP 404. Update it to BIS's current search route and query parameter so readers reach research results for the same CBDC query. This repairs one reference reported in #1923.

Validation on September 8, 2026:

- Original URL returned HTTP 404; replacement returned HTTP 200.
- BIS's search form retains `cbdc` and displays relevant CBDC research results.
- Only one URL changes; an exact byte comparison and `git diff --check` pass.

AI assistance was used for this documentation fix and verification. Please consider the accepted fix for the [published 0.005 ZEC broken-link tip](https://github.com/ZecHub/zechub/blob/main/site/contribute/Contributing_Guide.md), subject to review and eligibility.

Public Zcash unified receiving address: `u1j8fglle8qwyx9esd0yy5hca9eusk975acnukpcu97r9tagw45jncpwawu4f2wrdxyjsxvws3nd75detwwnfsn7uj2lqj26zggqtjhvx8`
