### PR TITLE
Fix five Edit Page badges that link to files that do not exist

### DIFF
--- a/site/Research/Namada_Privacy_and_Best_Practices.md
+++ b/site/Research/Namada_Privacy_and_Best_Practices.md
@@ -2,7 +2,7 @@
 published: 2025-08-02
 ---
 
-<a href="https://github.com/Zechub/zechub/edit/main/site/Research/Namada_Best_Practices.md" target="_blank">
+<a href="https://github.com/Zechub/zechub/edit/main/site/Research/Namada_Privacy_and_Best_Practices.md" target="_blank">
   <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
 </a>
 

--- a/site/Using_Zcash/Zimppy.md
+++ b/site/Using_Zcash/Zimppy.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/zimppy.md" target="_blank">
+<a href="https://github.com/zechub/zechub/edit/main/site/Using_Zcash/Zimppy.md" target="_blank">
   <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
 </a>
 

--- a/site/Zcash_Organizations/Financial_Privacy_Foundation.md
+++ b/site/Zcash_Organizations/Financial_Privacy_Foundation.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Organizations/Financial Privacy Foundation.md" target="_blank">
+<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Organizations/Financial_Privacy_Foundation.md" target="_blank">
   <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
 </a>
 

--- a/site/contribute/Community_Infrastructure.md
+++ b/site/contribute/Community_Infrastructure.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/zechub/zechub/edit/main/site/contribute/Community_Infrastructure" target="_blank">
+<a href="https://github.com/zechub/zechub/edit/main/site/contribute/Community_Infrastructure.md" target="_blank">
   <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
 </a>
 

--- a/site/guides/Verifying_Zcash_Releases.md
+++ b/site/guides/Verifying_Zcash_Releases.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/zechub/zechub/edit/main/site/Zcash_Community/Verifying_Zcash_Releases.md" target="_blank">
+<a href="https://github.com/zechub/zechub/edit/main/site/guides/Verifying_Zcash_Releases.md" target="_blank">
   <img src="https://img.shields.io/badge/Edit-blue" alt="Edit Page"/>
 </a>
 


### PR DESCRIPTION
The Edit badge at the top of an article is how a reader is invited to fix it. On
five pages it linked to a path that returns 404, so the invitation dead-ended.

Each failed a different way, which is what you would expect from hand-copied
badges drifting from their pages:

| Page | Badge pointed at | Problem |
|---|---|---|
| `site/Research/Namada_Privacy_and_Best_Practices.md` | `Namada_Best_Practices.md` | page renamed, badge not updated |
| `site/Using_Zcash/Zimppy.md` | `Using_Zcash/zimppy.md` | lowercase filename; GitHub paths are case-sensitive |
| `site/Zcash_Organizations/Financial_Privacy_Foundation.md` | `Financial Privacy Foundation.md` | literal spaces instead of underscores |
| `site/contribute/Community_Infrastructure.md` | `Community_Infrastructure` | missing `.md` extension |
| `site/guides/Verifying_Zcash_Releases.md` | `Zcash_Community/Verifying_Zcash_Releases.md` | wrong directory; the page lives under `guides/` |

Each badge now points at its own file. All five destinations confirmed 200 on
raw.githubusercontent.com, and each of the five old targets confirmed 404, on
9 September 2026.

Only the badge URL changed on each page; no prose was touched. Two of the five
edits are byte-neutral, since `zimppy.md` to `Zimppy.md` and spaces to
underscores are the same length.

Scope note: 83 of the 209 English pages carry no Edit badge at all. That is a
separate question about how badges are rendered and is deliberately not addressed
here.
