### PR TITLE
i18n: curate Valar_Group and Project_Tachyon for translation

### DIFF
--- a/translation/curated-pages.txt
+++ b/translation/curated-pages.txt
@@ -96,6 +96,7 @@ Zcash_Organizations/Financial_Privacy_Foundation.md
 Zcash_Organizations/Obscura_Labs.md
 Zcash_Organizations/Shielded_Labs.md
 Zcash_Organizations/Sovright.md
+Zcash_Organizations/Valar_Group.md
 Zcash_Organizations/ZKAV.md
 Zcash_Organizations/ZODL.md
 Zcash_Organizations/Zcash_Community_Grants.md
@@ -133,6 +134,7 @@ Zcash_Tech/Overwinter.md
 Zcash_Tech/Pepper_Sync.md
 Zcash_Tech/Post_Quantum_Security.md
 Zcash_Tech/Private_Information_Retrieval.md
+Zcash_Tech/Project_Tachyon.md
 Zcash_Tech/Sapling.md
 Zcash_Tech/Sprout.md
 Zcash_Tech/The_Turnstile.md


### PR DESCRIPTION
Two English pages have never been translated in any locale, so they fall outside the staleness numbers entirely — the detector only measures pages someone has decided to translate. This curates them:

- `Zcash_Organizations/Valar_Group.md`
- `Zcash_Tech/Project_Tachyon.md`

That makes them show up as `missing` (2 pages × 18 locales = 36 units). The sync tooling reserves part of every window's page cap for missing pages, so they get picked up rather than queueing behind the stale backlog.

**One file changed, no manifest edit** — so this does not conflict with an open sync PR and can merge in any order relative to one.