### PR TITLE
Repoint OKEx to OKX; okex.com no longer resolves

### DIFF
--- a/site/Using_Zcash/Custodial_Exchanges.md
+++ b/site/Using_Zcash/Custodial_Exchanges.md
@@ -102,13 +102,13 @@ ___
 - Deposit Time: 20 Minutes 
 ___
 
-## [OKEx](https://okex.com)
+## [OKX (formerly OKEx)](https://www.okx.com)
 
-<a href="https://okex.com">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/8/89/Official_logo_of_OKEx.png" alt="OKEx Logo" width="200" height="100"/>
+<a href="https://www.okx.com">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/8/89/Official_logo_of_OKEx.png" alt="OKX logo (shown under its former OKEx branding)" width="200" height="100"/>
 </a>
 
-- Website: [OKEx](https://okex.com)
+- Website: [OKX](https://www.okx.com)
 - Pairs: ALL/ZEC
 - Supports: Transparent
 - Deposit Time: 25 Minutes 


### PR DESCRIPTION
`site/Using_Zcash/Custodial_Exchanges.md` linked `okex.com` three times — the section heading (line 105), the logo link (line 107) and the website row (line 111). The exchange rebranded to OKX and `okex.com` now returns NXDOMAIN. `okx.com` resolves.

All three now point at `https://www.okx.com`. The section is titled **OKX (formerly OKEx)**, matching how this wiki already handles a rebrand elsewhere with "HTX (former Huobi)", so anyone searching for the old name still finds the entry.

Also confirmed the listing still holds. ZEC is listed and actively trading on their EU regional site, with ZEC/USD and ZEC/EUR spot pairs both showing live order-book depth, a ZEC USD perpetual future, and further pairs. Not delisted, so "Pairs: ALL/ZEC" stands

**The logo is still the old OKEx mark.** The image at `upload.wikimedia.org/.../Official_logo_of_OKEx.png` still returns 200, and I found no equivalent OKX logo on Wikimedia Commons, so I kept the working image and made the alt text say what it actually shows. Swapping it needs a source for the new mark.