### PR TITLE
i18n: restore the wallet brand names on Wallets.md (5 machine locales)

### DIFF
--- a/translation/menu-titles/ig.json
+++ b/translation/menu-titles/ig.json
@@ -58,7 +58,7 @@
   "Using_Zcash/Testnet.md": "Zcash Testnet",
   "Using_Zcash/Transactions.md": "Ihe ndị e mere eme",
   "Using_Zcash/Transparent_Exchange_Addresses.md": "Gịnị Bụ Adreesị Zcash TEX?",
-  "Using_Zcash/Wallets.md": "ZODL (n'asụsụ Bekee)",
+  "Using_Zcash/Wallets.md": "ZODL",
   "Using_Zcash/Zallet_Quick_Reference_Guide.md": "Akwụkwọ Ntuziaka Ọsọ Zallet",
   "Using_Zcash/Zcash_Mining_Guide.md": "Zcash Mining Guide: Ịbanye na Ngwuputa Ọdụdọ Na Ngwaọrụ Onwe Onye",
   "Using_Zcash/Zcash_Mining_Pools.md": "Zcash Mining Pools (Otu ndị na-egwu ego)",

--- a/translation/menu-titles/yo.json
+++ b/translation/menu-titles/yo.json
@@ -58,7 +58,7 @@
   "Using_Zcash/Testnet.md": "Ìdánwò Zcash",
   "Using_Zcash/Transactions.md": "Àwọn Àdéhùn Ìṣirò",
   "Using_Zcash/Transparent_Exchange_Addresses.md": "Kí Ni Àwọn Adirẹsi Zcash TEX?",
-  "Using_Zcash/Wallets.md": "ZODL (ì í ì ë ¤)",
+  "Using_Zcash/Wallets.md": "ZODL",
   "Using_Zcash/Zallet_Quick_Reference_Guide.md": "Ìwé Ìtọ́sọ́nà Rírìndìn Nípa Zallet",
   "Using_Zcash/Zcash_Mining_Guide.md": "Itọsọna Iwakọ-owo Zcash: Ṣiṣẹpọ Apapo iwakọ pẹlu Ẹrọ ti ara ẹni",
   "Using_Zcash/Zcash_Mining_Pools.md": "Àwọn Ìpínlẹ̀ Iwakùsà Zcash",

--- a/translation/sync-state.json
+++ b/translation/sync-state.json
@@ -485,7 +485,7 @@
       "src_commit": "4278910bf8dd3f4ccc522204674bebe2839d960b",
       "engine": "gt",
       "mode": "full",
