### PR TITLE
i18n: propagate the CBDC page's SSRN link repair into all 18 locales

### DIFF
--- a/translation/sync-state.json
+++ b/translation/sync-state.json
@@ -149,7 +149,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "gt",
       "mode": "full",
-      "tool": "gt-static",
+      "tool": "gt-static+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -1823,7 +1823,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -3497,7 +3497,7 @@
       "src_commit": "04e717c74f72acfabb8b0589be32e89eaa1bb211",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -5171,7 +5171,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "gt",
       "mode": "full",
-      "tool": "gt-static",
+      "tool": "gt-static+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -6845,7 +6845,7 @@
       "src_commit": "04e717c74f72acfabb8b0589be32e89eaa1bb211",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -8519,7 +8519,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -10193,7 +10193,7 @@
       "src_commit": "04e717c74f72acfabb8b0589be32e89eaa1bb211",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -11867,7 +11867,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -13541,7 +13541,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -15215,7 +15215,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -16889,7 +16889,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -18563,7 +18563,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -20237,7 +20237,7 @@
       "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
       "engine": "llm",
       "mode": "seed",
-      "tool": "gpt-5.4",
+      "tool": "gpt-5.4+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -21911,7 +21911,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -23585,7 +23585,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -25259,7 +25259,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -26933,7 +26933,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "nllb",
       "mode": "full",
-      "tool": "nllb-200-3.3B",
+      "tool": "nllb-200-3.3B+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {
@@ -28607,7 +28607,7 @@
       "src_commit": "e0299c1a434bf007274433ee81ce3034d4dbf6d4",
       "engine": "llm",
       "mode": "diff",
