### PR TITLE
docs: replace the dead SSRN link on the CBDC page

### DIFF
--- a/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Financial inclusion, once a beacon of hope, faces the shadows of potential discr
 For those venturing into the uncharted territory of CBDCs, resources become your compass.
 1. The Bank for International Settlements ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. the International Monetary Fund ([IMF](https://www.imf.org/en/About))
-3. Research papers ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Research papers ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Academic Journals ([journal](https://www.bis.org/publ/work976.pdf))
 5. C.E.I Article  ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 


### PR DESCRIPTION
Resource 3 on `Research/Navigating_the_Central_Bank_Digital_Currency.md` points at an SSRN `delivery.php?ID=…` URL — **316 characters, and it returns no response at all.**

That kind of URL is a per-session PDF download token: SSRN generates it when someone clicks "Download PDF", and it is valid only in the tab that produced it. It was copied out of a browser address bar rather than the paper's permanent address, so **it has never worked for a reader** — since the page was created on 2026-07-29 (782664a9). It has never been revised since.

The link text is just `paper`, with no title or author anywhere on the page, so the specific work cannot be recovered from the repository.

## The change

```diff
-3. Research papers ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=99810500600006612406709912209909712105304…&EXT=pdf&INDEX=TRUE))
+3. Research papers ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
```

A stable SSRN search for CBDC papers. This matches what the neighbouring entries in the same list already do — entry 1 was repaired exactly this way in `680979c5`, swapping a dead BIS URL for a search URL:

```
1. The Bank for International Settlements ([BIS](https://www.bis.org/search?keywords=cbdc))
```

## It also unblocks translation

That 316-character URL is what the Russian translation pass keeps dropping. The markup gate then sees a link URL missing from the output and reverts the whole page — three windows in a row, and it is currently the only item in the translation queue that a sync window could act on. A 51-character link is far less fragile.

The translated copies carry the same dead URL in all 18 locales; they are repaired in a separate PR.