### PR TITLE
Fix six broken Quick Navigation anchors on the FAQ page

### DIFF
--- a/site/Glossary_and_FAQs/FAQ.md
+++ b/site/Glossary_and_FAQs/FAQ.md
@@ -3,7 +3,7 @@
 A list of the most common questions about Zcash. For troubleshooting the Zcash client, please see the [official troubleshooting guide](https://zcash.readthedocs.io/en/latest/rtd_pages/troubleshooting_guide.html).
 
 ### Quick Navigation
-[What is Zcash?](#what-is-zcash) | [How to acquire Zcash?](#acquire) | [Difference from other cryptocurrencies?](#difference) | [Protocol governance?](#governance) | [Where is my transaction?](#transaction) | [Is Zcash really private?](#privacy) | [Common Misconceptions](#misconceptions)
+[What is Zcash?](#what-is-zcash) | [How to acquire Zcash?](#how-can-i-acquire-zcash) | [Difference from other cryptocurrencies?](#what-is-the-difference-between-zcash-and-other-cryptocurrencies) | [Protocol governance?](#how-is-the-zcash-protocol-governed) | [Where is my transaction?](#where-is-my-transaction) | [Is Zcash really private?](#is-zcash-really-private) | [Common Misconceptions](#a-few-common-misconceptions)
 
 ---
 


### PR DESCRIPTION
`site/Glossary_and_FAQs/FAQ.md` line 6 is the Quick Navigation bar, the first thing on the page. It has seven links and six of them went nowhere.

The renderer builds heading ids with `slugify()` in `src/components/MdxComponents/MdxComponent.tsx`, from the full heading text, and it normalises the href through the same function. The short fragments therefore could not resolve:

| Was | Now | Heading it reaches |
|---|---|---|
| `#acquire` | `#how-can-i-acquire-zcash` | How can I acquire Zcash? |
| `#difference` | `#what-is-the-difference-between-zcash-and-other-cryptocurrencies` | What is the difference between Zcash and other cryptocurrencies? |
| `#governance` | `#how-is-the-zcash-protocol-governed` | How is the Zcash protocol governed? |
| `#transaction` | `#where-is-my-transaction` | Where is my Transaction? |
| `#privacy` | `#is-zcash-really-private` | Is Zcash really Private? |
| `#misconceptions` | `#a-few-common-misconceptions` | A few common misconceptions |

`#what-is-zcash` already matched and is unchanged.

I chose to correct the links rather than add explicit ids to the headings, so the page keeps generating its own anchors and cannot drift again if a heading is reworded — the link and the heading stay derived from the same text.

Verified by re-running the site's own `slugify()` over the edited file: seven anchors, zero unresolved. Only line 6 changed.

For context, I checked every same-page anchor across all 209 English pages — 88 in total — and these six were the only broken ones, so this is the complete set rather than a sample.