-      "tool": "codex/gpt-5.6-terra",
+      "tool": "codex/gpt-5.6-terra+linkrepair",
       "edited": false
     },
     "Research/Social_Media_Data_Collection.md": {

--- a/translations/ak/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/ak/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Sikasɛm mu nkabom a bere bi na ɛyɛ anidaso kanea no hyia nyiyim a ebetumi aba
 Wɔ wɔn a wɔde wɔn ho hyɛ CBDC asasesin a wonhuu bi mu no fam no, nneɛma bɛyɛ wo kɔmpase.
 1. Sikakorabea a Ɛhwɛ Amanaman Ntam Nsiesiei So ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. Amanaman Ntam Sikakorabea ([IMF](https://www.imf.org/en/About))
-3. Nhwehwɛmu nkrataa ([krataa](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Nhwehwɛmu nkrataa ([krataa](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Adesua Ho Nsɛmma Nhoma ([nsɛmma nhoma](https://www.bis.org/publ/work976.pdf))
 5. C.E.I Ahyɛde ([Atwerɛ](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/ar/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/ar/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ __الاتحاد الأوروبي: Eurozone CBDC__
 بالنسبة لأولئك الذين يغامرون في الأراضي غير المطروقة لـ CBDCs، تصبح الموارد بوصلتكم.
 1. بنك التسويات الدولية ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. صندوق النقد الدولي ([IMF](https://www.imf.org/en/About))
-3. أوراق بحثية ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. أوراق بحثية ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. مجلات أكاديمية ([journal](https://www.bis.org/publ/work976.pdf))
 5. مقال C.E.I  ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/de/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/de/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Finanzielle Inklusion, einst ein Leuchtfeuer der Hoffnung, steht nun im Schatten
 Für diejenigen, die sich in das unerforschte Gebiet der CBDCs wagen, werden Ressourcen zu Ihrem Kompass.
 1. Die Bank für Internationalen Zahlungsausgleich ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. der Internationale Währungsfonds ([IMF](https://www.imf.org/en/About))
-3. Forschungsarbeiten ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Forschungsarbeiten ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Wissenschaftliche Fachzeitschriften ([journal](https://www.bis.org/publ/work976.pdf))
 5. Artikel von C.E.I ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/ee/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/ee/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Ganyawo ƒe gomekpɔkpɔ le eme, si nye mɔkpɔkpɔ ƒe akaɖi tsã la, dze ŋg�
 Le amesiwo le afɔ tsɔm yi CBDC-wo ƒe anyigbamama si womekpɔ kpɔ o gome la, nunɔamesiwo va zua wò kɔmpasi.
 1. Dukɔwo Dome Nyawo Gbɔkpɔkpɔ ƒe Gadzraɖoƒe ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. Dukɔwo Dome Ganyawo Gbɔkpɔha ([IMF ƒe nyawo](https://www.imf.org/en/About))
-3. Numekuku gbalẽwo ([pɛpa](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Numekuku gbalẽwo ([pɛpa](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Sukudede Ŋuti Nyadzɔdzɔgbalẽwo ([magazine](https://www.bis.org/publ/work976.pdf))
 5. C.E.I Nyati ([Nu](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/es/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/es/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ La inclusión financiera, antes un faro de esperanza, enfrenta las sombras de un
 Para quienes se aventuran en el territorio desconocido de las CBDC, los recursos se convierten en su brújula.
 1. El Banco de Pagos Internacionales ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. el Fondo Monetario Internacional ([IMF](https://www.imf.org/en/About))
-3. Artículos de investigación ([artículo](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Artículos de investigación ([artículo](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Revistas académicas ([revista](https://www.bis.org/publ/work976.pdf))
 5. Artículo de C.E.I  ([Artículo](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/fr/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/fr/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ L’inclusion financière, autrefois un phare d’espoir, se heurte à l’ombre
 Pour celles et ceux qui s’aventurent dans le territoire inexploré des CBDC, les ressources deviennent votre boussole.
 1. La Banque des règlements internationaux ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. le Fonds monétaire international ([IMF](https://www.imf.org/en/About))
-3. Articles de recherche ([article](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Articles de recherche ([article](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Revues universitaires ([revue](https://www.bis.org/publ/work976.pdf))
 5. Article du C.E.I  ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/hi/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/hi/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Eurozone CBDC की सुरक्षा नियामकीय चुनौ
 जो लोग CBDCs के अनजाने क्षेत्र में कदम रख रहे हैं, उनके लिए संसाधन आपका दिशासूचक बन जाते हैं।
 1. Bank for International Settlements ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. International Monetary Fund ([IMF](https://www.imf.org/en/About))
-3. शोध पत्र ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. शोध पत्र ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. शैक्षणिक जर्नल ([journal](https://www.bis.org/publ/work976.pdf))
 5. C.E.I लेख  ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/ig/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/ig/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Financial inclusion, once a beacon of hope, faces the shadows of potential discr
 Maka ndị na-abanye n'ókèala a na-amaghị nke CBDC, akụnụba ga-abụ kọmpas gị.
 1. Ụlọ Akụ Maka Ịgba Ụgwọ Mba Nile ([BIS na-ekwu okwu ya.](https://www.bis.org/search?keywords=cbdc))
 2. Ụlọ ọrụ International Monetary Fund ([IMF na-ekwu okwu ya.](https://www.imf.org/en/About))
-3. Akwụkwọ nyocha ([akwụkwọ](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Akwụkwọ nyocha ([akwụkwọ](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Akwụkwọ akụkọ agụmakwụkwọ ([akwụkwọ akụkọ](https://www.bis.org/publ/work976.pdf))
 5. C.E.I Isiokwu ([Isiokwu nke mbụ](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/it/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/it/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ L'inclusione finanziaria, un tempo faro di speranza, affronta le ombre di una po
 Per chi si avventura nel territorio inesplorato delle CBDC, le risorse diventano la tua bussola.
 1. La Banca dei Regolamenti Internazionali ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. il Fondo Monetario Internazionale ([IMF](https://www.imf.org/en/About))
-3. Paper di ricerca ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Paper di ricerca ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Riviste accademiche ([journal](https://www.bis.org/publ/work976.pdf))
 5. Articolo del C.E.I  ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/ja/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/ja/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -100,7 +100,7 @@ EU加盟国の多様な規制風景は、スムーズな統合に課題をもた
 CBDCという未開拓の領域に足を踏み入れる旅に出る人々にとって、資源はあなたのコンパスになります。
 1. 国際決済銀行（[BIS](https://www.bis.org/search?keywords=cbdc))
 2. 国際通貨基金（[IMF](https://www.imf.org/en/About))
-3. 研究論文 ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. 研究論文 ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. 学術雑誌 ([journal](https://www.bis.org/publ/work976.pdf))
 5. C.E.I 記事 ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/ko/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/ko/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -100,7 +100,7 @@ __유럽 연합: 유럽 통화구역 CBDC__
 CBDC라는 미지의 영역에 뛰어드는 이들에게, 자료는 나침반이 됩니다.
 1. 국제결제은행 ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. 국제통화기금 ([IMF](https://www.imf.org/en/About))
-3. 연구 논문 ([논문](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. 연구 논문 ([논문](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. 학술 저널 ([저널](https://www.bis.org/publ/work976.pdf))
 5. C.E.I 기사  ([기사](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/pt/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/pt/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ A inclusão financeira, antes um farol de esperança, enfrenta as sombras da pot
 Para aqueles que se aventuram no território inexplorado das CBDCs, os recursos tornam-se a sua bússola.
 1. O Banco de Compensações Internacionais ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. o Fundo Monetário Internacional ([FMI](https://www.imf.org/en/About))
-3. Artigos de investigação ([artigo](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Artigos de investigação ([artigo](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Revistas académicas ([revista](https://www.bis.org/publ/work976.pdf))
 5. Artigo do C.E.I ([Artigo](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/ru/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/ru/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ __Европейский союз: CBDC еврозоны__
 Для тех, кто отправляется на неизведанную территорию CBDC, ресурсы становятся вашим компасом.
 1. Банк международных расчётов ([BIS](https://www.bis.org/search/index.htm?globalset_q=cbdc))
 2. Международный валютный фонд ([IMF](https://www.imf.org/en/About))
-3. Научные статьи ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Научные статьи ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Академические журналы ([journal](https://www.bis.org/publ/work976.pdf))
 5. Статья C.E.I ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/sw/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/sw/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Ushirikiano wa kifedha, wakati mmoja kivuli cha matumaini, unakabiliwa na vivuli
 Kwa wale wanaojitokeza katika eneo lisilojulikana la CBDC, rasilimali huwa dira yako.
 1. Benki ya Malipo ya Kimataifa ([BIS ya](https://www.bis.org/search?keywords=cbdc))
 2. Shirika la Kimataifa la Fedha ([IMF](https://www.imf.org/en/About))
-3. Maandishi ya utafiti ([karatasi ya kuandikia](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Maandishi ya utafiti ([karatasi ya kuandikia](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Majarida ya kitaaluma ([jarida la habari](https://www.bis.org/publ/work976.pdf))
 5. C.E.I Makala ([Makala ya](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/tr/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/tr/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Bir zamanlar umut ışığı olan finansal kapsayıcılık, potansiyel ayrımcı
 CBDC'lerin keşfedilmemiş topraklarına adım atanlar için kaynaklar pusulanız hâline gelir.
 1. Uluslararası Ödemeler Bankası ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. Uluslararası Para Fonu ([IMF](https://www.imf.org/en/About))
-3. Araştırma makaleleri ([makale](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Araştırma makaleleri ([makale](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Akademik dergiler ([dergi](https://www.bis.org/publ/work976.pdf))
 5. C.E.I makalesi  ([Makale](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/uk/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/uk/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ __Європейський Союз: CBDC єврозони__
 Для тих, хто вирушає на незвідану територію CBDC, ресурси стають вашим компасом.
 1. Банк міжнародних розрахунків ([BIS](https://www.bis.org/search?keywords=cbdc))
 2. Міжнародний валютний фонд ([IMF](https://www.imf.org/en/About))
-3. Дослідницькі праці ([paper](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Дослідницькі праці ([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Академічні журнали ([journal](https://www.bis.org/publ/work976.pdf))
 5. Стаття C.E.I  ([Article](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/yo/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/yo/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ Bi a ṣe n ṣawari awọn ohun elo ti o ni imọran nipa oni-nọmba, itan kan
 Fún àwọn tí ó ń lọ sí àgbègbè CBDCs, ohun àmúṣọrọ̀ ni kókó ìlà-oòrùn wọn.
 1. Ilé Ìfowópamọ́ fún Àwọn Àkájọ Owo ([BIS (ìyẹn ilé ìfowópamọ́)](https://www.bis.org/search?keywords=cbdc))
 2. àjọ àgbáyé tó ń rí sí owó (i.e., international monetary fund)[IMF (ìyẹn Àjọ Náà)](https://www.imf.org/en/About))
-3. Àwọn ìwé ìwádìí ([ìwé àfọwọ́kọ](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE))
+3. Àwọn ìwé ìwádìí ([ìwé àfọwọ́kọ](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
 4. Àwọn Ìwé Ìròyìn Ẹ̀kọ́ Òye ([ìwé ìròyìn](https://www.bis.org/publ/work976.pdf))
 5. C.E.I Àpilẹ̀kọ ([Àpilẹ̀kọ náà:](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/))
 

--- a/translations/zh/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
+++ b/translations/zh/site/Research/Navigating_the_Central_Bank_Digital_Currency.md
@@ -102,7 +102,7 @@ __欧盟：欧元区 CBDC__
 对于那些踏入 CBDC 未知领域的人来说，资源将成为你的指南针。
 1. 国际清算银行（[BIS](https://www.bis.org/search?keywords=cbdc)）
 2. 国际货币基金组织（[IMF](https://www.imf.org/en/About)）
-3. 研究论文（[论文](https://deliverypdf.ssrn.com/delivery.php?ID=998105006000066124067099122099097121053040051018055094125101013098095097071065120123041031008002042043044095080119019124023085025010021006031087083026113098095102030064008046091121005002106021127103088122029021016098108064080120068125070088112093101069&EXT=pdf&INDEX=TRUE)）
+3. 研究论文（[论文](https://papers.ssrn.com/searchresults.cfm?term=CBDC)）
 4. 学术期刊（[期刊](https://www.bis.org/publ/work976.pdf)）
 5. C.E.I 文章（[文章](https://cei.org/blog/central-banks-are-watching-lets-watch-them-back/)）
 


### PR DESCRIPTION
The translated copies of `Research/Navigating_the_Central_Bank_Digital_Currency.md` carry the **same dead SSRN `delivery.php?ID=…` URL as the English page — byte-identical in all 18 locales.** So the broken link is not a Russian problem or an English problem; readers in every language hit a URL that returns nothing.

```diff
-…([paper](https://deliverypdf.ssrn.com/delivery.php?ID=99810500600006612406709912209909712105304…&EXT=pdf&INDEX=TRUE))
+…([paper](https://papers.ssrn.com/searchresults.cfm?term=CBDC))
```

Same stable search URL the English page adopts in its own PR.

## A substitution, not a re-translation

No engine was run and no prose was touched. **Every changed line is either the link itself or the `tool` marker** recording the pass — 18 link lines, 18 marker lines, nothing else. The marker follows the `+linkrepair` convention already used on this corpus.

That matters because re-translating these pages would re-roll every segment on them: the engines are not deterministic, and on a comparable page a full regeneration carried 8–14 unrelated changed lines per locale, one of which came back worse.

## Ordering

Pairs with the English fix. Either can merge first — the link text is identical in both, and this PR does not touch the page's prose.

All five checks pass locally against `main`.