### PR TITLE
Lowercase 'ledger' in the Project Tachyon glossary

### DIFF
--- a/site/Zcash_Tech/Project_Tachyon.md
+++ b/site/Zcash_Tech/Project_Tachyon.md
@@ -101,7 +101,7 @@ Related work is already visible. [Zakura](https://zechub.wiki/zcash-tech/zakura-
 | Oblivious synchronization | Fetching the chain data a wallet needs without revealing which data was requested |
 | Proof-carrying data (PCD) | Data that travels with a proof of its own correctness, so proofs can be combined and compressed |
 | Shielded transaction aggregate | Tachyon's way of bundling shielded state changes, changing how they are communicated and signed |
-| Ledger indistinguishability | The property that shielded transactions cannot be told apart from one another |
+| ledger indistinguishability | The property that shielded transactions cannot be told apart from one another |
 
 <br/>
 


### PR DESCRIPTION
One character, but it currently blocks this page from being translated into 12 of the 18 locales.

## What happens

`translation/protected-terms.json` lists **`Ledger`** under `preserveVerbatim` — the hardware wallet brand, which must survive translation intact. It appears on five other pages, always as the brand (`ledger.com`, wallet lists in `Maya_Protocol.md`, "Hardware wallets integration of Ledger").

The match is case-sensitive and word-bounded, which is how the vocabulary distinguishes the brand from the ordinary noun: the lowercase common words live in `glossaryOnly` (`token`, `chain`, `faucet`, `mining`, …) and are not enforced.

In this page's glossary table the word is capitalised only because it is first in the cell:

```
| Ledger indistinguishability | The property that shielded transactions cannot be told apart from one another |
```

So the checker demands the literal string `Ledger` in every translation. Any translator that renders "ledger indistinguishability" in the target language — which is the correct thing to do, since this is a property name from the Zerocash literature and not a brand — fails the gate and the whole page is rejected for that locale.

## Evidence

An automated run on 2026-09-09 translated this page into 18 locales. It failed in exactly the 12 that translate competently (ar, de, es, fr, it, ja, ko, pt, ru, tr, uk, zh) and passed in the 6 weakest — where the term head was left in English untouched. Reproduced directly against the shipped Hindi file:

```
$ check_terms.py Project_Tachyon.md hi/…/Project_Tachyon.md protected-terms.json
   (exit 0 — the row head is still English)

$ # same file, that one row head translated
   missing:Ledger
   (exit 1)
```

## The change

Lowercase the `L`. The brand stays protected everywhere it is actually meant — nothing is removed from `preserveVerbatim` — and the common noun stops being mistaken for it.

`ledger indistinguishability` is also how the term is conventionally written in the literature.

This re-stales the page for all locales, which is intended: the 12 blocked locales can then be translated for the first time.