### PR TITLE
Remove the dead testnet.zecfaucet.com entry from the faucet pages

### DIFF
--- a/site/Using_Zcash/Faucets.md
+++ b/site/Using_Zcash/Faucets.md
@@ -11,8 +11,6 @@ Faucets are services that dispense small amounts of cryptocurrency for free. The
 
 Mainnet: <a href="https://zecfaucet.com">zecfaucet</a>
 
-Testnet: <a href="https://testnet.zecfaucet.com">testnet.zecaucet.com</a>
-
 Testnet: <a href="https://fauzec.com/">fauzec.com</a>
 
 Testnet: <a href="https://zcashfaucet.jinolabs.xyz/">zcashfaucet.jinolabs.xyz</a>

--- a/site/Using_Zcash/Testnet.md
+++ b/site/Using_Zcash/Testnet.md
@@ -130,7 +130,7 @@ A **faucet** is a service that gives free TAZ coins for testing:
 - Avoids the need to mine TAZ manually  
 
 **Example:**  
-1. Visit a Testnet faucet (e.g., [testnet.zecfaucet.com](https://testnet.zecfaucet.com) | [fauzec.com](https://fauzec.com/))  
+1. Visit a Testnet faucet (e.g., [fauzec.com](https://fauzec.com/) | [zcashfaucet.jinolabs.xyz](https://zcashfaucet.jinolabs.xyz/))  
 2. Enter your Testnet address  
 3. Request TAZ  
 4. Receive TAZ instantly to start testing  


### PR DESCRIPTION
`testnet.zecfaucet.com` returns NXDOMAIN confirmed again on 9 September 2026.

It appeared twice:

- `site/Using_Zcash/Faucets.md` line 14, listed as a testnet faucet. The link
  text also read `testnet.zecaucet.com`, missing the f, so the visible name had
  never matched the destination either. Entry removed.
- `site/Using_Zcash/Testnet.md` line 133, given as the **first** suggestion in
  the worked example for getting TAZ. Replaced with the two faucets that work.

I removed the entry rather than repointing it, because there is nothing to repoint to — the host is gone, not moved, and guessing at a successor would be worse than the honest shorter list.

The remaining faucets were all confirmed 200 the same day: `fauzec.com` and `zcashfaucet.jinolabs.xyz` for testnet, and `zecfaucet.com` for mainnet. The Faucets page still lists two working testnet options, and the Testnet example now names both of them instead of one dead host and one live one.
