### PR TITLE
Repoint the BTCPay public lightwalletd example at zec.rocks

### DIFF
--- a/site/guides/BTCPayServer_Zcash_Plugin.md
+++ b/site/guides/BTCPayServer_Zcash_Plugin.md
@@ -441,7 +441,7 @@ Add the following line, replacing the URL with your chosen endpoint:
 
 You can use:
 
-* A **public node**, such as `https://lightwalletd.zcash-infra.com`
+* A **public node**, such as `https://zec.rocks:443`
 * Your own self-hosted node, deployed separately from BTCPay Server
 
 > If the external `lightwalletd` becomes unavailable or overloaded, shielded payments will fail.


### PR DESCRIPTION
`site/guides/BTCPayServer_Zcash_Plugin.md` line 444 offered merchants a public lightwalletd node at `https://lightwalletd.zcash-infra.com`. That host returns NXDOMAIN

The page states the consequence itself three lines later:

> If the external `lightwalletd` becomes unavailable or overloaded, shielded
> payments will fail.

So a merchant following the recommendation was pointing a payment processor at a host that is not there.

The replacement was already on the page. Line 448 calls `zec.rocks` "the default" and a "stable and proven endpoint", and line 385 uses `https://zec.rocks:443` in a working config example. Line 444 now offers the same endpoint, so the guide is internally consistent. `zec.rocks` resolves and returns 200.

I used the `:443` form to match line 385 exactly, since that is the value a reader would copy into `ZCASH_LIGHTWALLETD=`.

Worth noting: a bare `zec.rocks` endpoint is correct here but would not be in a browser. BTCPay Server connects server-side over gRPC, whereas a browser needs a gRPC-web proxy. Same service, different requirement.
