### PR TITLE
i18n sync 05d68d9e — 3 page(s) × 4 locale(s)

### DIFF
--- a/translation/sync-state.json
+++ b/translation/sync-state.json
@@ -5327,8 +5327,8 @@
       "edited": false
     },
     "Start_Here/Who_Can_See_Your_Zcash_Payment.md": {
-      "src": "sha256:8232b95df5d6a5af7eb05ddf441ed135b932329c9480118fafe8840d29f6265a",
-      "src_commit": "db0af74c5294ef0fb3ebf3b47d308a4426eace68",
+      "src": "sha256:70f868d687a1bff26628ae1b0f19b4f4db9a701c27e318460487c5cd6d454c8e",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "gt",
       "mode": "full",
       "tool": "gt-static",
@@ -6135,8 +6135,8 @@
       "edited": false
     },
     "Zcash_Tech/What_a_Block_Explorer_Can_See.md": {
-      "src": "sha256:3a7ee6b549897d1df44b6f5910938caf25bac827f86c0e5ff3868aba79b7cfc3",
-      "src_commit": "2dd8fb0fd1edbf4aa597fa8e2b283e6ee09127f6",
+      "src": "sha256:227640845a3b820c8d65a38fef99d48ab611965a70d5324306b0a7b37df9fc64",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "gt",
       "mode": "full",
       "tool": "gt-static",
@@ -12023,8 +12023,8 @@
       "edited": false
     },
     "Start_Here/Who_Can_See_Your_Zcash_Payment.md": {
-      "src": "sha256:8232b95df5d6a5af7eb05ddf441ed135b932329c9480118fafe8840d29f6265a",
-      "src_commit": "db0af74c5294ef0fb3ebf3b47d308a4426eace68",
+      "src": "sha256:70f868d687a1bff26628ae1b0f19b4f4db9a701c27e318460487c5cd6d454c8e",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "nllb",
       "mode": "full",
       "tool": "nllb-200-3.3B",
@@ -12831,8 +12831,8 @@
       "edited": false
     },
     "Zcash_Tech/What_a_Block_Explorer_Can_See.md": {
-      "src": "sha256:3a7ee6b549897d1df44b6f5910938caf25bac827f86c0e5ff3868aba79b7cfc3",
-      "src_commit": "2dd8fb0fd1edbf4aa597fa8e2b283e6ee09127f6",
+      "src": "sha256:227640845a3b820c8d65a38fef99d48ab611965a70d5324306b0a7b37df9fc64",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "nllb",
       "mode": "full",
       "tool": "nllb-200-3.3B",
@@ -13039,11 +13039,11 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "19052dfb9958dc8ce2e224ce9627ee9e01635c8b",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B+dedupe-linkrepair",
+      "tool": "nllb-200-3.3B",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
@@ -22067,8 +22067,8 @@
       "edited": false
     },
     "Start_Here/Who_Can_See_Your_Zcash_Payment.md": {
-      "src": "sha256:8232b95df5d6a5af7eb05ddf441ed135b932329c9480118fafe8840d29f6265a",
-      "src_commit": "db0af74c5294ef0fb3ebf3b47d308a4426eace68",
+      "src": "sha256:70f868d687a1bff26628ae1b0f19b4f4db9a701c27e318460487c5cd6d454c8e",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "nllb",
       "mode": "full",
       "tool": "nllb-200-3.3B",
@@ -22875,8 +22875,8 @@
       "edited": false
     },
     "Zcash_Tech/What_a_Block_Explorer_Can_See.md": {
-      "src": "sha256:3a7ee6b549897d1df44b6f5910938caf25bac827f86c0e5ff3868aba79b7cfc3",
-      "src_commit": "2dd8fb0fd1edbf4aa597fa8e2b283e6ee09127f6",
+      "src": "sha256:227640845a3b820c8d65a38fef99d48ab611965a70d5324306b0a7b37df9fc64",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "nllb",
       "mode": "full",
       "tool": "nllb-200-3.3B",
@@ -23083,11 +23083,11 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "19052dfb9958dc8ce2e224ce9627ee9e01635c8b",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B+dedupe-linkrepair",
+      "tool": "nllb-200-3.3B",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
@@ -28105,11 +28105,11 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "19052dfb9958dc8ce2e224ce9627ee9e01635c8b",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "05d68d9e540dcdab848870aed8ab4a28f4aa3ac2",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B+dedupe-linkrepair",
+      "tool": "nllb-200-3.3B",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {

--- a/translations/ee/site/Start_Here/Who_Can_See_Your_Zcash_Payment.md
+++ b/translations/ee/site/Start_Here/Who_Can_See_Your_Zcash_Payment.md
@@ -18,7 +18,7 @@
 
 Le blockchain akpa gãtɔ dzi la, tiatia aɖeke meli woawɔ o. Nusianu si nèɖo ɖa la nye dutoƒo, tegbee, na amesiame si akpɔe.
 
-Zcash naa tiatia wò boŋ. Wowɔa tiatia ma zi eve: **zi ɖeka ne ètia adrɛs si dzi nàɖo ɖee, eye zi ɖeka ne ètso nya me le amesi axɔ safui si axlẽ wò ŋutinya ŋu.**
+Zcash naa tiatia aɖe wò boŋ. Wowɔa tiatia ma zi eve: **zi ɖeka ne ètia adrɛs si dzi nàɖo ɖee, eye zi ɖeka ne ètso nya me le amesi axɔ safui si axlẽ wò ŋutinya ŋu.**
 
 Nɔnɔmetata si le ete la ƒo nu tso evea siaa ŋu.
 
@@ -30,9 +30,9 @@ Nɔnɔmetata si le ete la ƒo nu tso evea siaa ŋu.
 
 Zcash ƒe fexexe ɖesiaɖe zɔna le adrɛs eve dome, eye wo dometɔ ɖesiaɖe ateŋu anye esi me kɔ alo akpɔ eta. Ema naa mɔ ene, eye wo dometɔ ɖesiaɖe tsia agbɔsɔsɔ vovovo.
 
-Kpɔɖeŋua le bɔbɔe wu alesi wòdzenae: **nusianu si ka adrɛs si me kɔ la va zua dutoƒo.** Fexexe si nɔa ta si wotsɔ akpoxɔnu wɔe la me le mɔ bliboa dzi meɖea naneke fiana o negbe fe si woxenae ko.
+Kpɔɖeŋua le bɔbɔe wu alesi wòdzenae: **nusianu si ka adrɛs si me kɔ la va zua dutoƒo.** Fexexe si nɔa ta si ŋu wokpɔ akpoxɔnu le la me le mɔ bliboa dzi la meɖea naneke fiana o negbe fe si woaxe la ko.
 
-Esia le vevie wu ne èɖe asi le asitɔtrɔ aɖe ŋu. Adrɛs siwo dzi woɖea nu me le ko dzie asitɔtrɔ geɖe ɖona ɖa, eyata ga si woɖena le eme la nyea dutoƒo. Wò ŋutɔ kpɔ ga la ta ne wonya ɖo ko, hafi nàzãe.
+Esia le vevie wu ne èɖe asi le asitɔtrɔ aɖe ŋu. Adrɛs siwo me kɔ koe woɖona ɖe ame geɖe siwo woɖɔlia wo nɔewo ɖo, eyata ga si woɖe le eme la nyea dutoƒo. Wò ŋutɔ kpɔ ga la ta ne wonya ɖo ko, hafi nàzãe.
 
 Ne èdi be yealé ŋku ɖe nusi tututu anyigbayeyedila xlẽna ŋu tsitotsito la, kpɔ [Nusi block explorer ate ŋu akpɔ](/zcash-tech/what-a-block-explorer-can-see).
 
@@ -40,15 +40,15 @@ Ne èdi be yealé ŋku ɖe nusi tututu anyigbayeyedila xlẽna ŋu tsitotsito la
 
 ## Tiatia evelia: amesi axɔ safui
 
-Adzamenyawo si màte ŋu akɔ gbeɖe o la meɖea vi o. Ɣeaɖewoɣi la, ahiã be nàɖo kpe nane dzi na akɔntanyala, agbalẽdzikpɔla, alo adzɔxedɔwɔƒe aɖe. Zcash kpɔa esia gbɔ evɔ mebia tso asiwò be nàɖe asi le dziɖuɖu ŋu o.
+Adzamenyawo si màte ŋu akɔ gbeɖe o la meɖea vi o. Ɣeaɖewoɣi la, ehiãna be nàɖo kpe nane dzi na akɔntanyala, agbalẽdzikpɔla, alo adzɔxedɔwɔƒe aɖe. Zcash kpɔa esia gbɔ evɔ mebia tso asiwò be nàɖe asi le dziɖuɖu ŋu o.
 
 **Gazazã ƒe safui.** Ekpɔa nusianu eye wòʋua ga. Esiae nye ga la. Enɔa gbɔwò eye womegblɔnɛ na ame aɖeke gbeɖe o, le susu aɖeke ta.
 
 **Full viewing key.** Nuxexlẽ ɖeɖeko. Fia dɔwɔna si va kple esi dona kple dadasɔ, gake mate ŋu azã zatoshi ɖeka pɛ hã o. Esiae nye nusi nètsɔ dea asi na agbalẽdzikpɔla alo akɔntanyala.
 
-**Incoming viewing key.** Narrower still: fexexe siwo va ɖo koe wòɖena fiana. Exchange alo asitsala ate ŋu awɔ esia atsɔ aɖo kpe edzi be wò ga si nède eme la ɖi, evɔ gazazã ƒe safuia ya nɔa xɔtunu siwo meka asi internet ŋu gbeɖe o dzi.
+**Incoming viewing key.** Narrower still: fexexe siwo va ɖo koe wòɖena fiana. Exchange alo asitsala ate ŋu awɔ esia atsɔ aɖo kpe edzi be wò ga si nède la ɖi, evɔ gazazã ƒe safuia ya nɔa xɔtunu siwo meka asi internet ŋu gbeɖe o dzi.
 
-Sededea le vevie. Na safui si le kpuie wu si wɔa dɔa, ke menye esi keke wu si le asiwò le vome o.
+Sededea le vevie. Na safui si le gbadzaa wu si wɔa dɔa, ke menye esi keke wu si le asiwò le vome o.
 
 ---
 
@@ -58,15 +58,15 @@ Sededea le vevie. Na safui si le kpuie wu si wɔa dɔa, ke menye esi keke wu si 
 
 **Fewo nyea dutoƒo le fexexe si wokpɔ ta na bliboe gɔ̃ hã me.** Woɣla ga homea; fe si woxena la menye nenema o.
 
-**Dutoƒo nye nusi nɔa anyi ɖaa.** Nusianu si kɔsɔkɔsɔa ɖena fiana egbea la, eɖenɛ fiana le ƒe blaeve me. Nyametsotso be yeakpɔ fetu aɖe ta *le* esi nèɖoe ɖa vɔ megbe menye nusi nàte ŋu awɔ o.
+**Dutoƒo nye nusi nɔa anyi ɖaa.** Nusianu si kɔsɔkɔsɔa ɖena fiana egbea la, eɖenɛ fiana le ƒe blaeve me. Nyametsotso be yeakpɔ fetu aɖe ta *le* esi nèɖoe ɖa vɔ megbe la menye nusi nàte ŋu awɔ o.
 
 ---
 
 ## Tsɔe de dɔwɔwɔ me
 
-- Zã gakotoku si kpɔa ame ta le gɔmedzedzea me, abe [Zodl](https://zodl.com) or [Ywallet ƒe ŋkɔ](https://ywallet.app/).
+- Zã gakotoku si kpɔa ame ta le gɔmedzedzea me, abe [Zodl](https://zodl.com) or [Zingo!](https://www.zingolabs.org/).
 - Akpoxɔnu gawo ne wonya tso gaɖɔliƒe aɖe ko, hafi nàzãe.
-- Fe na adrɛs siwo ŋu wokpɔ ta na ɣesiaɣi si amesi xɔe la do alɔ ɖeka.
+- Fe na adrɛs siwo wokpɔ ta na ɣesiaɣi si amesi xɔe la do alɔ ɖeka.
 - Hafi nàma nukpɔkpɔ ƒe safui la, bia be safui kae nye suetɔ kekeake si ɖoa nya si wobia la ŋu.
 
 ---

--- a/translations/ee/site/Zcash_Tech/What_a_Block_Explorer_Can_See.md
+++ b/translations/ee/site/Zcash_Tech/What_a_Block_Explorer_Can_See.md
@@ -6,10 +6,10 @@
 
 ## TL;DR
 
-- Le Bitcoin dzi la, block explorer ɖea nusianu fiana: amesi ɖoe ɖa, amesi xɔe, kple ga home.
+- Le Bitcoin dzi la, block explorer ɖea nusianu fiana: ame si ɖoe ɖa, amesi xɔe, kple ga home.
 - Le Zcash dzi la, ema nye nyateƒe na dɔwɔna si me kɔ (t-adrɛs) ko.
 - Anyigbayeyedila ate ŋu akpɔ ga wòage ɖe ta si ŋu wokpɔ akpoxɔnu le la me ahado le eme, gake menye nusi dzɔna le eme o.
-- Asitsatsa siwo wokpɔ ta na bliboe (z vaseɖe z) meɖea ame aɖeke si ɖoe ɖa o, ame aɖeke mexɔe o, eye womeɖea ga home aɖeke fiana o.
+- Asitsatsa siwo wokpɔ ta na bliboe (z va ɖo z) meɖea ame aɖeke si ɖoe ɖa, ame aɖeke mexɔe o, kple ga home aɖeke fiana o.
 - Dutoƒo "akpoxɔnu ƒe agbɔsɔsɔme" ƒe xexlẽme ɖesiaɖe nye anyigba, elabena ame ŋutɔ ƒe dɔwɔna bliboe nye nusi womate ŋu akpɔ tso egodo o.
 
 ---
@@ -22,11 +22,11 @@ Adrɛs ƒomevi eve le Zcash si.
 
 **adrɛs si wokpɔ ta na** dzea egɔme kple `z` eye wotsɔa kpeɖodzi siwo me sidzedze aɖeke mele o kpɔa eta. Netwɔƒea ate ŋu aɖo kpe edzi be fexexe si wokpɔ ta na la sɔ evɔ maɖe amesi ɖoe ɖa, amesi xɔe, alo ga home si woaxe la afia o.
 
-Esi wònye be ƒomevi eve li ta la, asixɔxɔ ate ŋu azɔ le mɔ ene nu: nusi me kɔ yi esi me kɔ (t yi t), esi me kɔ va yi esi me wokpɔa ta (t yi z, si woyɔna be akpoxɔnu), esi wokpɔ ta na va ɖo esi me kɔ (z va ɖo t, si woyɔna be akpoxɔnu ɖeɖeɖa), kple esi wokpɔ ta na si me woɖea akpoxɔnu le (z va ɖo z, si nye ame ŋutɔ tɔ bliboe).
+Esi wònye be ƒomevi eve li ta la, asixɔxɔ ate ŋu azɔ le mɔ ene nu: esi me kɔ va ɖo esi me kɔ (t va ɖo t), esi me kɔ va yi esi me wokpɔa ta (t yi z, si woyɔna be akpoxɔnu), esi wotsɔ ta na va ɖo esi me kɔ (z va ɖo t, si woyɔna be akpoxɔnu ɖeɖeɖa), kple esi wokpɔ ta na si me woɖea akpoxɔnu le (z va ɖo z, si nye ame ŋutɔ tɔ bliboe).
 
 ## Nusi anyigbayeyedila ate ŋu akpɔ
 
-Dutoƒonudila aɖe abe [Blockchair ƒe zikpui](https://blockchair.com/zcash) ate ŋu axlẽe kɔte be:
+Dutoƒonudila aɖe abe [Blockchair ƒe zikpui](https://blockchair.com/zcash) ate ŋu axlẽe eme nakɔ be:
 
 - Fexexe ɖesiaɖe si me kɔ bliboe (t vaseɖe t), tso nuwuwu vaseɖe nuwuwu.
 - Ga si gena ɖe ta si wotsɔ akpoxɔnu wɔe la me (afã si me kɔ kple ga home si woaxe).
@@ -37,9 +37,9 @@ Kpuie ko la, ta si ŋu wokpɔ akpoxɔnu le la ƒe goawo dzena. Àte ŋu akpɔ as
 
 ## Nusi anyigbayeyedila mate ŋu akpɔ o
 
-Dutoƒonudila mate ŋu axlẽe be:
+Dutoƒonudila mate ŋu axlẽ be:
 
-- Adzɔnu siwo wokpɔ ta na bliboe (z vaseɖe z). Ame si ɖoe ɖa, amesi xɔe, kple ga home si woaxe la nɔa ɣaɣla.
+- Asitsatsa siwo wokpɔ ta na bliboe (z vaseɖe z). Ame si ɖoe ɖa, amesi xɔe, kple ga home si woaxe la nɔa ɣaɣla.
 - Amesi ɖoe ɖa alo xɔe le megbe na fexexe ɖesiaɖe si wokpɔ ta na.
 - Adrɛs ɖekaɖeka si wokpɔ ta na ƒe dadasɔ.
 - Nukae dzɔna ɖe ga dzi ne wonya ge ɖe ta la me ko.
@@ -52,13 +52,13 @@ Bia nyatakaka xoxoawo eye shielded sender and receiver fields trɔ gbɔ ƒuƒlu.
 
 **Dukɔa ƒe akpoxɔnu ƒe xexlẽme medea ame ŋutɔ ƒe nyawo ta o.** Nusiwo tso dukɔa ƒe liƒo koe numekulawo ate ŋu adzidze, eyata ame ŋutɔ ƒe dɔwɔnawo ƒe agbɔsɔsɔ ŋutɔŋutɔ nye nusi ŋu woka nya ta le ya teti, eye zi geɖe la, esɔ gbɔ wu.
 
-**Ta si lolo wu si wokpɔ ta na kpɔa amesiame ta.** Zi alesi ame geɖe zãa adrɛs siwo ŋu wokpɔa akpoxɔnu le la, zi nenemae ameha si me ame ŋutɔ ƒe fetu ɖeka ɖesiaɖe ɣlana ɖo la lolonae.
+**Ta si lolo wu si ŋu wokpɔ ta na la kpɔa amesiame ta.** Zi alesi ame geɖe zãa adrɛs siwo ŋu wokpɔ ta na la, zi nenemae ameha si me ame ŋutɔ ƒe fetu ɖeka ɖesiaɖe ɣlana ɖo la lolonae.
 
 ## Tsɔe de dɔwɔwɔ me
 
-- Zã gakotoku si nye adrɛs siwo wokpɔ ta na, abe [Zodl](https://zodl.com) or [Ywallet ƒe ŋkɔ](https://ywallet.app/).
+- Zã gakotoku si nye adrɛs siwo wokpɔ ta na, abe [Zodl](https://zodl.com) or [Zingo!](https://www.zingolabs.org/).
 - Ne èxɔ ZEC le adrɛs si me kɔ dzi la, tsɔe yi adrɛs si wokpɔ ta na hafi nàzãe.
-- Xe fe ɖe adrɛs siwo ŋu wokpɔ ta na le afisi nàte ŋui. Fexexe ɖesiaɖe si wowɔna le gaglãgbe nye dutoƒo bliboe; amesi ŋu wokpɔ akpoxɔnu le ya menye nenema o.
+- Xe fe ɖe adrɛs siwo ŋu wokpɔ ta na le afisi nàte ŋui. Fexexe ɖesiaɖe si wowɔna le gaglãgbe nye dutoƒo bliboe; amesi ŋu wotsɔ akpoxɔnu ɖo la menye nenemae o.
 
 ## Nunɔamesiwo
 
@@ -72,7 +72,7 @@ Bia nyatakaka xoxoawo eye shielded sender and receiver fields trɔ gbɔ ƒuƒlu.
 - [Zcash ƒe gɔmedzenufiafiawo](/start-here/what-is-zec-and-zcash)
 - [Gakotokuwo](/using-zcash/wallets)
 - [Ta siwo ŋu wokpɔ akpoxɔnu le](/using-zcash/shielded-pools)
-- [ZK-SNARKs ƒe nyawo](/zcash-tech/zk-snarks)
+- [ZK-SNARKs](/zcash-tech/zk-snarks)
 
 ---
 

--- a/translations/ig/site/Start_Here/Who_Can_See_Your_Zcash_Payment.md
+++ b/translations/ig/site/Start_Here/Who_Can_See_Your_Zcash_Payment.md
@@ -64,7 +64,7 @@ Ihe dị mkpa bụ otú e si hazie ya. Nye mkpịsị ugodi nke kasị dịrị 
 
 ## Mee ihe ị mụtara eme .
 
-- Jiri obere akpa ego nke na-echebe site na ndabara, dị ka [Zodl .](https://zodl.com) or [Akpa ego Ywallet](https://ywallet.app/).
+- Jiri obere akpa ego nke na-echebe site na ndabara, dị ka [Zodl .](https://zodl.com) or [Zingo!](https://www.zingolabs.org/).
 - Chekwa ego ozugbo ha si n'ụlọ ahịa ahụ rute, tupu a na-emefu ya.
 - Na-akwụ ụgwọ na adreesị echedoro mgbe ọ bụla onye natara ya kwadoro otu.
 - Tupu i nye onye ọzọ igodo e ji ele ihe anya, jụọ ya nke kacha obere ma zaa ajụjụ ahụ a jụrụ.

--- a/translations/ig/site/Zcash_Tech/What_a_Block_Explorer_Can_See.md
+++ b/translations/ig/site/Zcash_Tech/What_a_Block_Explorer_Can_See.md
@@ -56,7 +56,7 @@ Jụọ data raw na onye ezipụ ozi ahụ echekwara ma nata ubi laghachi efu. O
 
 ## Mee ihe ị mụtara eme .
 
-- Jiri obere akpa ego nke na-eme ka adreesị echedoro, dịka: [Zodl .](https://zodl.com) or [Akpa ego Ywallet](https://ywallet.app/).
+- Jiri obere akpa ego nke na-eme ka adreesị echedoro, dịka: [Zodl .](https://zodl.com) or [Zingo!](https://www.zingolabs.org/).
 - Mgbe ị natara ZEC na adreesị doro anya, bugharịa ya n'adres ezoro ezo tupu i jiri ya.
 - Kwụọ ụgwọ na adreesị echekwara ebe ị nwere ike. Ịkwụ ụgwọ ọ bụla doro anya bụ nke ọha; a naghị ekpuchi ya.
 

--- a/translations/ig/site/guides/Akash_Network_Zcashd.md
+++ b/translations/ig/site/guides/Akash_Network_Zcashd.md
@@ -420,7 +420,7 @@ Mgbe ị kwụsịrị maọbụ chọọ ịkwụsị akwụ ụgwọ:
 
 -> Gaa na ** My Deployments**
 
--> Chọta gị zcashd nkenye ọnọdụ
+-> Chọta gị zcashd nkesa
 
 -> Pịa **"Mechie Ntinye aka"**
 
@@ -518,7 +518,7 @@ Mgbe ego gị gwụrụ, Akash ga-emechi nkenye gi. ** Tinye obere akpa gị oge
 
 ## Ihe Ndị E Kwuru ná Ngwụcha
 
-- ** Ihe nchekwa na-adịgide adịgide.** Emela ka * nọgidere: ezi ma ọ bụ jiri klas beta2 mee ihe. Jiri * beta3*.
+- ** Ihe nchekwa na-adịgide adịgide.** Emela * persistent: true ma ọ bụ jiri klas beta2. Jiri beta3.
 - **Mmemme mbụ na-adị nwayọ.** Nwee ndidi. Nke a bụ ihe dị mma maka ọnụ ọgụgụ blockchain.
 - **Jide ego gị.** Ntinye aka na-emechi onwe ya mgbe AKT gwụrụ.
 - ** Ndabere abụghị akpaka.** Ọ bụrụ na ị hụrụ data n'anya, chee na ọ nwere ike ikpochapụ ma mee atụmatụ dịka.

--- a/translations/sw/site/Start_Here/Who_Can_See_Your_Zcash_Payment.md
+++ b/translations/sw/site/Start_Here/Who_Can_See_Your_Zcash_Payment.md
@@ -64,7 +64,7 @@ Funguo iliyo nyembamba zaidi ndiyo inayohitajika, si ile pana unayoweza kutumia.
 
 ## Tumia shauri hilo maishani mwako.
 
-- Tumia mkoba kwamba shields default, kama vile [Zodl](https://zodl.com) or [Kipaji cha Ywallet](https://ywallet.app/).
+- Tumia mkoba kwamba shields default, kama vile [Zodl](https://zodl.com) or [Zingo!](https://www.zingolabs.org/).
 - Kuhifadhi fedha mara tu wanapowasili kutoka kubadilishana, kabla ya matumizi.
 - Kulipa kwa anwani ulinzi wakati wowote mpokeaji inasaidia moja.
 - Kabla ya kushiriki ufunguo wa kutazama, uliza ni ipi iliyo ndogo zaidi inayojibu swali linaloulizwa.

--- a/translations/sw/site/Zcash_Tech/What_a_Block_Explorer_Can_See.md
+++ b/translations/sw/site/Zcash_Tech/What_a_Block_Explorer_Can_See.md
@@ -56,7 +56,7 @@ Takwimu za kiwango cha ulinzi wa umma hazingatii faragha.* Watafiti wanaweza kup
 
 ## Tumia shauri hilo maishani mwako.
 
-- Tumia mkoba kwamba defaults kwa anwani ulinzi, kama vile [Zodl](https://zodl.com) or [Kipaji cha Ywallet](https://ywallet.app/).
+- Tumia mkoba kwamba defaults kwa anwani ulinzi, kama vile [Zodl](https://zodl.com) or [Zingo!](https://www.zingolabs.org/).
 - Wakati kupokea ZEC katika anwani ya uwazi, hoja ni kwa anwani ulinzi kabla ya kutumia.
 - Kulipa kwa anwani za ulinzi ambapo unaweza. Kila malipo ya uwazi ni wazi kabisa; moja iliyohifadhiwa sio.
 

--- a/translations/sw/site/guides/Akash_Network_Zcashd.md
+++ b/translations/sw/site/guides/Akash_Network_Zcashd.md
@@ -44,7 +44,7 @@ full zcashd node ambayo itakuwa:
 
 -> Zebra tu ifuatavyo mlolongo wa sasa; node zcashd hawezi kufikia ncha
 
--> mkoba zcashd ya imekuwa kubadilishwa na [Zallet (Kifungu cha kulia)](/using-zcash/zallet-quick-reference-guide)
+-> mkoba zcashd ya imekuwa kubadilishwa na [Zallet](/using-zcash/zallet-quick-reference-guide)
 
 -> Tumia zcashd kama unahitaji mfuko wa fedha utendaji au maalum RPC APIs
 
@@ -312,7 +312,7 @@ Uncomment katika *env*:
 - "ZCASHD_TXINDEX=1"
 ```
 
-** Onyo**: kuwezesha txindex kwenye node iliyopo ya usawazishaji inahitaji re-kuorodhesha blockchain nzima, ambayo inachukua masaa.
+** Onyo**: kuwezesha txindex kwenye node iliyopo ya usawazishaji inahitaji upya indexing blockchain nzima, ambayo inachukua masaa.
 
 ### Kuwezesha Insight Explorer
 

--- a/translations/yo/site/guides/Akash_Network_Zcashd.md
+++ b/translations/yo/site/guides/Akash_Network_Zcashd.md
@@ -128,7 +128,7 @@ Tẹ "Fọwọsi" ki o si buwọlu awọn idunadura ni Keplr.
 
 ## Ìgbésẹ̀ Kẹrin: Yan Ẹni Tó Máa Bójú Tó O Ní Nǹkan Rẹ
 
-Lẹ́yìn ~ 30 ìṣẹ̀lẹ̀, ẹ ó rí àwọn owó tí wọ́n fi ń ra ọjà. Ẹnìkan ní:
+Lẹ́yìn ~ 30 ìṣẹ̀lẹ̀, ẹ óo rí àwọn owó tí wọ́n fi ń ra ọjà. Ẹnìkan ní:
 
 -> **Iye owo fun bulọọki** (ni AKT tabi USDC)
 


### PR DESCRIPTION
9 (page, locale) units across 3 pages and 4 curated locales:

- **9** regenerated whole

Pages: Start_Here/Who_Can_See_Your_Zcash_Payment, Zcash_Tech/What_a_Block_Explorer_Can_See, guides/Akash_Network_Zcashd.

9 of 10 (page, locale) units passed the front-matter, protected-term and structure gates. The other 1 was reverted and stays stale for the next window:

- `ru` Research/Navigating_the_Central_Bank_Digital_Currency — missing link URL https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE

A further 20 (page, locale) units came back identical to the committed translation, so no provenance was recorded for them and they stay stale for the next window.

Also included: the `translation/sync-state.json` provenance update. No side-menu labels changed, so the `translation/menu-titles/*.json` manifests are untouched.

Post-sync detection reports `stale=21 missing=0 orphan=0 high-severity=0` across all 3762 curated pairs.

<sub>Opened automatically by the scheduled translation sync against `05d68d9e540d`. Merging stays a human decision.</sub>