-      "tool": "gt-static",
+      "tool": "gt-static+brand-restore",
       "edited": false
     },
     "Using_Zcash/Zallet_Quick_Reference_Guide.md": {
@@ -5507,7 +5507,7 @@
       "src_commit": "4278910bf8dd3f4ccc522204674bebe2839d960b",
       "engine": "gt",
       "mode": "full",
-      "tool": "gt-static",
+      "tool": "gt-static+brand-restore",
       "edited": false
     },
     "Using_Zcash/Zallet_Quick_Reference_Guide.md": {
@@ -12203,7 +12203,7 @@
       "src_commit": "4278910bf8dd3f4ccc522204674bebe2839d960b",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+brand-restore",
       "edited": false
     },
     "Using_Zcash/Zallet_Quick_Reference_Guide.md": {
@@ -22247,7 +22247,7 @@
       "src_commit": "4278910bf8dd3f4ccc522204674bebe2839d960b",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+brand-restore",
       "edited": false
     },
     "Using_Zcash/Zallet_Quick_Reference_Guide.md": {
@@ -27269,7 +27269,7 @@
       "src_commit": "4278910bf8dd3f4ccc522204674bebe2839d960b",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+brand-restore",
       "edited": false
     },
     "Using_Zcash/Zallet_Quick_Reference_Guide.md": {

--- a/translations/ak/site/Using_Zcash/Wallets.md
+++ b/translations/ak/site/Using_Zcash/Wallets.md
@@ -9,7 +9,7 @@
 
 ---
 
-## [Ywallet na ɔkyerɛwee](https://ywallet.app/installation/)
+## [Ywallet](https://ywallet.app/installation/)
 ![logo](/content-images/ywalletcard-0cd7232810.webp "Ywallet")
 - Mfiri a Wɔde Yɛ Adwuma: Mobile | Desktop so na ɛyɛ adwuma
 - Dwumadie Nhyehyɛeɛ: Android | iOS | Mfɛnsere | Linux | macOS
@@ -62,7 +62,7 @@
 
 ---
 
-## [eZcash na ɛyɛ](https://blog.nerdbank.net/ezcash-app)
+## [eZcash](https://blog.nerdbank.net/ezcash-app)
 ![logo](/content-images/e-Zcash-1-41c8447b78.webp "eZcash")
 - Mfiri a Wɔde Yɛ Adwuma: Mobile | Desktop so na ɛyɛ adwuma
 - Dwumadie Nhyehyɛeɛ: Android | iOS | Windows
@@ -72,7 +72,7 @@
 
 ---
 
-## [Zkool na ɔkyerɛwee](https://github.com/hhanh00/zkool2/)
+## [Zkool](https://github.com/hhanh00/zkool2/)
 ![logo](/content-images/zkool-1-22ab388e65.webp "Zkool")
 - Mfiri a Wɔde Yɛ Adwuma: Mobile | Desktop so na ɛyɛ adwuma
 - Dwumadie Nhyehyɛeɛ: Android | iOS | Mfɛnsere | Linux
@@ -94,7 +94,7 @@
 
 ---
 
-## [Zenith na ɔkyerɛwee](https://code.vergara.tech/Vergara_Tech/zenith)
+## [Zenith](https://code.vergara.tech/Vergara_Tech/zenith)
 ![logo](/content-images/zenith-2-cea75a34fd.webp "Zenith")
 - Mfiri a Wɔde Yɛ: Desktop
 - Dwumadie Nhyehyɛeɛ: Windows | Linux | macOS
@@ -104,7 +104,7 @@
 
 ---
 
-## [Zingo-CLI na ɛwɔ hɔ](https://github.com/zingolabs/zingolib)
+## [Zingo-CLI](https://github.com/zingolabs/zingolib)
 ![logo](/content-images/zingocard-9a2546668d.webp "Zingo-CLI")
 - Mfiri a Wɔde Yɛ: Desktop
 - Dwumadie Nhyehyɛeɛ: Windows | Linux | macOS
@@ -115,7 +115,7 @@
 
 ---
 
-## [Zallet na ɔkyerɛwee](https://github.com/zcash/wallet)
+## [Zallet](https://github.com/zcash/wallet)
 ![logo](/content-images/Brandmark-Yellow-2eca7f6f68.webp "Zallet")
 - Mfiri a Wɔde Yɛ: Desktop
 - Dwumadie Nhyehyɛeɛ: Windows | Linux | macOS
@@ -126,7 +126,7 @@
 
 ---
 
-## [Zcashd na ɛyɛ adwuma](https://github.com/zcash/zcash)
+## [Zcashd](https://github.com/zcash/zcash)
 ![logo](/content-images/zcashd-92df3291ad.webp "Zcashd")
 - Mfiri a Wɔde Yɛ: Desktop
 - Dwumadie Nhyehyɛeɛ: Windows | Linux | macOS
@@ -157,7 +157,7 @@
 
 ---
 
-## [Zucchini a wɔde yɛ aduan](https://zucchinifi.xyz/)
+## [Zucchini](https://zucchinifi.xyz/)
 ![logo](/content-images/91a1005a-3daf-4747-9442-c178cbe50e49-9f5514d217.webp "Zucchini")
 - Mfiri a Wɔde Yɛ: Wɛbsaet
 - Dwumadi Nhyehyɛe: Browser
@@ -197,7 +197,7 @@
 
 ---
 
-## [Coinomi na ɛyɛ adwuma](https://www.coinomi.com/en/downloads)
+## [Coinomi](https://www.coinomi.com/en/downloads)
 ![logo](/content-images/coinomicard-226bcbf876.webp "Coinomi")
 - Mfiri a Wɔde Yɛ Adwuma: Mobile | Desktop so na ɛyɛ adwuma
 - Dwumadie Nhyehyɛeɛ: Android | iOS | Windows
@@ -207,7 +207,7 @@
 
 ---
 
-## [Keystone a wɔde yɛ nneɛma](https://shop.keyst.one)
+## [Keystone](https://shop.keyst.one)
 ![logo](/content-images/Keystone-1-8177a83308.webp "Keystone")
 - Mfiri a Wɔde Yɛ:
 - Dwumadi Nhyehyɛe:
@@ -218,7 +218,7 @@
 
 ---
 
-## [Ledger a wɔde kyerɛw nsɛm](https://www.ledger.com/coin/wallet/zcash)
+## [Ledger](https://www.ledger.com/coin/wallet/zcash)
 ![logo](/content-images/Desktop-Wallets-6e89fff408.webp "Ledger")
 - Mfiri a Wɔde Yɛ:
 - Dwumadi Nhyehyɛe:
@@ -229,7 +229,7 @@
 
 ---
 
-## [Safepal a ɛwɔ hɔ](https://safepal.com)
+## [Safepal](https://safepal.com)
 ![logo](/content-images/safepalcard-176b24c751.webp "Safepal")
 - Mfiri a Wɔde Yɛ Adwuma: Mobile | Wɛbsaet so
 - Dwumadie Nhyehyɛeɛ: Android | iOS | Browser a wɔde di dwuma
@@ -249,7 +249,7 @@
 
 ---
 
-## [Vultisig na ɔkyerɛwee](https://vultisig.com)
+## [Vultisig](https://vultisig.com)
 ![logo](/content-images/vultisig-713626c5ba.webp "Vultisig")
 - Mfiri: Wɛbsaet | Mobile so | Desktop so na ɛyɛ adwuma
 - Dwumadie Nhyehyɛeɛ: Android | iOS | Mfɛnsere | Linux | macOS | Browser a wɔde di dwuma
@@ -279,7 +279,7 @@
 
 ---
 
-## [LeoDex na ɔkyerɛwee](https://leodex.io/)
+## [LeoDex](https://leodex.io/)
 ![logo](/content-images/Leo-Dexwallet-96b65ffe1b.webp "LeoDex")
 - Mfiri: Wɛbsaet | Desktop so na ɛyɛ adwuma
 - Dwumadie Nhyehyɛe: Browser | Mfɛnsere | macOS
@@ -290,7 +290,7 @@
 
 ---
 
-## [Zapp na ɔkyerɛwee](https://www.justzappit.xyz/app)
+## [Zapp](https://www.justzappit.xyz/app)
 ![logo](/content-images/zapp.webp "Zapp")
 - Mfiri a Wɔde Yɛ: Mobile
 - Dwumadi Nhyehyɛe: Android
@@ -344,7 +344,7 @@
 
 ---
 
-## [Argos na ɔkyerɛwee](https://argos.sovright.com/)
+## [Argos](https://argos.sovright.com/)
 ![logo](/content-images/argos.webp "Argos")
 - Mfiri a Wɔde Yɛ: Desktop
 - Dwumadie Nhyehyɛeɛ: Windows | Linux | macOS

--- a/translations/ee/site/Using_Zcash/Wallets.md
+++ b/translations/ee/site/Using_Zcash/Wallets.md
@@ -9,7 +9,7 @@
 
 ---
 
-## [Ywallet ƒe ŋkɔ](https://ywallet.app/installation/)
+## [Ywallet](https://ywallet.app/installation/)
 ![logo](/content-images/ywalletcard-0cd7232810.webp "Ywallet")
 - Mɔ̃wo: Asitelefon dzi | Desktop dzi
 - Dɔwɔɖoɖo: Android | iOS ƒe iOS | Fesrewo | Linux | macOS ƒe nyawo
@@ -30,7 +30,7 @@
 
 ---
 
-## [Zingo ƒe nya!](https://www.zingolabs.org/)
+## [Zingo!](https://www.zingolabs.org/)
 ![logo](/content-images/zingocard-9a2546668d.webp "Zingo!")
 - Mɔ̃wo: Asitelefon dzi | Desktop dzi
 - Dɔwɔɖoɖo: Android | iOS ƒe iOS | Fesrewo | Linux
@@ -62,7 +62,7 @@
 
 ---
 
-## [eZcash ƒe nyawo](https://blog.nerdbank.net/ezcash-app)
+## [eZcash](https://blog.nerdbank.net/ezcash-app)
 ![logo](/content-images/e-Zcash-1-41c8447b78.webp "eZcash")
 - Mɔ̃wo: Asitelefon dzi | Desktop dzi
 - Dɔwɔɖoɖo: Android | iOS ƒe iOS | Fesrewo
@@ -72,7 +72,7 @@
 
 ---
 
-## [Zkool ƒe ŋkɔ](https://github.com/hhanh00/zkool2/)
+## [Zkool](https://github.com/hhanh00/zkool2/)
 ![logo](/content-images/zkool-1-22ab388e65.webp "Zkool")
 - Mɔ̃wo: Asitelefon dzi | Desktop dzi
 - Dɔwɔɖoɖo: Android | iOS ƒe iOS | Fesrewo | Linux
@@ -94,7 +94,7 @@
 
 ---
 
-## [Zenith ƒe ŋkɔ](https://code.vergara.tech/Vergara_Tech/zenith)
+## [Zenith](https://code.vergara.tech/Vergara_Tech/zenith)
 ![logo](/content-images/zenith-2-cea75a34fd.webp "Zenith")
 - Mɔ̃wo: Dɔwɔnu siwo wozãna le kɔmpiuta dzi
 - Dɔwɔɖoɖo: Windows | Linux | macOS ƒe nyawo
@@ -104,7 +104,7 @@
 
 ---
 
-## [Zingo-CLI ƒe dɔwɔwɔ](https://github.com/zingolabs/zingolib)
+## [Zingo-CLI](https://github.com/zingolabs/zingolib)
 ![logo](/content-images/zingocard-9a2546668d.webp "Zingo-CLI")
 - Mɔ̃wo: Dɔwɔnu siwo wozãna le kɔmpiuta dzi
 - Dɔwɔɖoɖo: Windows | Linux | macOS ƒe nyawo
@@ -115,7 +115,7 @@
 
 ---
 
-## [Zallet ƒe ŋkɔ](https://github.com/zcash/wallet)
+## [Zallet](https://github.com/zcash/wallet)
 ![logo](/content-images/Brandmark-Yellow-2eca7f6f68.webp "Zallet")
 - Mɔ̃wo: Dɔwɔnu siwo wozãna le kɔmpiuta dzi
 - Dɔwɔɖoɖo: Windows | Linux | macOS ƒe nyawo
@@ -126,7 +126,7 @@
 
 ---
 
-## [Zcashd ƒe ŋkɔ](https://github.com/zcash/zcash)
+## [Zcashd](https://github.com/zcash/zcash)
 ![logo](/content-images/zcashd-92df3291ad.webp "Zcashd")
 - Mɔ̃wo: Dɔwɔnu siwo wozãna le kɔmpiuta dzi
 - Dɔwɔɖoɖo: Windows | Linux | macOS ƒe nyawo
@@ -157,7 +157,7 @@
 
 ---
 
-## [Zucchini ƒe nuɖuɖu](https://zucchinifi.xyz/)
+## [Zucchini](https://zucchinifi.xyz/)
 ![logo](/content-images/91a1005a-3daf-4747-9442-c178cbe50e49-9f5514d217.webp "Zucchini")
 - Mɔ̃wo: Nyatakakadzraɖoƒe
 - Dɔwɔɖoɖo: Browser
@@ -197,7 +197,7 @@
 
 ---
 
-## [Coinomi ƒe ŋkɔ](https://www.coinomi.com/en/downloads)
+## [Coinomi](https://www.coinomi.com/en/downloads)
 ![logo](/content-images/coinomicard-226bcbf876.webp "Coinomi")
 - Mɔ̃wo: Asitelefon dzi | Desktop dzi
 - Dɔwɔɖoɖo: Android | iOS ƒe iOS | Fesrewo
@@ -207,7 +207,7 @@
 
 ---
 
-## [Keystone ƒe kpe](https://shop.keyst.one)
+## [Keystone](https://shop.keyst.one)
 ![logo](/content-images/Keystone-1-8177a83308.webp "Keystone")
 - Mɔ̃wo:
 - Dɔwɔɖoɖo:
@@ -218,7 +218,7 @@
 
 ---
 
-## [Agbalẽ si nye Ledger](https://www.ledger.com/coin/wallet/zcash)
+## [Ledger](https://www.ledger.com/coin/wallet/zcash)
 ![logo](/content-images/Desktop-Wallets-6e89fff408.webp "Ledger")
 - Mɔ̃wo:
 - Dɔwɔɖoɖo:
@@ -229,7 +229,7 @@
 
 ---
 
-## [Safepal ƒe nyawo](https://safepal.com)
+## [Safepal](https://safepal.com)
 ![logo](/content-images/safepalcard-176b24c751.webp "Safepal")
 - Mɔ̃wo: Asitelefon dzi | Nyatakakadzraɖoƒe
 - Dɔwɔɖoɖo: Android | iOS ƒe iOS | Browser ƒe dɔwɔnu
@@ -249,7 +249,7 @@
 
 ---
 
-## [Vultisig ƒe agbalẽ](https://vultisig.com)
+## [Vultisig](https://vultisig.com)
 ![logo](/content-images/vultisig-713626c5ba.webp "Vultisig")
 - Mɔ̃wo: Nyatakakadzraɖoƒe | Asitelefon dzi | Desktop dzi
 - Dɔwɔɖoɖo: Android | iOS ƒe iOS | Fesrewo | Linux | macOS ƒe nyawo | Browser ƒe dɔwɔnu
@@ -279,7 +279,7 @@
 
 ---
 
-## [LeoDex ƒe agbalẽ](https://leodex.io/)
+## [LeoDex](https://leodex.io/)
 ![logo](/content-images/Leo-Dexwallet-96b65ffe1b.webp "LeoDex")
 - Mɔ̃wo: Nyatakakadzraɖoƒe | Desktop dzi
 - Dɔwɔɖoɖo: Browser | Fesrewo | macOS ƒe nyawo
@@ -333,7 +333,7 @@
 
 ---
 
-## [Zipher ƒe dɔwɔwɔ](https://github.com/atmospherelabs-dev/zipher-app)
+## [Zipher](https://github.com/atmospherelabs-dev/zipher-app)
 ![logo](/content-images/zipher.webp "Zipher")
 - Mɔ̃wo: Asitelefon dzi | Desktop dzi
 - Dɔwɔɖoɖo: Android | Fesrewo | Linux (CLI kple MCP Dɔwɔƒe) | iOS ƒe iOS | macOS ƒe nyawo
@@ -344,7 +344,7 @@
 
 ---
 
-## [Argos ƒe ŋkɔ](https://argos.sovright.com/)
+## [Argos](https://argos.sovright.com/)
 ![logo](/content-images/argos.webp "Argos")
 - Mɔ̃wo: Dɔwɔnu siwo wozãna le kɔmpiuta dzi
 - Dɔwɔɖoɖo: Windows | Linux | macOS ƒe nyawo

--- a/translations/ig/site/Using_Zcash/Wallets.md
+++ b/translations/ig/site/Using_Zcash/Wallets.md
@@ -1,4 +1,4 @@
-## [ZODL (n'asụsụ Bekee)](https://zodl.com)
+## [ZODL](https://zodl.com)
 ![logo](/content-images/198608b2-9059-4cb7-aeb8-9354971376fd-d67c2d46f5.webp "ZODL")
 - Ngwaọrụ: Mobile
 - Sistemụ arụmọrụ: Android; iOS
@@ -9,7 +9,7 @@
 
 ---
 
-## [Akpa ego Ywallet](https://ywallet.app/installation/)
+## [Ywallet](https://ywallet.app/installation/)
 ![logo](/content-images/ywalletcard-0cd7232810.webp "Ywallet")
 - Ngwaọrụ: Mobile  Desktọpụ
 - Sistemụ arụmọrụ: Android  iOS Windows Linux macOS
@@ -30,7 +30,7 @@
 
 ---
 
-## [Zingo (nwa anụmanụ)!](https://www.zingolabs.org/)
+## [Zingo!](https://www.zingolabs.org/)
 ![logo](/content-images/zingocard-9a2546668d.webp "Zingo!")
 - Ngwaọrụ: Mobile  Desktọpụ
 - Sistemụ arụmọrụ: Android  iOS Windows Linux
@@ -72,7 +72,7 @@
 
 ---
 
-## [Zkool (ụlọ akwụkwọ)](https://github.com/hhanh00/zkool2/)
+## [Zkool](https://github.com/hhanh00/zkool2/)
 ![logo](/content-images/zkool-1-22ab388e65.webp "Zkool")
 - Ngwaọrụ: Mobile  Desktọpụ
 - Sistemụ arụmọrụ: Android  iOS Windows Linux
@@ -94,7 +94,7 @@
 
 ---
 
-## [Zenith (ihe nkiri)](https://code.vergara.tech/Vergara_Tech/zenith)
+## [Zenith](https://code.vergara.tech/Vergara_Tech/zenith)
 ![logo](/content-images/zenith-2-cea75a34fd.webp "Zenith")
 - Ngwaọrụ: Desktọpụ
 - Sistemụ arụmọrụ: Windows  Linux  macOS
@@ -218,7 +218,7 @@
 
 ---
 
-## [Ledger (akwụkwọ ndekọ ego)](https://www.ledger.com/coin/wallet/zcash)
+## [Ledger](https://www.ledger.com/coin/wallet/zcash)
 ![logo](/content-images/Desktop-Wallets-6e89fff408.webp "Ledger")
 - Ngwaọrụ:
 - Sistemụ arụmọrụ:
@@ -249,7 +249,7 @@
 
 ---
 
-## [Vultisig (ụmụ nwanyị)](https://vultisig.com)
+## [Vultisig](https://vultisig.com)
 ![logo](/content-images/vultisig-713626c5ba.webp "Vultisig")
 - Ngwaọrụ: Web  Mobile  Desktọpụ
 - Sistemụ arụmọrụ: Android  iOS Windows Linux macOS Nchọgharị
@@ -279,7 +279,7 @@
 
 ---
 
-## [LeoDex (Ụmụ nwoke)](https://leodex.io/)
+## [LeoDex](https://leodex.io/)
 ![logo](/content-images/Leo-Dexwallet-96b65ffe1b.webp "LeoDex")
 - Ngwaọrụ: Web  Desktọpụ
 - Sistemụ arụmọrụ: Nchọgharị Windows  MacOS
@@ -344,7 +344,7 @@
 
 ---
 
-## [Argos (ụgbọ mmiri)](https://argos.sovright.com/)
+## [Argos](https://argos.sovright.com/)
 ![logo](/content-images/argos.webp "Argos")
 - Ngwaọrụ: Desktọpụ
 - Sistemụ arụmọrụ: Windows  Linux  macOS

--- a/translations/sw/site/Using_Zcash/Wallets.md
+++ b/translations/sw/site/Using_Zcash/Wallets.md
@@ -9,7 +9,7 @@
 
 ---
 
-## [Kipaji cha Ywallet](https://ywallet.app/installation/)
+## [Ywallet](https://ywallet.app/installation/)
 ![logo](/content-images/ywalletcard-0cd7232810.webp "Ywallet")
 - Vifaa: Simu ya mkononi  Desktop
 - Mfumo wa uendeshaji: Android  iOS Windows Linux macOS
@@ -30,7 +30,7 @@
 
 ---
 
-## [Zingo (mnyama)!](https://www.zingolabs.org/)
+## [Zingo!](https://www.zingolabs.org/)
 ![logo](/content-images/zingocard-9a2546668d.webp "Zingo!")
 - Vifaa: Simu ya mkononi  Desktop
 - Mfumo wa uendeshaji: Android  iOS Windows Linux
@@ -72,7 +72,7 @@
 
 ---
 
-## [Shule ya Zkool](https://github.com/hhanh00/zkool2/)
+## [Zkool](https://github.com/hhanh00/zkool2/)
 ![logo](/content-images/zkool-1-22ab388e65.webp "Zkool")
 - Vifaa: Simu ya mkononi  Desktop
 - Mfumo wa uendeshaji: Android  iOS Windows Linux
@@ -115,7 +115,7 @@
 
 ---
 
-## [Zallet (Kifungu cha kulia)](https://github.com/zcash/wallet)
+## [Zallet](https://github.com/zcash/wallet)
 ![logo](/content-images/Brandmark-Yellow-2eca7f6f68.webp "Zallet")
 - Vifaa: Desktop
 - Mfumo wa uendeshaji: Windows Linux MacOS
@@ -218,7 +218,7 @@
 
 ---
 
-## [Ledger (Kitabu cha hesabu)](https://www.ledger.com/coin/wallet/zcash)
+## [Ledger](https://www.ledger.com/coin/wallet/zcash)
 ![logo](/content-images/Desktop-Wallets-6e89fff408.webp "Ledger")
 - Vifaa:
 - Mfumo wa Uendeshaji:

--- a/translations/yo/site/Using_Zcash/Wallets.md
+++ b/translations/yo/site/Using_Zcash/Wallets.md
@@ -1,4 +1,4 @@
-## [ZODL (ì í ì ë ¤)](https://zodl.com)
+## [ZODL](https://zodl.com)
 ![logo](/content-images/198608b2-9059-4cb7-aeb8-9354971376fd-d67c2d46f5.webp "ZODL")
 - Àwọn Ẹrọ: Ètò alágbèéká
 - Àwọn ètò ìṣiṣẹ: Android; iOS
@@ -62,7 +62,7 @@
 
 ---
 
-## [Èdè ìbílẹ̀: eZcash](https://blog.nerdbank.net/ezcash-app)
+## [eZcash](https://blog.nerdbank.net/ezcash-app)
 ![logo](/content-images/e-Zcash-1-41c8447b78.webp "eZcash")
 - Àwọn ohun èlò: Mobile  Desktop
 - Àwọn ètò ìṣiṣẹ: Android  iOS Windows
@@ -94,7 +94,7 @@
 
 ---
 
-## [Zenith (ìmọ̀lára)](https://code.vergara.tech/Vergara_Tech/zenith)
+## [Zenith](https://code.vergara.tech/Vergara_Tech/zenith)
 ![logo](/content-images/zenith-2-cea75a34fd.webp "Zenith")
 - Àwọn Ẹrọ: Àpótí Ìsọfúnni
 - Àwọn Ẹ̀rọ: Windows Linux macOS
@@ -104,7 +104,7 @@
 
 ---
 
-## [Zingo-CLI (ìmọ̀ ìjìnlẹ̀)](https://github.com/zingolabs/zingolib)
+## [Zingo-CLI](https://github.com/zingolabs/zingolib)
 ![logo](/content-images/zingocard-9a2546668d.webp "Zingo-CLI")
 - Àwọn Ẹrọ: Àpótí Ìránṣẹ́
 - Àwọn Ẹ̀rọ: Windows Linux macOS
@@ -126,7 +126,7 @@
 
 ---
 
-## [Zcashd (ì í ì)](https://github.com/zcash/zcash)
+## [Zcashd](https://github.com/zcash/zcash)
 ![logo](/content-images/zcashd-92df3291ad.webp "Zcashd")
 - Àwọn Ẹrọ: Àpótí Ìsọfúnni
 - Àwọn Ẹ̀rọ: Windows Linux macOS
@@ -197,7 +197,7 @@
 
 ---
 
-## [Coinomi (ìyẹn owó)](https://www.coinomi.com/en/downloads)
+## [Coinomi](https://www.coinomi.com/en/downloads)
 ![logo](/content-images/coinomicard-226bcbf876.webp "Coinomi")
 - Àwọn ohun èlò: Mobile  Desktop
 - Àwọn ètò ìṣiṣẹ: Android  iOS Windows
@@ -249,7 +249,7 @@
 
 ---
 
-## [Àmì ojúewé Vultisig](https://vultisig.com)
+## [Vultisig](https://vultisig.com)
 ![logo](/content-images/vultisig-713626c5ba.webp "Vultisig")
 - Àwọn ohun èlò: Wẹ́bútà  Òpó alágbèéká  Àkọlé orí kọ̀ǹpútà
 - Ẹrọ isẹ: Android  iOS Windows Linux macOS Àwòrán aṣàwákiri
@@ -279,7 +279,7 @@
 
 ---
 
-## [LeoDex (ì í ì ë°)](https://leodex.io/)
+## [LeoDex](https://leodex.io/)
 ![logo](/content-images/Leo-Dexwallet-96b65ffe1b.webp "LeoDex")
 - Àwọn ohun èlò: Wẹ́busaiti  Dísíkòpópù
 - Ẹrọ isẹ: Àwòrán Windows  MacOS
@@ -344,7 +344,7 @@
 
 ---
 
-## [Argos (ìlú)](https://argos.sovright.com/)
+## [Argos](https://argos.sovright.com/)
 ![logo](/content-images/argos.webp "Argos")
 - Àwọn Ẹrọ: Àpótí Ìránṣẹ́
 - Àwọn Ẹ̀rọ: Windows Linux macOS


### PR DESCRIPTION
The machine locales render the wallet directory's headings as **descriptions rather than brand names**. On `main` today:

| shipped | meaning |
|---|---|
| `## [Kipaji cha Ywallet]` (sw) | "Ywallet's talent" |
| `## [Zingo (mnyama)!]` (sw) | "Zingo (animal)!" |
| `## [Zkool (ụlọ akwụkwọ)]` (ig) | "Zkool (school)" |
| `## [Ledger (akwụkwọ ndekọ ego)]` (ig) | "Ledger (accounting book)" |
| `## [Vultisig (ụmụ nwanyị)]` (ig) | "Vultisig (women)" |
| `## [ZODL (ì í ì ë ¤)]` (yo) | mojibake, also in the side menu |

## Why the checks did not catch it

A heading like `## [Zingo!](https://www.zingolabs.org/)` segments to exactly `Zingo!`, so the engine received a bare brand with no sentence around it and supplied one. The protected-term check cannot object: the term **is** present, and the invented text sits beside it.

The cause is fixed in the sync tooling, but neither fix repairs what already shipped — this page is not stale, so no sync window would re-pick it.

## What is in it

**56 headings** across ak, ee, ig, sw and yo, plus the two side-menu labels derived from them (`menu-titles/ig.json`, `menu-titles/yo.json`), and a `tool` marker on the five manifest entries recording the pass.

**Deliberately narrow:** only heading lines are taken from the regenerated pages. Re-translating a page re-rolls every segment on it — these engines are not deterministic — so a full regeneration also carried 8–14 unrelated line changes per locale, one of which came back worse. Those are discarded. **Every changed line in this diff is a `## [` heading**; the rest of each file is byte-identical to `main`.

## This is not the whole problem

A scan of the curated corpus finds roughly **286 bare brand segments still rendered as descriptions, across ~60 pages in all five machine locales** (Zkool 22, Zallet 20, Zaino 18, QEDIT 14, ZODL 13, …) — for example `Halo (Habari Njema)` = "good news" in Swahili, `Ẹranko Zebra` = "animal Zebra" in Yoruba. Most sit on pages whose translations predate the protected-term list growing in August, and the CI check only inspects files a PR touches, so they have gone unseen.

Repairing those needs a way to patch individual segments without re-rolling whole pages. This PR does not attempt it.

All five checks pass locally against `main`.