### PR TITLE
Drop two dead links on the Maya Protocol and Community Blogs pages

### DIFF
--- a/site/Zcash_Community/Community_Blogs.md
+++ b/site/Zcash_Community/Community_Blogs.md
@@ -15,7 +15,7 @@ Here are some of the active ones:
 | Thumbs' Update             | Regular ecosystem updates and insights                   | [Visit ->](https://thumbsup.substack.com) |
 | roomatemusing              | Musings and community content                            | [Visit ->](https://free2z.cash/roommatemusing) |
 | NerdBank Blog              | Technical blog focused on Zcash development and tools    | [Visit ->](https://blog.nerdbank.net/) |
-| Thor Likes                 | News, opinions, and commentary on Zcash                  | [Visit ->](https://www.thorlikes.com/) |
+| Thor Likes                 | News, opinions, and commentary on Zcash                  | No longer online |
 | ZecMec                     | Zcash-focused articles on Medium                         | [Visit ->](https://zecmec21.medium.com/) |
 | Ian Sagstetter             | In-depth articles and newsletter                         | [Visit ->](https://iansagstetter.substack.com/) |
 | Naomi Brockwell (NBTV)     | High-profile interviews and content on privacy           | [Visit ->](https://naomibrockwell.com/highprofileinterviews) |

--- a/site/guides/Maya_Protocol.md
+++ b/site/guides/Maya_Protocol.md
@@ -73,7 +73,7 @@ Here's a list with some of the services already supporting Maya:
 
 [Asgardex](https://www.asgardex.com/): Keystore, Ledger
 
-[DefiSpot](https://www.defispot.com/t): XDEFI, Metamask, Keplr, Phantom, Walletconnect, Leap Wallet, Argeentx, Braavos, Trustwallet, and Rabby.
+DefiSpot: no longer online, its domain does not resolve.
 
 [XDEFI](https://www.xdefi.io/): a multi-ecosystem self-custody wallet with support for 30+ native blockchains, and all EVM and Cosmos chains, including Bitcoin, Ethereum, Solana, THORChain, Maya Protocol, TRON, and more.
 


### PR DESCRIPTION
**`site/guides/Maya_Protocol.md` line 76** listed DefiSpot as a swap front end, linking `https://www.defispot.com/t`. The trailing `/t` was a stray character on top of the dead host. The entry now reads as plain text noting the site is gone.
I dropped the trailing wallet list with it — it described how to connect to a service that no longer exists, so keeping it would imply the route still works.

**`site/Zcash_Community/Community_Blogs.md` line 18** listed Thor Likes in the blogs table with a "Visit ->" link to `https://www.thorlikes.com/`. The row is kept with the link cell replaced by "No longer online", so the table still
records that the blog existed rather than silently losing a community member's entry.

Neither host has an obvious successor, so nothing is repointed. Every other host on both pages resolves, which is what makes this ordinary rot rather than a site that moved.
