### PR TITLE
i18n: let a human authorise the twenty pages that can never settle

### DIFF
--- a/translation/README-sync.md
+++ b/translation/README-sync.md
@@ -28,7 +28,9 @@ detects that staleness deterministically.
     "guides/Zgo_Payment_Processor.md": {
       "src": "sha256:…",         // normalized hash of the English source this
                                  // translation was made from — the staleness key
-      "src_commit": "…",         // commit the source was read at (audit only)
+      "src_commit": "…",         // commit the source was read at; the staleness
+                                 //   detector compares against it to decide whether
+                                 //   a stale page is high-severity
       "engine": "llm",           // llm | nllb | gt
       "mode": "seed",            // seed | diff | full
       "tool": "gpt-5.4",         // generator tag, for reproducibility

--- a/translation/README-sync.md
+++ b/translation/README-sync.md
@@ -70,3 +70,26 @@ node --test translation/lib/normalize-hash.test.mjs
 
 The seeder stamps the present (every locale fresh at the current source hash);
 it never reconstructs history. Real staleness accrues only as `site/` changes.
+
+## Known gate limit: copy, then retire (Q5)
+
+The gate identifies a moved translation by matching its normalized text to a
+manifest key removed in the same comparison. Copying a page or locale to a new
+key while retaining the old key gives it no predecessor. The new record can
+therefore claim a newer `src` without a changed translation or a human exception.
+Retiring the old key in a later PR does not recover that relationship. This can
+leave stale text marked current indefinitely; it is a freshness gap.
+
+Round 9 accepts this limit under the constraints of one content matcher and no
+new false refusals. Searching all base entries would also match legitimate new
+translations: English passthrough pages already share text across locales.
+Even a unique matching hash does not establish that a new translation was copied
+rather than independently produced. Allowing ambiguous additions leaves the
+copy route open; refusing them blocks honest seeding. A manifest field declaring
+an addition to be a seed cannot independently establish its provenance either.
+
+For a move, retain the old record's `src` unless the translation actually changes
+or a human verifies it. Prefer moving the key and file in one PR so the existing
+predecessor check can apply. This is an operating convention, not enforcement of
+the split-PR case. Closing that case requires revisiting the evidence or the
+acceptance policy; the gate does not certify the provenance of new keys.

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -439,11 +439,11 @@ for (const loc of locales) {
 }
 
 // The translation ON DISK, hashed the same way as the English so a line can pin
-// both sides of what a person actually looked at. Note "on disk": this reads the
-// working tree, while the change-tracking below reads the two commits. In CI they
-// are the same thing — the checkout is clean — but a local run against a dirty
-// tree is answering a slightly different question, and a `src` bump you have not
-// committed yet will read as unchanged here.
+// both sides of what a person actually looked at. "On disk" is not a caveat here,
+// it is what the whole check reads: the manifest, both page hashes, and the diff
+// that narrows the work all describe the working tree. An uncommitted change is
+// therefore seen and judged — which is why a dirty tree gets a notice saying the
+// answer describes your disk rather than the commit CI will look at.
 const transHashCache = new Map();
 function translationHash(loc, page) {
   const k = `${loc}/${page}`;

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -164,7 +164,9 @@ const verifiedNoops = (() => {
 function localeDirs() {
   let out;
   try {
-    out = execFileSync("git", ["ls-files", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+    // -z: without it git C-quotes any non-ASCII path, and a quoted path matches
+    // none of the tests below — the file would leave the corpus unnoticed.
+    out = execFileSync("git", ["ls-files", "-z", "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
   } catch (e) {
     // An empty set here means "no locale directories exist", which would hide
     // the entire translated corpus and pass every bijection check vacuously.
@@ -173,7 +175,7 @@ function localeDirs() {
     return new Set();
   }
   const dirs = new Set();
-  for (const p of out.split("\n")) {
+  for (const p of out.split("\0")) {
     const m = p.match(/^translations\/([^/]+)\/site\//);
     if (m) dirs.add(m[1]);
   }
@@ -331,7 +333,7 @@ function pathAtBase(relPath) {
 function localeFiles(loc) {
   let out;
   try {
-    out = execFileSync("git", ["ls-files", `translations/${loc}/site/`], {
+    out = execFileSync("git", ["ls-files", "-z", "--", `translations/${loc}/site/`], {
       cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT,
     });
   } catch (e) {
@@ -342,7 +344,7 @@ function localeFiles(loc) {
     return new Set();
   }
   return new Set(
-    out.split("\n")
+    out.split("\0")
       .filter((p) => p.endsWith(".md"))
       .map((p) => p.replace(`translations/${loc}/site/`, "")),
   );

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -46,6 +46,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 import { hashPage } from "./lib/normalize-hash.mjs";
+import { parseVerifiedNoops, noopAllowed } from "./lib/verified-noops.mjs";
 
 const root = fileURLToPath(new URL("../", import.meta.url));
 const VALID_ENGINES = new Set(["llm", "nllb", "gt"]);
@@ -81,6 +82,11 @@ function baseRef() {
 
 const violations = [];
 const fail = (msg) => violations.push(msg);
+// Non-fatal. A notice is for something a human should tidy but that is not wrong:
+// it must never change the exit code, or an ordinary edit elsewhere would turn
+// this check red for housekeeping.
+const notices = [];
+const note = (msg) => notices.push(msg);
 
 // ---- load data ------------------------------------------------------------
 
@@ -99,6 +105,25 @@ try {
   report();
 }
 const locales = Object.keys(manifest);
+
+// ---- the human-authored Direction 2 exception list ------------------------
+// Absent means no exceptions, which is exactly the behaviour before it existed.
+const VERIFIED_NOOPS_PATH = "translation/verified-noops.txt";
+const verifiedNoops = (() => {
+  const abs = join(root, VERIFIED_NOOPS_PATH);
+  if (!existsSync(abs)) return new Map();
+  const { entries, errors } = parseVerifiedNoops(readFileSync(abs, "utf8"));
+  for (const e of errors) fail(`${VERIFIED_NOOPS_PATH}: ${e}`);
+  for (const key of entries.keys()) {
+    const [loc, ...rest] = key.split("/");
+    const page = rest.join("/");
+    // A line naming a page or locale that does not exist is a typo, and a typo
+    // here silently grants nothing while looking like it grants something.
+    if (!manifest[loc]) fail(`${VERIFIED_NOOPS_PATH}: unknown locale "${loc}" in "${key}"`);
+    else if (!curatedSet.has(page)) fail(`${VERIFIED_NOOPS_PATH}: "${page}" is not a curated page (in "${key}")`);
+  }
+  return entries;
+})();
 
 // ---- locale universe: manifest keys ⇔ translations/<loc> directories ------
 // The manifest defines the locale universe for detection, so it must not be
@@ -309,6 +334,25 @@ for (const loc of locales) {
   }
 }
 
+// ---- expired exception lines ----------------------------------------------
+// A line in verified-noops.txt names the English version it is about, so it stops
+// applying by itself once that page's English moves on. Expiry is the design
+// working, not a fault — so this is a notice, never a failure. Without it the
+// file would silently accumulate lines nobody can tell are dead.
+//
+// The other way a line dies — its PR having merged — needs the base manifest to
+// tell apart "already settled" from "settling right now", so it is reported
+// further down, inside the change-tracking block.
+for (const [key, sha] of verifiedNoops) {
+  const [loc, ...rest] = key.split("/");
+  const page = rest.join("/");
+  if (!manifest[loc] || !curatedSet.has(page)) continue;   // already failed above
+  const current = currentHash(page);
+  if (current !== null && current !== sha) {
+    note(`${VERIFIED_NOOPS_PATH}: "${key}" no longer applies — it names ${sha.slice(0, 19)}… but that page's English is now ${current.slice(0, 19)}…, so the line can be removed`);
+  }
+}
+
 // ---- change-tracking (git, optional) --------------------------------------
 
 // Set when --base was passed but carries no usable value. Distinct from "no
@@ -380,6 +424,7 @@ if (baseArgInvalid) {
     // silent skip. `ls-tree` is also cheaper: it answers from the tree objects
     // and never needs the blob at all.
     let baseManifest = null;
+    let baseVerifiedNoops = new Map();
     let firstIntroduction = false;
     let baseUnreadable = false;
     const baseManifestPath = `${mergeBase}:translation/sync-state.json`;
@@ -402,6 +447,40 @@ if (baseArgInvalid) {
     } else if (!baseUnreadable) {
       try {
         baseManifest = JSON.parse(execFileSync("git", ["show", baseManifestPath], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
+        // The allowlist as it stood at the base, so an authorisation can be spent
+        // exactly once.
+        //
+        // Absence and failure must not look alike here. An empty base list makes
+        // every line look NEW, which silently removes the single-use guard and
+        // reopens laundering — with a green exit and no message. That is the same
+        // inference this file already warns about twice, and it is worse on this
+        // repo: it is cloned --filter=blob:none, so an unreachable promisor turns
+        // a network hiccup into a disabled safeguard. So probe with ls-tree,
+        // where absence and presence are both exit 0 and distinguished by output,
+        // and treat a non-zero exit as a failure rather than as "no file".
+        let noopsAtBase = null;
+        try {
+          noopsAtBase = execFileSync(
+            "git",
+            ["ls-tree", "--name-only", mergeBase, "--", VERIFIED_NOOPS_PATH],
+            { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT },
+          );
+        } catch (e) {
+          fail(
+            `could not determine whether ${VERIFIED_NOOPS_PATH} exists at base ${mergeBase.slice(0, 12)} ` +
+            `(${e.code || e.message}) — refusing to treat that as "no exceptions were spent", ` +
+            `which would let a spent line authorise again.`,
+          );
+        }
+        if (noopsAtBase !== null && noopsAtBase.trim() !== "") {
+          try {
+            baseVerifiedNoops = parseVerifiedNoops(
+              execFileSync("git", ["show", `${mergeBase}:${VERIFIED_NOOPS_PATH}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }),
+            ).entries;
+          } catch (e) {
+            fail(`could not read ${VERIFIED_NOOPS_PATH} at base ${mergeBase.slice(0, 12)} (${e.code || e.message}) — refusing to guess that it was empty.`);
+          }
+        }
       } catch (e) {
         baseUnreadable = true;
         fail(
@@ -455,6 +534,17 @@ if (baseArgInvalid) {
         }
       }
 
+      // A line whose entry was ALREADY at this source before the change is spent:
+      // Direction 2 only consults the list when a change advances `src`, so such
+      // a line cannot be doing anything for this PR or any later one. Reported
+      // only against the base, so the very PR that settles an entry is not told
+      // its own lines are useless.
+      for (const [key, sha] of verifiedNoops) {
+        if (baseVerifiedNoops.get(key) === sha) {
+          note(`${VERIFIED_NOOPS_PATH}: "${key}" has done its job — an authorisation is spent by the change that introduces it, so this line no longer grants anything and can be removed`);
+        }
+      }
+
       // Direction 2 — manifest src changed ⇒ the translation must have changed
       // too. Otherwise a one-commit hash bump marks a genuinely-stale translation
       // "fresh" forever — the exact lie this gate exists to prevent.
@@ -463,7 +553,20 @@ if (baseArgInvalid) {
           const was = baseManifest[loc]?.[page];
           if (!was) continue; // new entry — bijection ensures a matching file
           if (now.src !== was.src && !changedSet.has(`${loc}/${page}`)) {
-            fail(`${loc}/${page}: manifest src changed but the translation file did not — a hash bump alone would mark a stale translation "fresh"`);
+            // Unless a human has listed this exact page against this exact
+            // source in translation/verified-noops.txt, confirming the committed
+            // translation is already correct for it. The pipeline writes the
+            // manifest and cannot write that file, so the exception needs two
+            // parties to agree — see lib/verified-noops.mjs.
+            const key = `${loc}/${page}`;
+            if (noopAllowed({
+              entry: now,
+              baseEntry: was,
+              listed: verifiedNoops.get(key),
+              listedInBase: baseVerifiedNoops.get(key),
+              currentSourceHash: currentHash(page),
+            })) continue;
+            fail(`${loc}/${page}: manifest src changed but the translation file did not — a hash bump alone would mark a stale translation "fresh". If the committed translation is genuinely already correct for this source, a human can record that in ${VERIFIED_NOOPS_PATH} as "${loc}/${page} ${now.src}".`);
           }
         }
       }
@@ -474,6 +577,7 @@ if (baseArgInvalid) {
 report();
 
 function report() {
+  for (const n of notices) console.log(`  note: ${n}`);
   if (violations.length === 0) {
     console.log(`Manifest invariants hold: ${curated.length} curated pages, ${locales.length} locales.`);
     process.exit(0);

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -8,7 +8,7 @@
 //
 // Invariants enforced:
 //
-//   Bijection (always, no git needed)
+//   Bijection (always; needs git to list the tree, but no base ref)
 //     - Every listed curated page exists in site/  (no phantom curated entries).
 //     - Per locale: the set of manifest entries == the set of translated files
 //       present under translations/<locale>/site/  (no orphan translations
@@ -355,11 +355,24 @@ for (const loc of locales) {
 
 // ---- freshness declaration ------------------------------------------------
 
+// Hash a page from disk, or null when there is no page there. An unreadable file
+// is neither: it is a finding. Letting the read throw would abandon every
+// violation already collected and print a stack trace instead of the report.
+function hashFileOrNull(abs, label) {
+  if (!existsSync(abs) || !statSync(abs).isFile()) return null;
+  try {
+    return hashPage(readFileSync(abs, "utf8"));
+  } catch (e) {
+    fail(`${label}: cannot be read (${e.code || e.message})`);
+    return null;
+  }
+}
+
 const srcHashCache = new Map();
 function currentHash(page) {
   if (!srcHashCache.has(page)) {
     const abs = join(root, "site", page);
-    srcHashCache.set(page, (existsSync(abs) && statSync(abs).isFile()) ? hashPage(readFileSync(abs, "utf8")) : null);
+    srcHashCache.set(page, hashFileOrNull(abs, `site/${page}`));
   }
   return srcHashCache.get(page);
 }
@@ -367,7 +380,11 @@ for (const loc of locales) {
   for (const [page, e] of Object.entries(manifest[loc])) {
     if (currentHash(page) === e.src) {
       const abs = join(root, "translations", loc, "site", page);
-      if (!existsSync(abs)) fail(`${loc}/${page}: claims freshness but translated file is absent`);
+      // isFile, not merely exists: a DIRECTORY at a page's path reads as a
+      // deletion to git, and a deletion counts as "changed" — which is the
+      // classification that satisfies Direction 2. Without this, replacing a
+      // translation with a directory of the same name settled a stale page.
+      if (!existsSync(abs) || !statSync(abs).isFile()) fail(`${loc}/${page}: claims freshness but there is no translated file there`);
     }
   }
 }
@@ -383,7 +400,7 @@ function translationHash(loc, page) {
   const k = `${loc}/${page}`;
   if (!transHashCache.has(k)) {
     const abs = join(root, "translations", loc, "site", page);
-    transHashCache.set(k, (existsSync(abs) && statSync(abs).isFile()) ? hashPage(readFileSync(abs, "utf8")) : null);
+    transHashCache.set(k, hashFileOrNull(abs, `translations/${loc}/site/${page}`));
   }
   return transHashCache.get(k);
 }
@@ -588,6 +605,34 @@ if (baseArgInvalid) {
         }
       } catch { /* status is advisory; never let it end the run */ }
 
+      // A manifest key that did not exist at base has no `src` to compare against,
+      // so it used to be skipped outright. That made a RENAME a way to settle a
+      // stale page: move the English, move its stale translation verbatim, move
+      // the manifest key, set `src` to the new English, and the entry is new so
+      // nothing looks at it. Not a corner case — the gate's own advice about a
+      // moved page says to put the new path in curated-pages.txt, and 9dcac0e4,
+      // the commit this whole exception exists for, was itself a route change.
+      //
+      // A moved page is not a new page: the translation came from somewhere, and
+      // that somewhere is a base entry whose key has since disappeared. Follow the
+      // CONTENT to find it, and the moved page keeps the record it always had.
+      const inheritedBase = (loc, page) => {
+        const th = translationHash(loc, page);
+        if (th === null) return undefined;
+        const baseBlock = baseManifest[loc];
+        if (!baseBlock) return undefined;
+        for (const [oldPage, oldEntry] of Object.entries(baseBlock)) {
+          if (manifest[loc][oldPage]) continue;     // that key still exists; not a move
+          const rel = `translations/${loc}/site/${oldPage}`;
+          let text;
+          try {
+            text = execFileSync("git", ["show", `${mergeBase}:${rel}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+          } catch { continue; }                     // no such file at base
+          if (hashPage(text) === th) return oldEntry;
+        }
+        return undefined;
+      };
+
       const worktreeText = (rel) => {
         try {
           return readFileSync(join(root, rel), "utf8");
@@ -621,8 +666,18 @@ if (baseArgInvalid) {
             fail(`${path} ${side} not a regular file (mode ${mode}) — translations must be ordinary files, not symlinks or submodules.`);
           }
         }
-        // A mode of 000000 is a real addition or deletion; that is a change.
-        if (srcMode === "000000" || dstMode === "000000") { changedPaths.push(path); continue; }
+        // A deletion is a change. An ADDITION usually is too — but with
+        // --no-renames a moved file arrives as one, and a page that merely moved
+        // is not a page that was retranslated. Calling it "changed" is what let a
+        // route rename settle a stale translation, so follow the content: if this
+        // file is the one that used to live under a manifest key that has since
+        // disappeared, it moved, and nothing about it changed.
+        if (dstMode === "000000") { changedPaths.push(path); continue; }
+        if (srcMode === "000000") {
+          const mm = path.match(/^translations\/([^/]+)\/site\/(.+)$/);
+          if (!(mm && inheritedBase(mm[1], mm[2]))) changedPaths.push(path);
+          continue;
+        }
         const before = blobText(srcOid);
         // Diffing a commit against the working tree, git reports a null oid for
         // anything not staged — it has no object to name yet. The content still
@@ -670,8 +725,8 @@ if (baseArgInvalid) {
       // "fresh" forever — the exact lie this gate exists to prevent.
       for (const loc of locales) {
         for (const [page, now] of Object.entries(manifest[loc])) {
-          const was = baseManifest[loc]?.[page];
-          if (!was) continue; // new entry — bijection ensures a matching file
+          const was = baseManifest[loc]?.[page] ?? inheritedBase(loc, page);
+          if (!was) continue; // genuinely new — bijection ensures a matching file
           if (now.src !== was.src && !changedSet.has(`${loc}/${page}`)) {
             // Unless a human has listed this exact page against this exact
             // source in translation/verified-noops.txt, confirming the committed
@@ -702,13 +757,21 @@ if (baseArgInvalid) {
             // printing one anyway sends the operator round a loop: they add
             // exactly what was asked for and the same refusal comes back.
             const srcMatchesDisk = now.src === currentHash(page);
-            const suggestion = !srcMatchesDisk
+            // A page held as hand-edited is out of automated sync, and an
+            // exception cannot settle it — noopAllowed refuses on `edited` before
+            // it ever looks at a line. Offering one anyway is the same loop as
+            // above: the operator adds exactly what was printed and the identical
+            // refusal comes back.
+            const heldByHand = now.edited !== false || (was && was.edited !== false);
+            const suggestion = heldByHand
+              ? `but this page is held as hand-edited (edited:true), which takes it out of automated sync — no exception applies while that is set, so either clear the flag or retranslate the page`
+              : !srcMatchesDisk
               ? `but note the manifest records src ${String(now.src).slice(0, 20)}… while site/${page} hashes to ${String(currentHash(page)).slice(0, 20)}… — no exception can bridge that, because a line pins the manifest to the English actually on disk. Fix the recorded src first`
               : inexpressible
               ? `this page cannot be authorised: its path contains whitespace or "#", which ${VERIFIED_NOOPS_PATH} has no way to express — rename the page, or settle it with a real translation change`
               : th === null
               ? `there is no translation file at translations/${loc}/site/${page} to name, so the exception cannot apply — the missing file is the thing to fix`
-              : `a human can record that in ${VERIFIED_NOOPS_PATH} as "${loc}/${page} ${now.src} ${th}" — naming both the English checked and the translation found already correct for it`;
+              : `a human can record that in ${VERIFIED_NOOPS_PATH} as "${loc}/${page} ${now.src} ${th}" — naming both the English checked and the translation found already correct for it${verifiedNoops.has(key) ? `. REPLACE the existing line for this page: a second line for the same key is a duplicate and fails the check` : ""}`;
             fail(`${loc}/${page}: manifest src changed but the translation file did not — a hash bump alone would mark a stale translation "fresh". If the committed translation is genuinely already correct for this source, ${suggestion}.`);
           }
         }

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -664,7 +664,7 @@ if (baseArgInvalid) {
           // paths stand still, nothing comes free, and asking git for each of
           // them is one invocation per pair. That run has already failed on the
           // diff; it does not also need to take 27 seconds about it.
-          if (touched === null && manifest[loc]?.[page]) continue;
+          if (touched === null) continue;
           if (!isBlock(baseManifest[loc][page])) continue;   // malformed: not a record
           const h = baseHash(loc, page);
           if (h === null) continue;

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -122,6 +122,16 @@ for (const loc of locales) {
     fail(`manifest locale "${loc}" is not an object — cannot read its entries.`);
     report();
   }
+  // And each record. Everything downstream reads fields off these; a value that
+  // is not a record makes that a TypeError, which throws away the report and
+  // every finding already in it. The checks further down test what a record
+  // SAYS; this one establishes that there is a record to ask.
+  for (const [page, entry] of Object.entries(manifest[loc])) {
+    if (!isBlock(entry)) {
+      fail(`${loc}/${page}: manifest entry is not an object — there is nothing to check.`);
+      report();
+    }
+  }
 }
 
 // ---- the human-authored Direction 2 exception list ------------------------
@@ -653,6 +663,7 @@ if (baseArgInvalid) {
           // them is one invocation per pair. That run has already failed on the
           // diff; it does not also need to take 27 seconds about it.
           if (touched === null && manifest[loc]?.[page]) continue;
+          if (!isBlock(baseManifest[loc][page])) continue;   // malformed: not a record
           const h = baseHash(loc, page);
           if (h === null) continue;
           predecessors.set(h, [...(predecessors.get(h) || []), { loc, page, entry: baseManifest[loc][page] }]);
@@ -683,7 +694,14 @@ if (baseArgInvalid) {
             // honest work: three pages in this corpus carry one translation
             // across up to 17 locales (the English, passed through untranslated),
             // and seeding any new locale lands on them.
-            const disagree = new Set(candidates.map((c) => `${c.entry.src} ${c.entry.edited}`));
+            // Compare the two fields as VALUES, not as text. `false` and the
+            // string "false" print the same and are not the same: noopAllowed
+            // admits one and refuses the other, so a key that conflates them
+            // would call two candidates equivalent when they decide the page
+            // differently. `edited` is keyed as "is it exactly false", because
+            // that is the only distinction anything downstream makes of it.
+            const disagree = new Set(candidates.map((c) =>
+              JSON.stringify([c.entry.src ?? null, c.entry.edited === false])));
             if (disagree.size > 1) {
               fail(`${loc}/${page}: this translation is identical to ${candidates.length} entries at the base (${candidates.map((c) => `${c.loc}/${c.page}`).join(", ")}), and they do not agree on the source they were translated against, so which record this page continues cannot be told. Give this page a translation distinct from theirs — re-translating it is the only thing that separates them, and moving one page at a time does not, because a page that is still there counts too.`);
             }

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -140,7 +140,16 @@ const VERIFIED_NOOPS_PATH = "translation/verified-noops.txt";
 const verifiedNoops = (() => {
   const abs = join(root, VERIFIED_NOOPS_PATH);
   if (!existsSync(abs)) return new Map();
-  const { entries, errors } = parseVerifiedNoops(readFileSync(abs, "utf8"));
+  let text;
+  try {
+    text = readFileSync(abs, "utf8");
+  } catch (e) {
+    // Unreadable is not empty. Returning no exceptions would quietly refuse every
+    // page the list authorises; throwing would discard the report entirely.
+    fail(`${VERIFIED_NOOPS_PATH}: cannot be read (${e.code || e.message})`);
+    return new Map();
+  }
+  const { entries, errors } = parseVerifiedNoops(text);
   for (const e of errors) fail(`${VERIFIED_NOOPS_PATH}: ${e}`);
   for (const key of entries.keys()) {
     const [loc, ...rest] = key.split("/");
@@ -230,8 +239,11 @@ function localeDirs() {
 // than softening it to a warning. The deletion PR is the cheap moment to catch it.
 //
 //   deleted here  — the source existed at the base ref and is gone now. A
-//                   legitimate editorial act; drop the curated line in the same
-//                   PR and the next sync removes the orphaned translations.
+//                   legitimate editorial act; retire it in the same PR, which
+//                   means the curated line AND the manifest entries AND the
+//                   translated files. Leaving the files for a later sync does not
+//                   work: an entry without a curated line and a file without an
+//                   entry are each refused in their own right.
 //   never existed — a phantom entry (typo, wrong case, wrong directory). A real
 //                   defect in the curated list, not a consequence of this PR.
 
@@ -634,12 +646,34 @@ if (baseArgInvalid) {
       // twice for one fault. Third instance of the cache already used for the
       // English and the translated side.
       const baseHashCache = new Map();
+      // The head-side rule that a translation must be an ordinary file says nothing
+      // about the base, and the base's hash is evidence in the same comparison. A
+      // symlink there reads back as its TARGET PATH, which cannot equal the page
+      // text, so the pair compares unequal forever — "changed", the answer that
+      // settles a source bump. Listed once; the modes come from the same tree read
+      // the head-side rule uses.
+      const baseNonRegular = new Set();
+      try {
+        const listing = execFileSync("git", ["ls-tree", "-r", "-z", mergeBase, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+        for (const rec of listing.split("\0")) {
+          if (!rec) continue;
+          const m = rec.match(/^(\d{6}) \w+ [0-9a-f]+\t([\s\S]+)$/);
+          if (m && m[1] !== "100644" && m[1] !== "100755") baseNonRegular.add(m[2]);
+        }
+      } catch (e) {
+        fail(`could not list translations/ at base ${mergeBase.slice(0, 12)}: ${e.message}`);
+      }
+
       const baseHash = (loc, page) => {
         const k = `${loc}/${page}`;
         if (!baseHashCache.has(k)) baseHashCache.set(k, readBaseHash(loc, page));
         return baseHashCache.get(k);
       };
       function readBaseHash(loc, page) {
+        if (baseNonRegular.has(`translations/${loc}/site/${page}`)) {
+          fail(`translations/${loc}/site/${page} was not a regular file at base ${mergeBase.slice(0, 12)} — what it recorded cannot be read back, so nothing can be compared against it.`);
+          return null;
+        }
         const rel = `translations/${loc}/site/${page}`;
         // A path git did not list has identical bytes at both ends, so the hash
         // already read from the working tree IS the hash at the base. That is the

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -419,14 +419,11 @@ for (const [key, listed] of verifiedNoops) {
   const [loc, ...rest] = key.split("/");
   const page = rest.join("/");
   if (!manifest[loc] || !curatedSet.has(page)) continue;   // noted above; inert
-  // Housekeeping must never be able to end the run. currentHash reads the working
-  // tree, and this loop reaches pages no other loop does, so an unreadable source
-  // here could take down an otherwise-green check for the sake of a notice.
-  let current, currentTrans;
-  try {
-    current = currentHash(page);
-    currentTrans = translationHash(loc, page);
-  } catch { continue; }
+  // Both helpers report an unreadable file and return null, so neither throws and
+  // this loop cannot end the run. A file nothing else reaches still gets reported
+  // once, by the helper, rather than silently skipped here.
+  const current = currentHash(page);
+  const currentTrans = translationHash(loc, page);
   if (current !== null && current !== listed.src) {
     note(`${VERIFIED_NOOPS_PATH}: "${key}" no longer applies — the English it names has changed, so the line can be removed`);
   } else if (currentTrans !== null && currentTrans !== listed.translation) {
@@ -622,7 +619,7 @@ if (baseArgInvalid) {
         const baseBlock = baseManifest[loc];
         if (!baseBlock) return undefined;
         for (const [oldPage, oldEntry] of Object.entries(baseBlock)) {
-          if (manifest[loc][oldPage]) continue;     // that key still exists; not a move
+          if (manifest[loc]?.[oldPage]) continue;   // that key still exists; not a move
           const rel = `translations/${loc}/site/${oldPage}`;
           let text;
           try {

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -158,6 +158,33 @@ function localeDirs() {
   for (const l of manifestLocales) if (!dirs.has(l)) fail(`manifest declares locale "${l}" with no translations/${l}/site/ directory`);
 }
 
+// ---- every tracked translation is an ordinary file -----------------------
+// A symlink's blob holds its TARGET PATH, so the object id and the text a reader
+// actually sees can move independently: the diff says "changed" when the page did
+// not, or says nothing when the target was rewritten underneath it. The change
+// detector refuses that shape when it appears in a diff, but a link that was
+// already there never appears in one — so state the rule over the whole tree,
+// where it is a rule rather than a special case.
+{
+  let listing;
+  try {
+    listing = execFileSync("git", ["ls-files", "-s", "-z", "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+  } catch (e) {
+    fail(`could not list translations/ with modes (${e.code || e.message}) — refusing to treat that as "nothing is there".`);
+    listing = "";
+  }
+  for (const rec of listing.split("\0")) {
+    if (!rec) continue;
+    const m = rec.match(/^(\d{6}) [0-9a-f]+ \d+\t([\s\S]+)$/);
+    if (!m) { fail(`could not parse git ls-files record "${rec.slice(0, 80)}".`); continue; }
+    const [, mode, path] = m;
+    if (!path.endsWith(".md")) continue;
+    if (mode !== "100644" && mode !== "100755") {
+      fail(`${path} is not a regular file (mode ${mode}) — translations must be ordinary files, not symlinks or submodules.`);
+    }
+  }
+}
+
 // ---- bijection: curated ⊆ site -------------------------------------------
 //
 // Still blocking, but the message now distinguishes two very different causes.
@@ -548,7 +575,14 @@ if (baseArgInvalid) {
       // promise about what they are pushing.
       try {
         const dirty = execFileSync("git", ["status", "--porcelain", "-z", "--", "site/", "translations/", "translation/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
-        const n = dirty.split("\0").filter((x) => x.trim() !== "").length;
+        // Each entry is "XY path"; a rename or copy adds a SECOND field for the
+        // old path, so counting fields reports one change as two.
+        const fields = dirty.split("\0").filter((x) => x !== "");
+        let n = 0;
+        for (let i = 0; i < fields.length; i++) {
+          n++;
+          if (/^[RC]/.test(fields[i]) || /^.[RC]/.test(fields[i])) i++;   // skip the old-path field
+        }
         if (n > 0) {
           note(`${n} uncommitted change(s) under site/, translations/ or translation/ — this run describes your WORKING TREE, not the commit CI will check. Commit before trusting a green result.`);
         }
@@ -625,7 +659,7 @@ if (baseArgInvalid) {
         // PR (false/absent → true). `edited:true` already at base is not a
         // standing licence to mutate the file forever with no manifest trace.
         const editFlipped = now.edited === true && was?.edited !== true;
-        const provenanceChanged = !was || now.src !== was.src || now.mode !== was.mode || now.tool !== was.tool;
+        const provenanceChanged = !was || now.src !== was.src || now.mode !== was.mode || now.tool !== was.tool || now.engine !== was.engine;
         if (!provenanceChanged && !editFlipped) {
           fail(`${loc}/${page}: translation changed but manifest provenance did not — record the pass in \`tool\` (free-form, e.g. "${now.tool || "gpt-5.4"}+linkrepair"). Only flip edited:true for a human-authored fix you want protected from machine re-translation: it removes the page from automated sync permanently.`);
         }
@@ -663,7 +697,14 @@ if (baseArgInvalid) {
             // printing a line that cannot parse would send someone to a build
             // that is permanently red for a reason the message does not mention.
             const inexpressible = /[\s#]/.test(`${loc}/${page}`);
-            const suggestion = inexpressible
+            // An exception pins the manifest's src to the English ON DISK. If the
+            // manifest records some other hash, no line can satisfy that, and
+            // printing one anyway sends the operator round a loop: they add
+            // exactly what was asked for and the same refusal comes back.
+            const srcMatchesDisk = now.src === currentHash(page);
+            const suggestion = !srcMatchesDisk
+              ? `but note the manifest records src ${String(now.src).slice(0, 20)}… while site/${page} hashes to ${String(currentHash(page)).slice(0, 20)}… — no exception can bridge that, because a line pins the manifest to the English actually on disk. Fix the recorded src first`
+              : inexpressible
               ? `this page cannot be authorised: its path contains whitespace or "#", which ${VERIFIED_NOOPS_PATH} has no way to express — rename the page, or settle it with a real translation change`
               : th === null
               ? `there is no translation file at translations/${loc}/site/${page} to name, so the exception cannot apply — the missing file is the thing to fix`

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -586,10 +586,31 @@ if (baseArgInvalid) {
         touched = null;
       }
 
-      // Asked for exactly once per path: a manifest key is either still current or
-      // removed, never both, so there is nothing to memoise.
+      // Two readers now ask for the same path — the predecessor index below and
+      // the per-entry comparison after it — so the answer is kept. Not for speed:
+      // an unreadable base file is a violation, and asking twice would report it
+      // twice for one fault. Third instance of the cache already used for the
+      // English and the translated side.
+      const baseHashCache = new Map();
       const baseHash = (loc, page) => {
+        const k = `${loc}/${page}`;
+        if (!baseHashCache.has(k)) baseHashCache.set(k, readBaseHash(loc, page));
+        return baseHashCache.get(k);
+      };
+      function readBaseHash(loc, page) {
         const rel = `translations/${loc}/site/${page}`;
+        // A path git did not list has identical bytes at both ends, so the hash
+        // already read from the working tree IS the hash at the base. That is the
+        // same inference the narrowing above rests on, used here to source an
+        // answer instead of to skip one. It is what keeps a predecessor index
+        // over every base entry from costing one git invocation per pair:
+        // measured on this corpus, 3762 of them take the run from 0.6s to 27.7s.
+        // Only when the file is actually there — an absent one is a finding the
+        // read below reports, not a hash of nothing.
+        if (touched !== null && !touched.has(rel)) {
+          const wt = translationHash(loc, page);
+          if (wt !== null) return wt;
+        }
         try {
           // `cat-file --filters`, not `show`: `show` hands back the raw blob, while
           // the other side of this comparison reads the working tree. Where a
@@ -606,24 +627,35 @@ if (baseArgInvalid) {
           fail(`could not read ${rel} at base ${mergeBase.slice(0, 12)}: ${e.message}`);
           return null;
         }
-      };
+      }
 
       // key -> { was, changed }
       //
       // A page that moved is still the page it was, and its record should move
-      // with it. Its predecessor is a manifest key that disappeared in this same
-      // change and whose translation is the one now sitting at the new key.
+      // with it. Its predecessor is a base manifest key whose translation is the
+      // one now sitting at the new key.
       // Keys, not paths, and across ALL locales: renaming `translations/it` to
       // `translations/it-IT` moves every page at once, and searching only within
       // a locale made all 18 of them look brand new — which is how a locale-code
       // migration could mark stale translations current.
-      const removed = new Map();
+      // And across all base keys, INCLUDING ones that still exist. A move split
+      // across two pull requests copies the page in the first and retires the old
+      // key in the second; if only keys that disappeared here could be a
+      // predecessor, the copying half has nothing to compare against, so the new
+      // key's `src` is checked against no record at all and can claim an English
+      // its translation was never made against. Both halves go green.
+      const predecessors = new Map();
       for (const loc of Object.keys(baseManifest)) {
         for (const page of Object.keys(baseManifest[loc])) {
-          if (manifest[loc]?.[page]) continue;      // that key still exists; not a move
+          // A key that still exists earns its place in this index only when its
+          // hash comes free from the working tree. With no diff to say which
+          // paths stand still, nothing comes free, and asking git for each of
+          // them is one invocation per pair. That run has already failed on the
+          // diff; it does not also need to take 27 seconds about it.
+          if (touched === null && manifest[loc]?.[page]) continue;
           const h = baseHash(loc, page);
           if (h === null) continue;
-          removed.set(h, [...(removed.get(h) || []), { loc, page, entry: baseManifest[loc][page] }]);
+          predecessors.set(h, [...(predecessors.get(h) || []), { loc, page, entry: baseManifest[loc][page] }]);
         }
       }
 
@@ -640,9 +672,20 @@ if (baseArgInvalid) {
             const before = touched !== null && touched.has(rel) ? baseHash(loc, page) : null;
             changed = before !== null && before !== translationHash(loc, page);
           } else {
-            const candidates = removed.get(translationHash(loc, page)) || [];
-            if (candidates.length > 1) {
-              fail(`${loc}/${page}: this translation is identical to ${candidates.length} entries removed in this change (${candidates.map((c) => `${c.loc}/${c.page}`).join(", ")}), so which one it continues cannot be told and its record cannot be checked. Move one page at a time, or give them distinct translations.`);
+            const candidates = predecessors.get(translationHash(loc, page)) || [];
+            // Several predecessors only matter when they would answer
+            // differently. What is read from `was` on this path is the source it
+            // was translated against and whether it is held as hand-edited —
+            // Direction 2 below, and noopAllowed's refusal on `edited`. Direction
+            // 1 never sees it, because a page that continues a record did not
+            // change. Candidates agreeing on those two give the same verdict
+            // whichever one this page continues, so refusing would only block
+            // honest work: three pages in this corpus carry one translation
+            // across up to 17 locales (the English, passed through untranslated),
+            // and seeding any new locale lands on them.
+            const disagree = new Set(candidates.map((c) => `${c.entry.src} ${c.entry.edited}`));
+            if (disagree.size > 1) {
+              fail(`${loc}/${page}: this translation is identical to ${candidates.length} entries at the base (${candidates.map((c) => `${c.loc}/${c.page}`).join(", ")}), and they do not agree on the source they were translated against, so which record this page continues cannot be told. Give this page a translation distinct from theirs — re-translating it is the only thing that separates them, and moving one page at a time does not, because a page that is still there counts too.`);
             }
             was = candidates[0]?.entry;
             changed = !was;   // a move changed nothing; a genuinely new page is new

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -653,19 +653,7 @@ if (baseArgInvalid) {
         }
         const [, srcMode, dstMode, srcOid, dstOid] = meta;
         const path = rawFields[i + 1];
-        if (srcOid === dstOid) continue;                       // mode-only, incl. `-diff` paths
         if (!/^translations\/[^/]+\/site\/.+\.md$/.test(path)) { changedPaths.push(path); continue; }
-        // A translation must be an ordinary file. A symlink's blob holds its TARGET
-        // PATH, so swapping a page for a link to an identical copy changes the blob
-        // while readFileSync — which follows the link — still sees the same stale
-        // text: the two halves of this check would disagree, and the page would be
-        // settled without a byte of it being retranslated. Verified, so refuse the
-        // shape outright rather than trying to resolve it.
-        for (const [mode, side] of [[srcMode, "was"], [dstMode, "is"]]) {
-          if (mode !== "000000" && mode !== "100644" && mode !== "100755") {
-            fail(`${path} ${side} not a regular file (mode ${mode}) — translations must be ordinary files, not symlinks or submodules.`);
-          }
-        }
         // A deletion is a change. An ADDITION usually is too — but with
         // --no-renames a moved file arrives as one, and a page that merely moved
         // is not a page that was retranslated. Calling it "changed" is what let a

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -235,11 +235,17 @@ function localeDirs() {
 //   never existed — a phantom entry (typo, wrong case, wrong directory). A real
 //                   defect in the curated list, not a consequence of this PR.
 
-// Resolve the comparison point ONCE. The MERGE-BASE, not the base tip: probing
-// the tip answers "is it on main right now", which is a different question and
-// gives the wrong answer on every PR after a deletion has landed. (Confirmed by
-// simulation: an unrelated PR branched after such a deletion was told the page
-// "never did" exist — for a page that had been there for years.)
+// Resolve the comparison point ONCE, and as the MERGE-BASE rather than the base
+// tip. The reason is change-tracking, not the deletion message: comparing against
+// a tip that has moved ahead of the branch reads main's own later commits as
+// reversals, which shows up as a refusal for work the branch never did. Measured:
+// a branch cut before an authorised no-op landed on main is refused when compared
+// against the tip and passes against the merge base.
+//
+// (An earlier note here credited this to the deletion diagnostic instead. That was
+// checked and does not reproduce — the two resolutions give the same answer there,
+// because the base path is only consulted when the page is absent from the working
+// tree, and then the tip answers as well as the merge base.)
 let _baseCmpSha;
 function baseCompareSha() {
   if (_baseCmpSha !== undefined) return _baseCmpSha;
@@ -568,6 +574,18 @@ if (baseArgInvalid) {
           if (!isBlock(baseManifest[loc])) {
             baseUnreadable = true;
             fail(`locale "${loc}" in the manifest at base ${mergeBase.slice(0, 12)} is not an object — cannot change-track against it.`);
+            continue;
+          }
+          // And the records inside. This level was left unchecked while the two
+          // around it were checked, and it is the one where a miss costs a verdict
+          // rather than a crash: a FALSY record reads exactly like "no record at
+          // this key", so the page is taken for a new one and both rules step
+          // over it — the record advances with nothing to check it against.
+          for (const page of Object.keys(baseManifest[loc])) {
+            if (!isBlock(baseManifest[loc][page])) {
+              baseUnreadable = true;
+              fail(`${loc}/${page} in the manifest at base ${mergeBase.slice(0, 12)} is not a record — cannot change-track against it.`);
+            }
           }
         }
       }
@@ -579,11 +597,22 @@ if (baseArgInvalid) {
       // ONE comparison per manifest entry, shared by both rules: did this
       // translation change, and what record did this page have before?
       //
-      // "Changed" means what it means everywhere else in this pipeline — the
-      // normalised text differs (hashPage: line endings, trailing blank lines,
-      // BOM, volatile front matter, Unicode form). Asking git a different
-      // question and treating its answer as this one is what produced the worst
-      // defect this check has had.
+      // "Changed" means the normalised text differs (hashPage: line endings,
+      // trailing blank lines, BOM, volatile front matter, Unicode form). Asking
+      // git a different question and treating its answer as this one is what
+      // produced the worst defect this check has had.
+      //
+      // Be careful with the next step of that thought, because it does not hold.
+      // hashPage is deliberately generous about what counts as a change: on the
+      // ENGLISH side, over-reporting costs a little retranslation and
+      // under-reporting serves a stale page forever, so it errs towards flipping.
+      // Here that asymmetry is INVERTED — a translation counted as changed is what
+      // lets `src` advance, so over-reporting a change under-reports staleness.
+      // The five things above are what hashPage normalises, NOT the set of edits a
+      // reader cannot see: an HTML comment, a zero-width character, an interior
+      // blank line all count as changes and will settle a stale page. That is a
+      // known limit with a test on it, not an oversight; narrowing it would take a
+      // markdown AST, which this pipeline deliberately does not have.
       //
       // git's byte-level diff is used only to NARROW the work. A difference in
       // normalised text implies a difference in bytes, so a path git calls

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -544,49 +544,85 @@ if (baseArgInvalid) {
     if (firstIntroduction) {
       console.log(`notice: base ${mergeBase.slice(0, 12)} has no manifest — first introduction, nothing to change-track.`);
     } else if (!baseUnreadable) {
-      let changed;
+      // ONE comparison per manifest entry, shared by both rules: did this
+      // translation change, and what record did this page have before?
+      //
+      // "Changed" means what it means everywhere else in this pipeline — the
+      // normalised text differs (hashPage: line endings, trailing blank lines,
+      // BOM, volatile front matter, Unicode form). Asking git a different
+      // question and treating its answer as this one is what produced the worst
+      // defect this check has had.
+      //
+      // git's byte-level diff is used only to NARROW the work. A difference in
+      // normalised text implies a difference in bytes, so a path git calls
+      // identical cannot have changed; the reverse does not hold, which is why
+      // the paths git does list are then compared properly.
+      let touched;
       try {
-        changed = execFileSync("git", ["diff", "--raw", "-z", "--no-abbrev", "--no-renames", mergeBase, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+        const listing = execFileSync("git", ["diff", "--name-only", "-z", "--no-renames", mergeBase, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+        touched = new Set(listing.split("\0").filter(Boolean));
       } catch (e) {
         // The base resolved but the diff failed — do not treat as "no changes".
         fail(`git diff against base ${mergeBase.slice(0, 12)} failed: ${e.message}`);
-        changed = "";
+        touched = null;
       }
-      // Whether a translation changed is decided by the SAME notion of "changed"
-      // that the rest of this pipeline uses — hashPage, which ignores line
-      // endings, trailing blank lines, volatile front matter and Unicode form.
-      //
-      // Raw blob identity is not that notion, and the gap was a hole you could
-      // drive a stale page through: append two blank lines to an out-of-date
-      // translation, advance `src` and `tool`, and Direction 1 saw recorded
-      // provenance while Direction 2 saw a changed blob. No exception, no human,
-      // and a translation still carrying the old text was marked current. Line
-      // counts had the same hole; a pure mode change and a `-diff` path were the
-      // narrow, zero-byte corner of it.
-      //
-      // So: cheap blob check first (identical oid cannot be a content change, and
-      // that alone disposes of chmod and of `-diff` paths), then compare the
-      // NORMALISED text of the two blobs. Direction 2 and the exception's
-      // translation pin now answer the same question.
-      // Raw -z alternates a metadata field and a path field:
-      //   :<srcmode> <dstmode> <srcoid> <dstoid> <status>\0<path>\0
-      const RAW_META = /^:(\d{6}) (\d{6}) ([0-9a-f]{40,}) ([0-9a-f]{40,}) ([A-Z])/;
-      const NULL_OID = /^0+$/;
-      const blobText = (oid) => {
-        try {
-          return execFileSync("git", ["cat-file", "blob", oid], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
-        } catch (e) {
-          // Unreadable blob: we cannot say the file is unchanged, and guessing is
-          // how a stale translation gets waved through. Refuse the run.
-          fail(`could not read git blob ${oid.slice(0, 12)}: ${e.message}`);
-          return null;
+
+      const baseHashes = new Map();
+      const baseHash = (loc, page) => {
+        const rel = `translations/${loc}/site/${page}`;
+        if (!baseHashes.has(rel)) {
+          let hash = null;
+          try {
+            hash = hashPage(execFileSync("git", ["show", `${mergeBase}:${rel}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
+          } catch (e) {
+            // Only ever asked for a path the BASE manifest names, so the file was
+            // there. Failing to read it is a finding, not an absence — and it must
+            // not read as "changed", because that is the answer that satisfies
+            // Direction 2 and would license the very bump we cannot verify.
+            fail(`could not read ${rel} at base ${mergeBase.slice(0, 12)}: ${e.message}`);
+          }
+          baseHashes.set(rel, hash);
         }
+        return baseHashes.get(rel);
       };
-      // Everything here reads the working tree — the diff is base-vs-disk, and
-      // currentHash/translationHash read disk too, so the answer is coherent. But
-      // it is an answer ABOUT DISK, and CI will be asking about your commit. Say
-      // so when the two can differ, or a contributor reads "invariants hold" as a
-      // promise about what they are pushing.
+
+      // key -> { was, changed }
+      const comparisons = new Map();
+      for (const loc of locales) {
+        const baseBlock = baseManifest[loc] || {};
+        // Pages whose manifest key disappeared: a moved page's translation came
+        // from one of these. Identical content in two of them means the move
+        // cannot be identified, and a claim that cannot be checked is refused.
+        const removed = new Map();
+        for (const [oldPage, oldEntry] of Object.entries(baseBlock)) {
+          if (manifest[loc][oldPage]) continue;
+          const h = baseHash(loc, oldPage);
+          if (h === null) continue;
+          removed.set(h, [...(removed.get(h) || []), { oldPage, oldEntry }]);
+        }
+        for (const page of Object.keys(manifest[loc])) {
+          const rel = `translations/${loc}/site/${page}`;
+          let was = baseBlock[page];
+          let changed;
+          if (was) {
+            // Unlisted by git ⇒ the bytes are identical ⇒ nothing changed. A side
+            // we could not read is not "changed" either: unknown must never be the
+            // answer that lets a source bump through.
+            const before = touched !== null && touched.has(rel) ? baseHash(loc, page) : null;
+            changed = before !== null && before !== translationHash(loc, page);
+          } else {
+            const candidates = removed.get(translationHash(loc, page)) || [];
+            if (candidates.length > 1) {
+              fail(`${loc}/${page}: this translation is identical to ${candidates.length} pages removed in this change (${candidates.map((c) => c.oldPage).join(", ")}) — which one it came from cannot be told, so its record cannot be checked. Settle it with a line in ${VERIFIED_NOOPS_PATH}, or make the move one page at a time.`);
+            }
+            was = candidates[0]?.oldEntry;
+            changed = !was;   // a move changed nothing; a genuinely new page is new
+          }
+          comparisons.set(`${loc}/${page}`, { was, changed });
+        }
+      }
+      const changedSet = new Set([...comparisons].filter(([, c]) => c.changed).map(([k]) => k));
+
       try {
         const dirty = execFileSync("git", ["status", "--porcelain", "-z", "--", "site/", "translations/", "translation/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
         // Each entry is "XY path"; a rename or copy adds a SECOND field for the
@@ -595,106 +631,20 @@ if (baseArgInvalid) {
         let n = 0;
         for (let i = 0; i < fields.length; i++) {
           n++;
-          if (/^[RC]/.test(fields[i]) || /^.[RC]/.test(fields[i])) i++;   // skip the old-path field
+          if (/^[RC]/.test(fields[i]) || /^.[RC]/.test(fields[i])) i++;
         }
         if (n > 0) {
           note(`${n} uncommitted change(s) under site/, translations/ or translation/ — this run describes your WORKING TREE, not the commit CI will check. Commit before trusting a green result.`);
         }
       } catch { /* status is advisory; never let it end the run */ }
 
-      // A manifest key that did not exist at base has no `src` to compare against,
-      // so it used to be skipped outright. That made a RENAME a way to settle a
-      // stale page: move the English, move its stale translation verbatim, move
-      // the manifest key, set `src` to the new English, and the entry is new so
-      // nothing looks at it. Not a corner case — the gate's own advice about a
-      // moved page says to put the new path in curated-pages.txt, and 9dcac0e4,
-      // the commit this whole exception exists for, was itself a route change.
-      //
-      // A moved page is not a new page: the translation came from somewhere, and
-      // that somewhere is a base entry whose key has since disappeared. Follow the
-      // CONTENT to find it, and the moved page keeps the record it always had.
-      const inheritedBase = (loc, page) => {
-        const th = translationHash(loc, page);
-        if (th === null) return undefined;
-        const baseBlock = baseManifest[loc];
-        if (!baseBlock) return undefined;
-        for (const [oldPage, oldEntry] of Object.entries(baseBlock)) {
-          if (manifest[loc]?.[oldPage]) continue;   // that key still exists; not a move
-          const rel = `translations/${loc}/site/${oldPage}`;
-          let text;
-          try {
-            text = execFileSync("git", ["show", `${mergeBase}:${rel}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
-          } catch { continue; }                     // no such file at base
-          if (hashPage(text) === th) return oldEntry;
-        }
-        return undefined;
-      };
-
-      const worktreeText = (rel) => {
-        try {
-          return readFileSync(join(root, rel), "utf8");
-        } catch (e) {
-          fail(`could not read ${rel} from the working tree: ${e.message}`);
-          return null;
-        }
-      };
-      const rawFields = changed.split("\0");
-      const changedPaths = [];
-      for (let i = 0; i + 1 < rawFields.length; i += 2) {
-        const meta = rawFields[i].match(RAW_META);
-        if (!meta) {
-          // An unrecognised record means we are not reading what we think we are.
-          // Staying silent here is how a fail-open starts, so refuse the run.
-          if (rawFields[i] !== "") fail(`could not parse git raw diff record "${rawFields[i].slice(0, 80)}" — refusing to guess which translations changed.`);
-          continue;
-        }
-        const [, srcMode, dstMode, srcOid, dstOid] = meta;
-        const path = rawFields[i + 1];
-        if (!/^translations\/[^/]+\/site\/.+\.md$/.test(path)) { changedPaths.push(path); continue; }
-        // A deletion is a change. An ADDITION usually is too — but with
-        // --no-renames a moved file arrives as one, and a page that merely moved
-        // is not a page that was retranslated. Calling it "changed" is what let a
-        // route rename settle a stale translation, so follow the content: if this
-        // file is the one that used to live under a manifest key that has since
-        // disappeared, it moved, and nothing about it changed.
-        if (dstMode === "000000") { changedPaths.push(path); continue; }
-        if (srcMode === "000000") {
-          const mm = path.match(/^translations\/([^/]+)\/site\/(.+)$/);
-          if (!(mm && inheritedBase(mm[1], mm[2]))) changedPaths.push(path);
-          continue;
-        }
-        const before = blobText(srcOid);
-        // Diffing a commit against the working tree, git reports a null oid for
-        // anything not staged — it has no object to name yet. The content still
-        // exists, on disk, which is where the rest of this checker looks, so read
-        // it there. Calling a null oid "changed" without looking would undo the
-        // whole point of comparing normalised text.
-        const after = NULL_OID.test(dstOid) ? worktreeText(path) : blobText(dstOid);
-        if (before === null || after === null) {
-          // Unreadable blob. `fail()` above has already made the run red, but do
-          // NOT also call this path "changed": that classification is what
-          // SATISFIES Direction 2, so an unreadable object would be arguing that
-          // a source bump is fine. Fail-closedness has to live in the decision
-          // itself, not in a separate accumulator that a later edit might soften.
-          continue;
-        }
-        if (hashPage(before) !== hashPage(after)) changedPaths.push(path);
-      }
-      const changedSet = new Set(
-        changedPaths
-          .filter((p) => p.endsWith(".md"))
-          .map((p) => p.match(/^translations\/([^/]+)\/site\/(.+)$/))
-          .filter(Boolean)
-          .map((m) => `${m[1]}/${m[2]}`),
-      );
-
       // Direction 1 — translation changed ⇒ manifest must record why.
       for (const key of changedSet) {
         const [loc, ...rest] = key.split("/");
         const page = rest.join("/");
         const now = manifest[loc]?.[page];
-        const was = baseManifest[loc]?.[page];
         if (!now) continue; // deletion — bijection handles the file/entry pairing
+        const was = comparisons.get(key)?.was;
         // A hand-edit is a valid reason ONLY when the edited flag FLIPS in this
         // PR (false/absent → true). `edited:true` already at base is not a
         // standing licence to mutate the file forever with no manifest trace.
@@ -710,7 +660,7 @@ if (baseArgInvalid) {
       // "fresh" forever — the exact lie this gate exists to prevent.
       for (const loc of locales) {
         for (const [page, now] of Object.entries(manifest[loc])) {
-          const was = baseManifest[loc]?.[page] ?? inheritedBase(loc, page);
+          const was = comparisons.get(`${loc}/${page}`)?.was;
           if (!was) continue; // genuinely new — bijection ensures a matching file
           if (now.src !== was.src && !changedSet.has(`${loc}/${page}`)) {
             // Unless a human has listed this exact page against this exact
@@ -731,12 +681,6 @@ if (baseArgInvalid) {
             // name. With no file on disk the hash is null, and printing that
             // would hand the operator a line the parser rejects.
             const th = translationHash(loc, page);
-            // The file is whitespace-separated and treats `#` as a comment, so a
-            // page path containing either cannot be written as a line at all.
-            // None are curated today, but 39 such files exist under site/, and
-            // printing a line that cannot parse would send someone to a build
-            // that is permanently red for a reason the message does not mention.
-            const inexpressible = /[\s#]/.test(`${loc}/${page}`);
             // An exception pins the manifest's src to the English ON DISK. If the
             // manifest records some other hash, no line can satisfy that, and
             // printing one anyway sends the operator round a loop: they add
@@ -752,8 +696,6 @@ if (baseArgInvalid) {
               ? `but this page is held as hand-edited (edited:true), which takes it out of automated sync — no exception applies while that is set, so either clear the flag or retranslate the page`
               : !srcMatchesDisk
               ? `but note the manifest records src ${String(now.src).slice(0, 20)}… while site/${page} hashes to ${String(currentHash(page)).slice(0, 20)}… — no exception can bridge that, because a line pins the manifest to the English actually on disk. Fix the recorded src first`
-              : inexpressible
-              ? `this page cannot be authorised: its path contains whitespace or "#", which ${VERIFIED_NOOPS_PATH} has no way to express — rename the page, or settle it with a real translation change`
               : th === null
               ? `there is no translation file at translations/${loc}/site/${page} to name, so the exception cannot apply — the missing file is the thing to fix`
               : `a human can record that in ${VERIFIED_NOOPS_PATH} as "${loc}/${page} ${now.src} ${th}" — naming both the English checked and the translation found already correct for it${verifiedNoops.has(key) ? `. REPLACE the existing line for this page: a second line for the same key is a duplicate and fails the check` : ""}`;

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -501,26 +501,42 @@ if (baseArgInvalid) {
     } else if (!baseUnreadable) {
       let changed;
       try {
-        changed = execFileSync("git", ["diff", "--raw", "-z", "--no-renames", `${mergeBase}..HEAD`, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+        changed = execFileSync("git", ["diff", "--raw", "-z", "--no-abbrev", "--no-renames", `${mergeBase}..HEAD`, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
       } catch (e) {
         // The base resolved but the diff failed — do not treat as "no changes".
         fail(`git diff against base ${mergeBase.slice(0, 12)} failed: ${e.message}`);
         changed = "";
       }
-      // Whether a translation's BYTES changed is decided by blob identity, not by
-      // a line count. Two shapes fooled a line-count reading, and each one let a
-      // stale translation be marked current with nothing edited:
-      //   - a pure mode change (100644 -> 100755) reports 0 added / 0 deleted, and
-      //     a path marked `-diff` reports "-\t-" even when the blob is untouched;
-      //   - a renamed-and-edited file reports its paths in SEPARATE NUL fields,
-      //     so a record-per-line reading dropped it and missed a real edit.
-      // `--raw` gives the source and destination object ids directly, so the test
-      // is simply "did the content id move". `--no-renames` keeps every record to
-      // one path: a rename arrives as a delete plus an add, which is the honest
-      // reading — the file at that path really did appear or disappear.
+      // Whether a translation changed is decided by the SAME notion of "changed"
+      // that the rest of this pipeline uses — hashPage, which ignores line
+      // endings, trailing blank lines, volatile front matter and Unicode form.
+      //
+      // Raw blob identity is not that notion, and the gap was a hole you could
+      // drive a stale page through: append two blank lines to an out-of-date
+      // translation, advance `src` and `tool`, and Direction 1 saw recorded
+      // provenance while Direction 2 saw a changed blob. No exception, no human,
+      // and a translation still carrying the old text was marked current. Line
+      // counts had the same hole; a pure mode change and a `-diff` path were the
+      // narrow, zero-byte corner of it.
+      //
+      // So: cheap blob check first (identical oid cannot be a content change, and
+      // that alone disposes of chmod and of `-diff` paths), then compare the
+      // NORMALISED text of the two blobs. Direction 2 and the exception's
+      // translation pin now answer the same question.
       // Raw -z alternates a metadata field and a path field:
-      //   :<srcmode> <dstmode> <srcsha> <dstsha> <status>\0<path>\0
-      const RAW_META = /^:(\d{6}) (\d{6}) ([0-9a-f]+) ([0-9a-f]+) ([A-Z])/;
+      //   :<srcmode> <dstmode> <srcoid> <dstoid> <status>\0<path>\0
+      const RAW_META = /^:(\d{6}) (\d{6}) ([0-9a-f]{40,}) ([0-9a-f]{40,}) ([A-Z])/;
+      const NULL_OID = /^0+$/;
+      const blobText = (oid) => {
+        try {
+          return execFileSync("git", ["cat-file", "blob", oid], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+        } catch (e) {
+          // Unreadable blob: we cannot say the file is unchanged, and guessing is
+          // how a stale translation gets waved through. Refuse the run.
+          fail(`could not read git blob ${oid.slice(0, 12)}: ${e.message}`);
+          return null;
+        }
+      };
       const rawFields = changed.split("\0");
       const changedPaths = [];
       for (let i = 0; i + 1 < rawFields.length; i += 2) {
@@ -531,8 +547,15 @@ if (baseArgInvalid) {
           if (rawFields[i] !== "") fail(`could not parse git raw diff record "${rawFields[i].slice(0, 80)}" — refusing to guess which translations changed.`);
           continue;
         }
-        const [, , , srcSha, dstSha] = meta;
-        if (srcSha !== dstSha) changedPaths.push(rawFields[i + 1]);
+        const [, , , srcOid, dstOid] = meta;
+        const path = rawFields[i + 1];
+        if (srcOid === dstOid) continue;                       // mode-only, incl. `-diff` paths
+        if (!/^translations\/[^/]+\/site\/.+\.md$/.test(path)) { changedPaths.push(path); continue; }
+        if (NULL_OID.test(srcOid) || NULL_OID.test(dstOid)) { changedPaths.push(path); continue; } // added or deleted
+        const before = blobText(srcOid);
+        const after = blobText(dstOid);
+        if (before === null || after === null) { changedPaths.push(path); continue; }
+        if (hashPage(before) !== hashPage(after)) changedPaths.push(path);
       }
       const changedSet = new Set(
         changedPaths

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -505,7 +505,7 @@ if (baseArgInvalid) {
     } else if (!baseUnreadable) {
       let changed;
       try {
-        changed = execFileSync("git", ["diff", "--raw", "-z", "--no-abbrev", "--no-renames", `${mergeBase}..HEAD`, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+        changed = execFileSync("git", ["diff", "--raw", "-z", "--no-abbrev", "--no-renames", mergeBase, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
       } catch (e) {
         // The base resolved but the diff failed — do not treat as "no changes".
         fail(`git diff against base ${mergeBase.slice(0, 12)} failed: ${e.message}`);
@@ -541,6 +541,27 @@ if (baseArgInvalid) {
           return null;
         }
       };
+      // Everything here reads the working tree — the diff is base-vs-disk, and
+      // currentHash/translationHash read disk too, so the answer is coherent. But
+      // it is an answer ABOUT DISK, and CI will be asking about your commit. Say
+      // so when the two can differ, or a contributor reads "invariants hold" as a
+      // promise about what they are pushing.
+      try {
+        const dirty = execFileSync("git", ["status", "--porcelain", "-z", "--", "site/", "translations/", "translation/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+        const n = dirty.split("\0").filter((x) => x.trim() !== "").length;
+        if (n > 0) {
+          note(`${n} uncommitted change(s) under site/, translations/ or translation/ — this run describes your WORKING TREE, not the commit CI will check. Commit before trusting a green result.`);
+        }
+      } catch { /* status is advisory; never let it end the run */ }
+
+      const worktreeText = (rel) => {
+        try {
+          return readFileSync(join(root, rel), "utf8");
+        } catch (e) {
+          fail(`could not read ${rel} from the working tree: ${e.message}`);
+          return null;
+        }
+      };
       const rawFields = changed.split("\0");
       const changedPaths = [];
       for (let i = 0; i + 1 < rawFields.length; i += 2) {
@@ -566,10 +587,23 @@ if (baseArgInvalid) {
             fail(`${path} ${side} not a regular file (mode ${mode}) — translations must be ordinary files, not symlinks or submodules.`);
           }
         }
-        if (NULL_OID.test(srcOid) || NULL_OID.test(dstOid)) { changedPaths.push(path); continue; } // added or deleted
+        // A mode of 000000 is a real addition or deletion; that is a change.
+        if (srcMode === "000000" || dstMode === "000000") { changedPaths.push(path); continue; }
         const before = blobText(srcOid);
-        const after = blobText(dstOid);
-        if (before === null || after === null) { changedPaths.push(path); continue; }
+        // Diffing a commit against the working tree, git reports a null oid for
+        // anything not staged — it has no object to name yet. The content still
+        // exists, on disk, which is where the rest of this checker looks, so read
+        // it there. Calling a null oid "changed" without looking would undo the
+        // whole point of comparing normalised text.
+        const after = NULL_OID.test(dstOid) ? worktreeText(path) : blobText(dstOid);
+        if (before === null || after === null) {
+          // Unreadable blob. `fail()` above has already made the run red, but do
+          // NOT also call this path "changed": that classification is what
+          // SATISFIES Direction 2, so an unreadable object would be arguing that
+          // a source bump is fine. Fail-closedness has to live in the decision
+          // itself, not in a separate accumulator that a later edit might soften.
+          continue;
+        }
         if (hashPage(before) !== hashPage(after)) changedPaths.push(path);
       }
       const changedSet = new Set(
@@ -623,7 +657,15 @@ if (baseArgInvalid) {
             // name. With no file on disk the hash is null, and printing that
             // would hand the operator a line the parser rejects.
             const th = translationHash(loc, page);
-            const suggestion = th === null
+            // The file is whitespace-separated and treats `#` as a comment, so a
+            // page path containing either cannot be written as a line at all.
+            // None are curated today, but 39 such files exist under site/, and
+            // printing a line that cannot parse would send someone to a build
+            // that is permanently red for a reason the message does not mention.
+            const inexpressible = /[\s#]/.test(`${loc}/${page}`);
+            const suggestion = inexpressible
+              ? `this page cannot be authorised: its path contains whitespace or "#", which ${VERIFIED_NOOPS_PATH} has no way to express — rename the page, or settle it with a real translation change`
+              : th === null
               ? `there is no translation file at translations/${loc}/site/${page} to name, so the exception cannot apply — the missing file is the thing to fix`
               : `a human can record that in ${VERIFIED_NOOPS_PATH} as "${loc}/${page} ${now.src} ${th}" — naming both the English checked and the translation found already correct for it`;
             fail(`${loc}/${page}: manifest src changed but the translation file did not — a hash bump alone would mark a stale translation "fresh". If the committed translation is genuinely already correct for this source, ${suggestion}.`);

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -302,8 +302,10 @@ function pathAtBase(relPath) {
       `but are still listed in translation/curated-pages.txt:\n` +
       deletedHere.map((q) => `      - ${q}`).join("\n") +
       `\n    If you DELETED the page: remove those exact lines from ` +
-      `translation/curated-pages.txt here. Leave translations/<locale>/site/ alone — the ` +
-      `next translation sync detects them as orphans and removes them.` +
+      `translation/curated-pages.txt, AND the page's entry from every locale block in ` +
+      `translation/sync-state.json, AND the translated files themselves. All three: a ` +
+      `curated line without a page, an entry without a curated line, and a file without an ` +
+      `entry are each refused, so removing only some of them cannot go green.` +
       `\n    If you RENAMED or MOVED it: put the NEW path in curated-pages.txt instead of ` +
       `deleting the line, or the page silently drops out of translation in all 18 locales.`
     );
@@ -366,7 +368,6 @@ for (const loc of locales) {
   }
   // provenance well-formedness
   for (const [page, e] of Object.entries(entries)) {
-    if (typeof e !== "object" || e === null) { fail(`${loc}/${page}: entry is not an object`); continue; }
     if (typeof e.src !== "string" || !/^sha256:[0-9a-f]{64}$/.test(e.src)) fail(`${loc}/${page}: invalid src hash`);
     if (!VALID_ENGINES.has(e.engine)) fail(`${loc}/${page}: invalid engine "${e.engine}"`);
     if (!VALID_MODES.has(e.mode)) fail(`${loc}/${page}: invalid mode "${e.mode}"`);
@@ -630,7 +631,16 @@ if (baseArgInvalid) {
           // the same page, and every listed path then compares unequal forever —
           // which is the answer that skips Direction 2. Both sides must be read in
           // the form a reader sees.
-          return hashPage(execFileSync("git", ["cat-file", "--filters", `${mergeBase}:${rel}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
+          //
+          // GIT_ATTR_SOURCE pins WHOSE attributes: without it `--filters` reads the
+          // base blob through the attributes in the tree being checked, so adding a
+          // .gitattributes line changes what the BASE is taken to have said. The
+          // base must be read as the base, or a change to the rules is mistaken for
+          // a change to the page.
+          return hashPage(execFileSync("git", ["cat-file", "--filters", `${mergeBase}:${rel}`], {
+            cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT,
+            env: { ...process.env, GIT_ATTR_SOURCE: mergeBase },
+          }));
         } catch (e) {
           // Only ever asked for a path the BASE manifest names, so the file was
           // there. Failing to read it is a finding, not an absence — and it must
@@ -705,7 +715,7 @@ if (baseArgInvalid) {
             const disagree = new Set(candidates.map((c) =>
               JSON.stringify([c.entry.src ?? null, c.entry.edited === false])));
             if (disagree.size > 1) {
-              fail(`${loc}/${page}: this translation is identical to ${candidates.length} entries at the base (${candidates.map((c) => `${c.loc}/${c.page}`).join(", ")}), and they do not agree on the source they were translated against, so which record this page continues cannot be told. Give this page a translation distinct from theirs — re-translating it is the only thing that separates them, and moving one page at a time does not, because a page that is still there counts too.`);
+              fail(`${loc}/${page}: this translation is identical to ${candidates.length} entries at the base (${candidates.map((c) => `${c.loc}/${c.page}`).join(", ")}), and they do not agree on the record they carry — the source they were translated against, or whether they are held as hand-edited — so which one this page continues cannot be told. Give this page a translation distinct from theirs — re-translating it is the only thing that separates them, and moving one page at a time does not, because a page that is still there counts too.`);
             }
             was = candidates[0]?.entry;
             changed = !was;   // a move changed nothing; a genuinely new page is new

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -345,8 +345,12 @@ for (const loc of locales) {
   }
 }
 
-// The committed translation, hashed the same way as the English so a line can
-// pin both sides of what a person actually looked at.
+// The translation ON DISK, hashed the same way as the English so a line can pin
+// both sides of what a person actually looked at. Note "on disk": this reads the
+// working tree, while the change-tracking below reads the two commits. In CI they
+// are the same thing — the checkout is clean — but a local run against a dirty
+// tree is answering a slightly different question, and a `src` bump you have not
+// committed yet will read as unchanged here.
 const transHashCache = new Map();
 function translationHash(loc, page) {
   const k = `${loc}/${page}`;
@@ -547,10 +551,21 @@ if (baseArgInvalid) {
           if (rawFields[i] !== "") fail(`could not parse git raw diff record "${rawFields[i].slice(0, 80)}" — refusing to guess which translations changed.`);
           continue;
         }
-        const [, , , srcOid, dstOid] = meta;
+        const [, srcMode, dstMode, srcOid, dstOid] = meta;
         const path = rawFields[i + 1];
         if (srcOid === dstOid) continue;                       // mode-only, incl. `-diff` paths
         if (!/^translations\/[^/]+\/site\/.+\.md$/.test(path)) { changedPaths.push(path); continue; }
+        // A translation must be an ordinary file. A symlink's blob holds its TARGET
+        // PATH, so swapping a page for a link to an identical copy changes the blob
+        // while readFileSync — which follows the link — still sees the same stale
+        // text: the two halves of this check would disagree, and the page would be
+        // settled without a byte of it being retranslated. Verified, so refuse the
+        // shape outright rather than trying to resolve it.
+        for (const [mode, side] of [[srcMode, "was"], [dstMode, "is"]]) {
+          if (mode !== "000000" && mode !== "100644" && mode !== "100755") {
+            fail(`${path} ${side} not a regular file (mode ${mode}) — translations must be ordinary files, not symlinks or submodules.`);
+          }
+        }
         if (NULL_OID.test(srcOid) || NULL_OID.test(dstOid)) { changedPaths.push(path); continue; } // added or deleted
         const before = blobText(srcOid);
         const after = blobText(dstOid);
@@ -593,8 +608,9 @@ if (baseArgInvalid) {
             // Unless a human has listed this exact page against this exact
             // source in translation/verified-noops.txt, confirming the committed
             // translation is already correct for it. The pipeline writes the
-            // manifest and cannot write that file, so the exception needs two
-            // parties to agree — see lib/verified-noops.mjs.
+            // manifest; nothing in it writes that file, so in practice the claim
+            // and the thing it claims about come from different hands — see
+            // lib/verified-noops.mjs for how far that does and does not go.
             const key = `${loc}/${page}`;
             if (noopAllowed({
               entry: now,

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -200,10 +200,12 @@ function localeDirs() {
 // ---- every tracked translation is an ordinary file -----------------------
 // A symlink's blob holds its TARGET PATH, so the object id and the text a reader
 // actually sees can move independently: the diff says "changed" when the page did
-// not, or says nothing when the target was rewritten underneath it. The change
-// detector refuses that shape when it appears in a diff, but a link that was
-// already there never appears in one — so state the rule over the whole tree,
-// where it is a rule rather than a special case.
+// not, or says nothing when the target was rewritten underneath it. Stated over
+// the whole tree rather than per change, because a link that was already there
+// appears in no diff, and the rule is a property of the corpus rather than of one
+// pull request. (An earlier note credited a per-diff-record check for this; that
+// check was deleted once this one existed.) The base side is covered separately,
+// where its hash is read.
 {
   let listing;
   try {
@@ -254,10 +256,10 @@ function localeDirs() {
 // a branch cut before an authorised no-op landed on main is refused when compared
 // against the tip and passes against the merge base.
 //
-// (An earlier note here credited this to the deletion diagnostic instead. That was
-// checked and does not reproduce — the two resolutions give the same answer there,
-// because the base path is only consulted when the page is absent from the working
-// tree, and then the tip answers as well as the merge base.)
+// The deletion diagnostic is affected too, and in the same direction: where main
+// has since deleted the page, or added it after the branch was cut, the tip and
+// the merge base disagree and the merge base gives the truer message. An earlier
+// note here claimed they were indifferent there; they are not.
 let _baseCmpSha;
 function baseCompareSha() {
   if (_baseCmpSha !== undefined) return _baseCmpSha;
@@ -695,11 +697,16 @@ if (baseArgInvalid) {
           // which is the answer that skips Direction 2. Both sides must be read in
           // the form a reader sees.
           //
-          // GIT_ATTR_SOURCE pins WHOSE attributes: without it `--filters` reads the
-          // base blob through the attributes in the tree being checked, so adding a
-          // .gitattributes line changes what the BASE is taken to have said. The
-          // base must be read as the base, or a change to the rules is mistaken for
-          // a change to the page.
+          // GIT_ATTR_SOURCE pins WHOSE attributes convert it: without it the base
+          // blob is read through the attributes of the tree being checked. Pinning
+          // to the base is correct by construction — read the base as the base —
+          // but be accurate about its worth: a sweep of the attribute transitions
+          // this comment used to cite found no case where it changes a verdict, and
+          // no test pins it. It is kept as a correctness statement, not as a guard
+          // that is known to catch something.
+          //
+          // And it buys nothing on the head side, which applies no attributes at
+          // all: readFileSync reads the bytes on disk. See limit C.
           return hashPage(execFileSync("git", ["cat-file", "--filters", `${mergeBase}:${rel}`], {
             cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT,
             env: { ...process.env, GIT_ATTR_SOURCE: mergeBase },
@@ -738,7 +745,6 @@ if (baseArgInvalid) {
           // them is one invocation per pair. That run has already failed on the
           // diff; it does not also need to take 27 seconds about it.
           if (touched === null) continue;
-          if (!isBlock(baseManifest[loc][page])) continue;   // malformed: not a record
           const h = baseHash(loc, page);
           if (h === null) continue;
           predecessors.set(h, [...(predecessors.get(h) || []), { loc, page, entry: baseManifest[loc][page] }]);

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -477,21 +477,14 @@ if (baseArgInvalid) {
   // Fail closed: a REQUESTED base that can't be resolved must NOT silently skip
   // the gate (force-push, shallow clone, or a typo would otherwise disable the
   // only history-dependent invariant while still exiting green).
-  let baseSha = null;
-  try {
-    baseSha = execFileSync("git", ["rev-parse", "--verify", "--quiet", `${base}^{commit}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }).trim();
-  } catch {
-    baseSha = null;
-  }
-  if (!baseSha) {
+  // baseCompareSha() already answers "which commit do we compare against" — it
+  // resolves the ref and walks back to the merge base, with the same fallback for
+  // unrelated histories. Asking it twice, two different ways, is how the two
+  // answers drift apart.
+  const mergeBase = baseCompareSha();
+  if (!mergeBase) {
     fail(`base ref "${base}" could not be resolved — refusing to skip change-tracking silently (shallow clone? force-push? run CI with fetch-depth: 0).`);
   } else {
-    let mergeBase = baseSha;
-    try {
-      mergeBase = execFileSync("git", ["merge-base", baseSha, "HEAD"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }).trim();
-    } catch {
-      mergeBase = baseSha; // divergent/unrelated history → direct diff against base
-    }
 
     // Whether the manifest existed at the base is a real distinction — absent
     // means this PR introduces it and there is genuinely nothing to
@@ -653,14 +646,7 @@ if (baseArgInvalid) {
 
       try {
         const dirty = execFileSync("git", ["status", "--porcelain", "-z", "--", "site/", "translations/", "translation/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
-        // Each entry is "XY path"; a rename or copy adds a SECOND field for the
-        // old path, so counting fields reports one change as two.
-        const fields = dirty.split("\0").filter((x) => x !== "");
-        let n = 0;
-        for (let i = 0; i < fields.length; i++) {
-          n++;
-          if (/^[RC]/.test(fields[i]) || /^.[RC]/.test(fields[i])) i++;
-        }
+        const n = dirty.split("\0").filter((x) => x !== "").length;
         if (n > 0) {
           note(`${n} uncommitted change(s) under site/, translations/ or translation/ — this run describes your WORKING TREE, not the commit CI will check. Commit before trusting a green result.`);
         }
@@ -718,9 +704,15 @@ if (baseArgInvalid) {
             // it ever looks at a line. Offering one anyway is the same loop as
             // above: the operator adds exactly what was printed and the identical
             // refusal comes back.
-            const heldByHand = now.edited !== false || (was && was.edited !== false);
-            const suggestion = heldByHand
-              ? `but this page is held as hand-edited (edited:true), which takes it out of automated sync — no exception applies while that is set, so either clear the flag or retranslate the page`
+            const heldNow = now.edited !== false;
+            const heldAtBase = Boolean(was) && was.edited !== false;
+            const suggestion = heldNow
+              ? `but this page is held as hand-edited, which takes it out of automated sync — no exception applies while that is set, so either clear the flag or retranslate the page`
+              : heldAtBase
+              // The flag is already clear here; it was set at the base. Telling the
+              // operator to clear it describes what they have just done, and the
+              // refusal comes from history they cannot edit in this change.
+              ? `but this page was held as hand-edited at the base, and an exception cannot reach back past that — land the cleared flag on its own first, or retranslate the page`
               : !srcMatchesDisk
               ? `but note the manifest records src ${String(now.src).slice(0, 20)}… while site/${page} hashes to ${String(currentHash(page)).slice(0, 20)}… — no exception can bridge that, because a line pins the manifest to the English actually on disk. Fix the recorded src first`
               : th === null

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -117,10 +117,13 @@ const verifiedNoops = (() => {
   for (const key of entries.keys()) {
     const [loc, ...rest] = key.split("/");
     const page = rest.join("/");
-    // A line naming a page or locale that does not exist is a typo, and a typo
-    // here silently grants nothing while looking like it grants something.
-    if (!manifest[loc]) fail(`${VERIFIED_NOOPS_PATH}: unknown locale "${loc}" in "${key}"`);
-    else if (!curatedSet.has(page)) fail(`${VERIFIED_NOOPS_PATH}: "${page}" is not a curated page (in "${key}")`);
+    // A line naming a locale or page that does not exist grants nothing — the
+    // key can never match an entry — so this is a notice, not a violation.
+    // Failing here would make retiring a page or a locale impossible until
+    // somebody remembered to edit this file, and would turn a correct cleanup
+    // into a red build. A typo is worth surfacing; it is not worth blocking on.
+    if (!manifest[loc]) note(`${VERIFIED_NOOPS_PATH}: "${key}" names locale "${loc}", which does not exist — the line grants nothing and can be removed`);
+    else if (!curatedSet.has(page)) note(`${VERIFIED_NOOPS_PATH}: "${key}" names a page that is not curated — the line grants nothing and can be removed`);
   }
   return entries;
 })();
@@ -134,7 +137,11 @@ function localeDirs() {
   let out;
   try {
     out = execFileSync("git", ["ls-files", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
-  } catch {
+  } catch (e) {
+    // An empty set here means "no locale directories exist", which would hide
+    // the entire translated corpus and pass every bijection check vacuously.
+    // Absence must be observed, never inferred from a failure.
+    fail(`could not list translations/ (${e.code || e.message}) — refusing to treat that as "nothing is there".`);
     return new Set();
   }
   const dirs = new Set();
@@ -272,7 +279,11 @@ function localeFiles(loc) {
     out = execFileSync("git", ["ls-files", `translations/${loc}/site/`], {
       cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT,
     });
-  } catch {
+  } catch (e) {
+    // Empty would mean "this locale has no files", so every manifest entry for
+    // it would look like an orphan and every real file would go unchecked.
+    // Absence must be observed, never inferred from a failure.
+    fail(`could not list translations/${loc}/site/ (${e.code || e.message}) — refusing to treat that as "nothing is there".`);
     return new Set();
   }
   return new Set(
@@ -334,22 +345,44 @@ for (const loc of locales) {
   }
 }
 
+// The committed translation, hashed the same way as the English so a line can
+// pin both sides of what a person actually looked at.
+const transHashCache = new Map();
+function translationHash(loc, page) {
+  const k = `${loc}/${page}`;
+  if (!transHashCache.has(k)) {
+    const abs = join(root, "translations", loc, "site", page);
+    transHashCache.set(k, (existsSync(abs) && statSync(abs).isFile()) ? hashPage(readFileSync(abs, "utf8")) : null);
+  }
+  return transHashCache.get(k);
+}
+
 // ---- expired exception lines ----------------------------------------------
-// A line in verified-noops.txt names the English version it is about, so it stops
-// applying by itself once that page's English moves on. Expiry is the design
-// working, not a fault — so this is a notice, never a failure. Without it the
-// file would silently accumulate lines nobody can tell are dead.
+// A line in verified-noops.txt names both the English and the translation it is
+// about, so it stops applying by itself once either of them moves on. Expiry is
+// the design working, not a fault — so this is a notice, never a failure.
+// Without it the file would silently accumulate lines nobody can tell are dead.
 //
-// The other way a line dies — its PR having merged — needs the base manifest to
-// tell apart "already settled" from "settling right now", so it is reported
-// further down, inside the change-tracking block.
-for (const [key, sha] of verifiedNoops) {
+// This loop must stay BELOW both hash helpers: it once sat above translationHash's
+// cache, so every call threw on the uninitialised `const` and the catch below
+// swallowed it. The notices were dead for the whole life of the feature and no
+// exit code could show it.
+for (const [key, listed] of verifiedNoops) {
   const [loc, ...rest] = key.split("/");
   const page = rest.join("/");
-  if (!manifest[loc] || !curatedSet.has(page)) continue;   // already failed above
-  const current = currentHash(page);
-  if (current !== null && current !== sha) {
-    note(`${VERIFIED_NOOPS_PATH}: "${key}" no longer applies — it names ${sha.slice(0, 19)}… but that page's English is now ${current.slice(0, 19)}…, so the line can be removed`);
+  if (!manifest[loc] || !curatedSet.has(page)) continue;   // noted above; inert
+  // Housekeeping must never be able to end the run. currentHash reads the working
+  // tree, and this loop reaches pages no other loop does, so an unreadable source
+  // here could take down an otherwise-green check for the sake of a notice.
+  let current, currentTrans;
+  try {
+    current = currentHash(page);
+    currentTrans = translationHash(loc, page);
+  } catch { continue; }
+  if (current !== null && current !== listed.src) {
+    note(`${VERIFIED_NOOPS_PATH}: "${key}" no longer applies — the English it names has changed, so the line can be removed`);
+  } else if (currentTrans !== null && currentTrans !== listed.translation) {
+    note(`${VERIFIED_NOOPS_PATH}: "${key}" no longer applies — the translation it names has changed since it was looked at, so the line can be removed`);
   }
 }
 
@@ -424,7 +457,6 @@ if (baseArgInvalid) {
     // silent skip. `ls-tree` is also cheaper: it answers from the tree objects
     // and never needs the blob at all.
     let baseManifest = null;
-    let baseVerifiedNoops = new Map();
     let firstIntroduction = false;
     let baseUnreadable = false;
     const baseManifestPath = `${mergeBase}:translation/sync-state.json`;
@@ -447,40 +479,6 @@ if (baseArgInvalid) {
     } else if (!baseUnreadable) {
       try {
         baseManifest = JSON.parse(execFileSync("git", ["show", baseManifestPath], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
-        // The allowlist as it stood at the base, so an authorisation can be spent
-        // exactly once.
-        //
-        // Absence and failure must not look alike here. An empty base list makes
-        // every line look NEW, which silently removes the single-use guard and
-        // reopens laundering — with a green exit and no message. That is the same
-        // inference this file already warns about twice, and it is worse on this
-        // repo: it is cloned --filter=blob:none, so an unreachable promisor turns
-        // a network hiccup into a disabled safeguard. So probe with ls-tree,
-        // where absence and presence are both exit 0 and distinguished by output,
-        // and treat a non-zero exit as a failure rather than as "no file".
-        let noopsAtBase = null;
-        try {
-          noopsAtBase = execFileSync(
-            "git",
-            ["ls-tree", "--name-only", mergeBase, "--", VERIFIED_NOOPS_PATH],
-            { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT },
-          );
-        } catch (e) {
-          fail(
-            `could not determine whether ${VERIFIED_NOOPS_PATH} exists at base ${mergeBase.slice(0, 12)} ` +
-            `(${e.code || e.message}) — refusing to treat that as "no exceptions were spent", ` +
-            `which would let a spent line authorise again.`,
-          );
-        }
-        if (noopsAtBase !== null && noopsAtBase.trim() !== "") {
-          try {
-            baseVerifiedNoops = parseVerifiedNoops(
-              execFileSync("git", ["show", `${mergeBase}:${VERIFIED_NOOPS_PATH}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }),
-            ).entries;
-          } catch (e) {
-            fail(`could not read ${VERIFIED_NOOPS_PATH} at base ${mergeBase.slice(0, 12)} (${e.code || e.message}) — refusing to guess that it was empty.`);
-          }
-        }
       } catch (e) {
         baseUnreadable = true;
         fail(
@@ -503,14 +501,41 @@ if (baseArgInvalid) {
     } else if (!baseUnreadable) {
       let changed;
       try {
-        changed = execFileSync("git", ["diff", "--name-only", "-z", `${mergeBase}..HEAD`, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
+        changed = execFileSync("git", ["diff", "--raw", "-z", "--no-renames", `${mergeBase}..HEAD`, "--", "translations/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
       } catch (e) {
         // The base resolved but the diff failed — do not treat as "no changes".
         fail(`git diff against base ${mergeBase.slice(0, 12)} failed: ${e.message}`);
         changed = "";
       }
+      // Whether a translation's BYTES changed is decided by blob identity, not by
+      // a line count. Two shapes fooled a line-count reading, and each one let a
+      // stale translation be marked current with nothing edited:
+      //   - a pure mode change (100644 -> 100755) reports 0 added / 0 deleted, and
+      //     a path marked `-diff` reports "-\t-" even when the blob is untouched;
+      //   - a renamed-and-edited file reports its paths in SEPARATE NUL fields,
+      //     so a record-per-line reading dropped it and missed a real edit.
+      // `--raw` gives the source and destination object ids directly, so the test
+      // is simply "did the content id move". `--no-renames` keeps every record to
+      // one path: a rename arrives as a delete plus an add, which is the honest
+      // reading — the file at that path really did appear or disappear.
+      // Raw -z alternates a metadata field and a path field:
+      //   :<srcmode> <dstmode> <srcsha> <dstsha> <status>\0<path>\0
+      const RAW_META = /^:(\d{6}) (\d{6}) ([0-9a-f]+) ([0-9a-f]+) ([A-Z])/;
+      const rawFields = changed.split("\0");
+      const changedPaths = [];
+      for (let i = 0; i + 1 < rawFields.length; i += 2) {
+        const meta = rawFields[i].match(RAW_META);
+        if (!meta) {
+          // An unrecognised record means we are not reading what we think we are.
+          // Staying silent here is how a fail-open starts, so refuse the run.
+          if (rawFields[i] !== "") fail(`could not parse git raw diff record "${rawFields[i].slice(0, 80)}" — refusing to guess which translations changed.`);
+          continue;
+        }
+        const [, , , srcSha, dstSha] = meta;
+        if (srcSha !== dstSha) changedPaths.push(rawFields[i + 1]);
+      }
       const changedSet = new Set(
-        changed.split("\0")
+        changedPaths
           .filter((p) => p.endsWith(".md"))
           .map((p) => p.match(/^translations\/([^/]+)\/site\/(.+)$/))
           .filter(Boolean)
@@ -534,17 +559,6 @@ if (baseArgInvalid) {
         }
       }
 
-      // A line whose entry was ALREADY at this source before the change is spent:
-      // Direction 2 only consults the list when a change advances `src`, so such
-      // a line cannot be doing anything for this PR or any later one. Reported
-      // only against the base, so the very PR that settles an entry is not told
-      // its own lines are useless.
-      for (const [key, sha] of verifiedNoops) {
-        if (baseVerifiedNoops.get(key) === sha) {
-          note(`${VERIFIED_NOOPS_PATH}: "${key}" has done its job — an authorisation is spent by the change that introduces it, so this line no longer grants anything and can be removed`);
-        }
-      }
-
       // Direction 2 — manifest src changed ⇒ the translation must have changed
       // too. Otherwise a one-commit hash bump marks a genuinely-stale translation
       // "fresh" forever — the exact lie this gate exists to prevent.
@@ -563,10 +577,17 @@ if (baseArgInvalid) {
               entry: now,
               baseEntry: was,
               listed: verifiedNoops.get(key),
-              listedInBase: baseVerifiedNoops.get(key),
               currentSourceHash: currentHash(page),
+              currentTranslationHash: translationHash(loc, page),
             })) continue;
-            fail(`${loc}/${page}: manifest src changed but the translation file did not — a hash bump alone would mark a stale translation "fresh". If the committed translation is genuinely already correct for this source, a human can record that in ${VERIFIED_NOOPS_PATH} as "${loc}/${page} ${now.src}".`);
+            // Only offer a copy-paste line when there is a real translation to
+            // name. With no file on disk the hash is null, and printing that
+            // would hand the operator a line the parser rejects.
+            const th = translationHash(loc, page);
+            const suggestion = th === null
+              ? `there is no translation file at translations/${loc}/site/${page} to name, so the exception cannot apply — the missing file is the thing to fix`
+              : `a human can record that in ${VERIFIED_NOOPS_PATH} as "${loc}/${page} ${now.src} ${th}" — naming both the English checked and the translation found already correct for it`;
+            fail(`${loc}/${page}: manifest src changed but the translation file did not — a hash bump alone would mark a stale translation "fresh". If the committed translation is genuinely already correct for this source, ${suggestion}.`);
           }
         }
       }

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -567,42 +567,46 @@ if (baseArgInvalid) {
         touched = null;
       }
 
-      const baseHashes = new Map();
+      // Asked for exactly once per path: a manifest key is either still current or
+      // removed, never both, so there is nothing to memoise.
       const baseHash = (loc, page) => {
         const rel = `translations/${loc}/site/${page}`;
-        if (!baseHashes.has(rel)) {
-          let hash = null;
-          try {
-            hash = hashPage(execFileSync("git", ["show", `${mergeBase}:${rel}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
-          } catch (e) {
-            // Only ever asked for a path the BASE manifest names, so the file was
-            // there. Failing to read it is a finding, not an absence — and it must
-            // not read as "changed", because that is the answer that satisfies
-            // Direction 2 and would license the very bump we cannot verify.
-            fail(`could not read ${rel} at base ${mergeBase.slice(0, 12)}: ${e.message}`);
-          }
-          baseHashes.set(rel, hash);
+        try {
+          return hashPage(execFileSync("git", ["show", `${mergeBase}:${rel}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
+        } catch (e) {
+          // Only ever asked for a path the BASE manifest names, so the file was
+          // there. Failing to read it is a finding, not an absence — and it must
+          // not read as "changed", because that is the answer that satisfies
+          // Direction 2 and would license the very bump we cannot verify.
+          fail(`could not read ${rel} at base ${mergeBase.slice(0, 12)}: ${e.message}`);
+          return null;
         }
-        return baseHashes.get(rel);
       };
 
       // key -> { was, changed }
+      //
+      // A page that moved is still the page it was, and its record should move
+      // with it. Its predecessor is a manifest key that disappeared in this same
+      // change and whose translation is the one now sitting at the new key.
+      // Keys, not paths, and across ALL locales: renaming `translations/it` to
+      // `translations/it-IT` moves every page at once, and searching only within
+      // a locale made all 18 of them look brand new — which is how a locale-code
+      // migration could mark stale translations current.
+      const removed = new Map();
+      for (const loc of Object.keys(baseManifest)) {
+        for (const page of Object.keys(baseManifest[loc])) {
+          if (manifest[loc]?.[page]) continue;      // that key still exists; not a move
+          const h = baseHash(loc, page);
+          if (h === null) continue;
+          removed.set(h, [...(removed.get(h) || []), { loc, page, entry: baseManifest[loc][page] }]);
+        }
+      }
+
       const comparisons = new Map();
       for (const loc of locales) {
-        const baseBlock = baseManifest[loc] || {};
-        // Pages whose manifest key disappeared: a moved page's translation came
-        // from one of these. Identical content in two of them means the move
-        // cannot be identified, and a claim that cannot be checked is refused.
-        const removed = new Map();
-        for (const [oldPage, oldEntry] of Object.entries(baseBlock)) {
-          if (manifest[loc][oldPage]) continue;
-          const h = baseHash(loc, oldPage);
-          if (h === null) continue;
-          removed.set(h, [...(removed.get(h) || []), { oldPage, oldEntry }]);
-        }
         for (const page of Object.keys(manifest[loc])) {
           const rel = `translations/${loc}/site/${page}`;
-          let was = baseBlock[page];
+          let was = baseManifest[loc]?.[page];
           let changed;
           if (was) {
             // Unlisted by git ⇒ the bytes are identical ⇒ nothing changed. A side
@@ -613,15 +617,14 @@ if (baseArgInvalid) {
           } else {
             const candidates = removed.get(translationHash(loc, page)) || [];
             if (candidates.length > 1) {
-              fail(`${loc}/${page}: this translation is identical to ${candidates.length} pages removed in this change (${candidates.map((c) => c.oldPage).join(", ")}) — which one it came from cannot be told, so its record cannot be checked. Settle it with a line in ${VERIFIED_NOOPS_PATH}, or make the move one page at a time.`);
+              fail(`${loc}/${page}: this translation is identical to ${candidates.length} entries removed in this change (${candidates.map((c) => `${c.loc}/${c.page}`).join(", ")}), so which one it continues cannot be told and its record cannot be checked. Move one page at a time, or give them distinct translations.`);
             }
-            was = candidates[0]?.oldEntry;
+            was = candidates[0]?.entry;
             changed = !was;   // a move changed nothing; a genuinely new page is new
           }
           comparisons.set(`${loc}/${page}`, { was, changed });
         }
       }
-      const changedSet = new Set([...comparisons].filter(([, c]) => c.changed).map(([k]) => k));
 
       try {
         const dirty = execFileSync("git", ["status", "--porcelain", "-z", "--", "site/", "translations/", "translation/"], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT });
@@ -639,12 +642,11 @@ if (baseArgInvalid) {
       } catch { /* status is advisory; never let it end the run */ }
 
       // Direction 1 — translation changed ⇒ manifest must record why.
-      for (const key of changedSet) {
+      for (const [key, { was, changed }] of comparisons) {
+        if (!changed) continue;
         const [loc, ...rest] = key.split("/");
         const page = rest.join("/");
-        const now = manifest[loc]?.[page];
-        if (!now) continue; // deletion — bijection handles the file/entry pairing
-        const was = comparisons.get(key)?.was;
+        const now = manifest[loc][page];
         // A hand-edit is a valid reason ONLY when the edited flag FLIPS in this
         // PR (false/absent → true). `edited:true` already at base is not a
         // standing licence to mutate the file forever with no manifest trace.
@@ -662,7 +664,7 @@ if (baseArgInvalid) {
         for (const [page, now] of Object.entries(manifest[loc])) {
           const was = comparisons.get(`${loc}/${page}`)?.was;
           if (!was) continue; // genuinely new — bijection ensures a matching file
-          if (now.src !== was.src && !changedSet.has(`${loc}/${page}`)) {
+          if (now.src !== was.src && !comparisons.get(`${loc}/${page}`).changed) {
             // Unless a human has listed this exact page against this exact
             // source in translation/verified-noops.txt, confirming the committed
             // translation is already correct for it. The pipeline writes the

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -104,7 +104,18 @@ try {
   fail(`sync-state.json is not valid JSON: ${e.message}`);
   report();
 }
+const isBlock = (v) => typeof v === "object" && v !== null && !Array.isArray(v);
 const locales = Object.keys(manifest);
+// Every level of the manifest gets its shape checked before anything reads it.
+// The top level was checked and the entries were checked; the locale blocks in
+// between were not, and Object.keys(null) is a TypeError — which loses every
+// violation collected so far and prints a stack trace instead of the report.
+for (const loc of locales) {
+  if (!isBlock(manifest[loc])) {
+    fail(`manifest locale "${loc}" is not an object — cannot read its entries.`);
+    report();
+  }
+}
 
 // ---- the human-authored Direction 2 exception list ------------------------
 // Absent means no exceptions, which is exactly the behaviour before it existed.
@@ -535,9 +546,17 @@ if (baseArgInvalid) {
       // an array, or a string parses fine and then throws on the first
       // `baseManifest[loc]` below. Reject the shape here so the reason is
       // reported instead of a stack trace.
-      if (!baseUnreadable && (typeof baseManifest !== "object" || baseManifest === null || Array.isArray(baseManifest))) {
+      if (!baseUnreadable && !isBlock(baseManifest)) {
         baseUnreadable = true;
         fail(`the manifest at base ${mergeBase.slice(0, 12)} is not a JSON object — cannot change-track against it.`);
+      }
+      if (!baseUnreadable) {
+        for (const loc of Object.keys(baseManifest)) {
+          if (!isBlock(baseManifest[loc])) {
+            baseUnreadable = true;
+            fail(`locale "${loc}" in the manifest at base ${mergeBase.slice(0, 12)} is not an object — cannot change-track against it.`);
+          }
+        }
       }
     }
 
@@ -572,7 +591,13 @@ if (baseArgInvalid) {
       const baseHash = (loc, page) => {
         const rel = `translations/${loc}/site/${page}`;
         try {
-          return hashPage(execFileSync("git", ["show", `${mergeBase}:${rel}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
+          // `cat-file --filters`, not `show`: `show` hands back the raw blob, while
+          // the other side of this comparison reads the working tree. Where a
+          // .gitattributes filter applies those are different representations of
+          // the same page, and every listed path then compares unequal forever —
+          // which is the answer that skips Direction 2. Both sides must be read in
+          // the form a reader sees.
+          return hashPage(execFileSync("git", ["cat-file", "--filters", `${mergeBase}:${rel}`], { cwd: root, encoding: "utf8", maxBuffer: MAX_GIT_OUTPUT }));
         } catch (e) {
           // Only ever asked for a path the BASE manifest names, so the file was
           // there. Failing to read it is a finding, not an absence — and it must

--- a/translation/check-invariants.mjs
+++ b/translation/check-invariants.mjs
@@ -105,6 +105,13 @@ try {
   report();
 }
 const isBlock = (v) => typeof v === "object" && v !== null && !Array.isArray(v);
+// The file parsed as JSON, which does not make it a manifest: `null`, a list or a
+// string all parse. Object.keys(null) is a TypeError, and a TypeError here throws
+// away the report along with every finding in it.
+if (!isBlock(manifest)) {
+  fail("sync-state.json is not a JSON object — cannot read any locale from it.");
+  report();
+}
 const locales = Object.keys(manifest);
 // Every level of the manifest gets its shape checked before anything reads it.
 // The top level was checked and the entries were checked; the locale blocks in

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -887,3 +887,42 @@ test("an AMBIGUOUS move is refused rather than guessed", () => {
       `expected an ambiguity refusal, got:\n${out}`);
   } finally { r.cleanup(); }
 });
+
+test("KNOWN LIMIT: a rename that also edits escapes rule 1", () => {
+  // Not a bug report — a boundary, pinned so it cannot drift unnoticed.
+  //
+  // A move is identified by its content, so when the translation changes too there
+  // is nothing to match and the page reads as new. Rule 1 asks whether provenance
+  // moved SINCE the base record, and a page with no base record has nothing to
+  // compare, so it passes. The same edit without the rename is refused.
+  //
+  // Accepted deliberately: nothing stale is being marked current — the file really
+  // did change — so the failure this gate exists to prevent still cannot happen.
+  // What is lost is the record of WHY it changed. Closing it needs the predecessor
+  // identified some other way (matching the English side, or git's rename
+  // detection), which is a second matcher; the cost was judged higher than the gap.
+  const r = makeRepo();
+  try {
+    const NEW = "guides/Demo_v2.md";
+    r.write("translation/curated-pages.txt", `${NEW}\n`);
+    git(r.dir, "mv", `site/${EN_PAGE}`, `site/${NEW}`);
+    git(r.dir, "mv", `translations/${LOC}/site/${EN_PAGE}`, `translations/${LOC}/site/${NEW}`);
+    r.write(`translations/${LOC}/site/${NEW}`, TR_BODY.replace("Vedi", "Guarda"));
+    const m = r.manifest();
+    m[LOC][NEW] = { ...m[LOC][EN_PAGE] };       // provenance copied verbatim
+    delete m[LOC][EN_PAGE];
+    r.setManifest(m);
+    r.commit("move the page and edit its translation, recording nothing");
+    assert.equal(r.run(), 0, "documented limit: a renamed+edited page reads as new");
+  } finally { r.cleanup(); }
+});
+
+test("...but the same edit WITHOUT a rename is refused", () => {
+  // The control that gives the limit above its exact shape.
+  const r = makeRepo();
+  try {
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
+    r.commit("edit the translation, recording nothing");
+    assert.equal(r.run(), 1);
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -88,15 +88,16 @@ function makeRepo() {
         return { code: 0, out };
       } catch (e) { return { code: e.status ?? 1, out: `${e.stdout || ""}${e.stderr || ""}` }; }
     },
-    /** run with `git ls-files` failing but the rest of git working */
-    runWithBrokenLsFiles() {
+    /** run with the named git subcommands failing and the rest of git working */
+    runWithBrokenGit(subcommands, base) {
       const shim = mkdtempSync(join(tmpdir(), "shim-"));
       const real = execFileSync("sh", ["-c", "command -v git"], { encoding: "utf8" }).trim();
+      const cases = subcommands.map((s) => `"${s}"`).join("|");
       writeFileSync(join(shim, "git"),
-        `#!/bin/sh\nfor a in "$@"; do\n  if [ "$a" = "ls-files" ]; then echo "fatal: simulated ls-files failure" >&2; exit 128; fi\ndone\nexec ${real} "$@"\n`);
+        `#!/bin/sh\nfor a in "$@"; do\n  case "$a" in\n    ${cases}) echo "fatal: simulated $a failure" >&2; exit 128;;\n  esac\ndone\nexec ${real} "$@"\n`);
       chmodSync(join(shim, "git"), 0o755);
       try {
-        return this.runOut(this.base, { PATH: `${shim}:${process.env.PATH}` });
+        return this.runOut(base || this.base, { PATH: `${shim}:${process.env.PATH}` });
       } finally { rmSync(shim, { recursive: true, force: true }); }
     },
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
@@ -380,7 +381,7 @@ test("a failed git listing is reported as a failed listing", () => {
   // pinning is the MESSAGE, which an exit code alone cannot see.
   const r = makeRepo();
   try {
-    const { code, out } = r.runWithBrokenLsFiles();
+    const { code, out } = r.runWithBrokenGit(["ls-files"]);
     assert.equal(code, 1, "an unreadable listing must never pass");
     assert.match(out, /could not list translations\//,
       "the run must say the listing failed, not blame the corpus for being absent");
@@ -851,10 +852,12 @@ test("an unreadable ENGLISH page is a finding, not a crash", { skip: ROOT && "ru
 });
 
 test("an AMBIGUOUS move is refused rather than guessed", () => {
-  // Two removed pages can hold identical translations, and then content cannot
-  // say which one a moved file came from. A record that cannot be identified
-  // cannot be checked, so the gate refuses and asks for a human line rather than
-  // silently inheriting whichever it happened to find first.
+  // Two pages can hold identical translations, and then content cannot say which
+  // one a moved file came from. That only matters when the two records DISAGREE
+  // about the source they were translated against — then the page's verdict
+  // depends on a guess, so the gate refuses instead of guessing. (The companion
+  // test below pins the other half: candidates that agree are not ambiguous in
+  // any way this check can act on, and refusing there would block honest work.)
   const r = makeRepo();
   try {
     const TWIN = "guides/Twin.md";
@@ -862,7 +865,8 @@ test("an AMBIGUOUS move is refused rather than guessed", () => {
     r.write(`translations/${LOC}/site/${TWIN}`, TR_BODY);   // IDENTICAL translation
     r.write("translation/curated-pages.txt", `${EN_PAGE}\n${TWIN}\n`);
     const m0 = r.manifest();
-    m0[LOC][TWIN] = { ...m0[LOC][EN_PAGE] };
+    // ...but a DIFFERENT recorded source. Identical text, two stories about it.
+    m0[LOC][TWIN] = { ...m0[LOC][EN_PAGE], src: hashPage("# Other\n\nsomething else entirely\n") };
     r.setManifest(m0);
     r.commit("two curated pages whose translations are identical");
     const base = git(r.dir, "rev-parse", "HEAD").trim();
@@ -883,8 +887,171 @@ test("an AMBIGUOUS move is refused rather than guessed", () => {
 
     const { code, out } = r.runOut(base);
     assert.equal(code, 1);
-    assert.ok(hasViolation(out, /identical to 2 entries removed in this change/),
+    assert.ok(hasViolation(out, /identical to 2 entries at the base/),
       `expected an ambiguity refusal, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("a diff that failed is a finding, and does not become one per pair", () => {
+  // The only thing that says which paths stand still is the diff. Without it no
+  // base hash comes free, and a predecessor index over every base entry would ask
+  // git once per pair — on the real corpus 3762 reads, most of which would fail
+  // the same way the diff just did and each of which would print. One fault, one
+  // finding. This branch had no test at all; deleting the guard must be visible.
+  const r = makeRepo();
+  try {
+    // cat-file breaks with it: a repo that cannot answer one git read usually
+    // cannot answer the others either, and that is the case where an index over
+    // every base entry turns one fault into one finding per pair.
+    const { code, out } = r.runWithBrokenGit(["diff", "cat-file"]);
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /git diff against base .* failed/), `expected the diff failure to be reported, got:\n${out}`);
+    assert.equal(violations(out).length, 1, `one fault must produce one finding, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("an unreadable base file is reported once, not once per reader", () => {
+  // Two readers ask for the same base hash — the predecessor index and the
+  // per-entry comparison. Only paths the diff listed are read from git, so this
+  // needs a translation that actually changed; then the read fails and must
+  // still produce a single finding.
+  const r = makeRepo();
+  try {
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
+    const m = r.manifest();
+    m[LOC][EN_PAGE].tool = "t+repair";
+    r.setManifest(m);
+    r.commit("retranslate");
+    const { code, out } = r.runWithBrokenGit(["cat-file"]);
+    assert.equal(code, 1);
+    const reads = violations(out).filter((l) => /could not read .* at base/.test(l));
+    assert.equal(reads.length, 1, `one unreadable file must produce one finding, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("predecessors that disagree about `edited` are ambiguous too", () => {
+  // `edited` is read from the predecessor as well as `src`: noopAllowed refuses
+  // outright when the base record was held as hand-edited. Two candidates that
+  // agree on the source but not on that flag decide the page's verdict between
+  // them, so picking whichever came first would be a guess with an exception
+  // line riding on it.
+  const r = makeRepo();
+  try {
+    const TWIN = "guides/Twin.md";
+    r.write(`site/${TWIN}`, EN_BODY);
+    r.write(`translations/${LOC}/site/${TWIN}`, TR_BODY);      // identical translation
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${TWIN}\n`);
+    const m0 = r.manifest();
+    m0[LOC][TWIN] = { ...m0[LOC][EN_PAGE], edited: true };     // same src, held by hand
+    r.setManifest(m0);
+    r.commit("two pages, one translation, one of them held");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const MERGED = "guides/Merged.md";
+    r.write("translation/curated-pages.txt", `${MERGED}\n`);
+    git(r.dir, "rm", "-q", `site/${EN_PAGE}`, `site/${TWIN}`,
+      `translations/${LOC}/site/${EN_PAGE}`, `translations/${LOC}/site/${TWIN}`);
+    r.write(`site/${MERGED}`, NEW_EN);
+    r.write(`translations/${LOC}/site/${MERGED}`, TR_BODY);
+    const m = r.manifest();
+    m[LOC][MERGED] = { ...m[LOC][EN_PAGE], src: hashPage(NEW_EN) };
+    delete m[LOC][EN_PAGE];
+    delete m[LOC][TWIN];
+    r.setManifest(m);
+    r.commit("collapse both into one route");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /identical to 2 entries at the base/),
+      `expected an ambiguity refusal, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("predecessors that agree are not ambiguous — seeding a locale is not blocked", () => {
+  // The corpus this runs on carries one page's translation across 17 locales
+  // untranslated (English passed through), and two more across 5 and 2. Every
+  // such group agrees on the source it was translated against. Refusing on the
+  // COUNT of candidates rather than on their disagreement would make seeding any
+  // new locale red on those pages, with a remedy ("give them distinct
+  // translations") the operator cannot apply to a passthrough. A gate that blocks
+  // honest work gets switched off.
+  const r = makeRepo();
+  try {
+    const SHARED = "guides/Shared.md";
+    const PASS = "# Shared\n\nIdentical in every locale.\n";
+    r.write(`site/${SHARED}`, PASS);
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${SHARED}\n`);
+    const m0 = r.manifest();
+    const shared = { src: hashPage(PASS), src_commit: "0".repeat(40), engine: "gt", mode: "seed", tool: "t", edited: false };
+    for (const loc of [LOC, "es", "de"]) {
+      r.write(`translations/${loc}/site/${SHARED}`, PASS);
+      m0[loc] = { ...(m0[loc] || {}), [SHARED]: { ...shared } };
+    }
+    r.setManifest(m0);
+    r.commit("three locales sharing one passthrough translation");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    // seed a fourth locale: same text, same recorded source, nothing stale
+    r.write(`translations/sw/site/${SHARED}`, PASS);
+    const m = r.manifest();
+    m.sw = { [SHARED]: { ...shared } };
+    r.setManifest(m);
+    r.commit("seed sw");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 0, `seeding a locale must not be refused, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("a COPY that claims a source its translation was never made against is refused", () => {
+  // Q5. A page move split across two pull requests: the first copies the page to
+  // its new key and leaves the old one in place, the second retires the old key.
+  // Each is checked on its own, and in the copying half the new key's record is
+  // whatever it says it is — unless a page that still exists can also be a
+  // predecessor. This is the half that carries the lie, so this is the half that
+  // has to refuse; the retiring half is an ordinary deletion.
+  const r = makeRepo();
+  try {
+    const NEW = "guides/Moved.md";
+    const NEW_BODY = "# Moved\n\nA different English page about transparent addresses.\n";
+    r.write(`site/${NEW}`, NEW_BODY);
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${NEW}\n`);
+    r.write(`translations/${LOC}/site/${NEW}`, TR_BODY);     // the COPY, unchanged text
+    const m = r.manifest();
+    m[LOC][NEW] = { ...m[LOC][EN_PAGE], src: hashPage(NEW_BODY) };  // claims the new English
+    r.setManifest(m);
+    r.commit("PR1: copy the page to its new key, keep the old one");
+
+    const { code, out } = r.runOut();
+    assert.equal(code, 1, `the copying half must refuse, got:\n${out}`);
+    assert.ok(hasViolation(out, new RegExp(`${LOC}/${NEW}: manifest src changed but the translation file did not`)),
+      `expected Direction 2 to fire on the copy, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("a whole-locale COPY cannot re-date a stale locale under a new code", () => {
+  // The same split move at locale scale: copy translations/it to translations/xx,
+  // keep it, and let the new block record today's English for text translated
+  // against something older. 18 locales' worth of stale pages marked current in
+  // one pull request, with the second half — deleting `it` — entirely innocent.
+  const r = makeRepo();
+  try {
+    const m0 = r.manifest();
+    m0[LOC][EN_PAGE].src = hashPage("# Demo\n\nan older English\n");   // `it` is stale
+    r.setManifest(m0);
+    r.commit("it falls behind");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    r.write(`translations/it-IT/site/${EN_PAGE}`, TR_BODY);            // byte-for-byte copy
+    const m = r.manifest();
+    m["it-IT"] = { [EN_PAGE]: { ...m0[LOC][EN_PAGE], src: EN_HASH } }; // but claims today's
+    r.setManifest(m);
+    r.commit("PR1: copy the locale under its new code");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1, `the copying half must refuse, got:\n${out}`);
+    assert.ok(hasViolation(out, /it-IT\/guides\/Demo\.md: manifest src changed but the translation file did not/),
+      `expected Direction 2 to fire on the copied locale, got:\n${out}`);
   } finally { r.cleanup(); }
 });
 

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1,0 +1,296 @@
+// Integration tests for check-invariants.mjs, run against REAL git repositories.
+//
+// Why these exist, and why here. The unit tests next door cover the predicates.
+// They do not cover the wiring, and the wiring is where the defects have been:
+// a review demonstrated that severing the call site — passing a constant instead
+// of the real value — restored a laundering bypass with every unit test still
+// green. Two earlier regressions in this file lived in the same layer.
+//
+// They sit in translation/lib/ because the repo's CI runs
+// `node --test translation/lib/*.test.mjs`; a test elsewhere would not run at
+// all, which is the failure mode this is meant to prevent.
+//
+// Each case builds a throwaway repo, commits a base, commits a change on top,
+// and asserts the checker's EXIT CODE. Exit code is the whole contract: a gate
+// that returns 0 has admitted whatever it was shown.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, cpSync, readFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { hashPage } from "./normalize-hash.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, "..", "..");
+const CHECKER = join("translation", "check-invariants.mjs");
+
+const EN_PAGE = "guides/Demo.md";
+const EN_BODY = "# Demo\n\nSee [explorers](https://zechub.wiki/guides/blockchain-explorers).\n";
+const TR_BODY = "# Demo\n\nVedi [explorers](https://zechub.wiki/guides/blockchain-explorers).\n";
+const LOC = "it";
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+/** A minimal but REAL repo the checker can run against. */
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "inv-"));
+  git(dir, "init", "-q", "-b", "main");
+  git(dir, "config", "user.email", "t@t");
+  git(dir, "config", "user.name", "t");
+  const write = (rel, text) => {
+    mkdirSync(join(dir, dirname(rel)), { recursive: true });
+    writeFileSync(join(dir, rel), text);
+  };
+  // the checker and the libs it imports, copied from the repo under test
+  mkdirSync(join(dir, "translation", "lib"), { recursive: true });
+  cpSync(join(REPO, CHECKER), join(dir, CHECKER));
+  for (const lib of ["normalize-hash.mjs", "verified-noops.mjs", "extract-title.mjs", "frontmatter.mjs", "term-forms.mjs"]) {
+    try { cpSync(join(REPO, "translation", "lib", lib), join(dir, "translation", "lib", lib)); } catch { /* optional */ }
+  }
+  write(`site/${EN_PAGE}`, EN_BODY);
+  write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY);
+  write("translation/curated-pages.txt", `${EN_PAGE}\n`);
+  const entry = {
+    src: hashPage(EN_BODY), src_commit: "0".repeat(40), engine: "llm",
+    mode: "diff", tool: "t", edited: false,
+  };
+  write("translation/sync-state.json", JSON.stringify({ [LOC]: { [EN_PAGE]: entry } }, null, 2) + "\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-qm", "base");
+  return {
+    dir, write,
+    base: git(dir, "rev-parse", "HEAD").trim(),
+    manifest: () => JSON.parse(readFileSync(join(dir, "translation/sync-state.json"), "utf8")),
+    setManifest: (m) => write("translation/sync-state.json", JSON.stringify(m, null, 2) + "\n"),
+    commit: (msg) => { git(dir, "add", "-A"); git(dir, "commit", "-qm", msg); },
+    /** the checker's exit code against the base */
+    run(base) {
+      return this.runOut(base).code;
+    },
+    /** exit code AND stdout — notices are part of the contract, not just the code */
+    runOut(base) {
+      try {
+        const out = execFileSync("node", [CHECKER, "--base", base || this.base], { cwd: dir, encoding: "utf8", stdio: "pipe" });
+        return { code: 0, out };
+      } catch (e) { return { code: e.status ?? 1, out: `${e.stdout || ""}${e.stderr || ""}` }; }
+    },
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+const EN_HASH = hashPage(EN_BODY);
+const TR_HASH = hashPage(TR_BODY);
+const NEW_EN = EN_BODY.replace("blockchain-explorers", "block-explorers");
+
+function bumpSrcTo(r, hash) {
+  const m = r.manifest();
+  m[LOC][EN_PAGE].src = hash;
+  r.setManifest(m);
+}
+
+test("a clean repo passes", () => {
+  const r = makeRepo();
+  try { assert.equal(r.run(), 0); } finally { r.cleanup(); }
+});
+
+test("a bare source bump with no translation change is REFUSED", () => {
+  // The invariant this gate exists for.
+  const r = makeRepo();
+  try {
+    r.write(`site/${EN_PAGE}`, NEW_EN);
+    bumpSrcTo(r, hashPage(NEW_EN));
+    r.commit("bump only");
+    assert.equal(r.run(), 1);
+  } finally { r.cleanup(); }
+});
+
+test("a listed page whose English and translation both still match is ALLOWED", () => {
+  const r = makeRepo();
+  try {
+    r.write(`site/${EN_PAGE}`, NEW_EN);
+    bumpSrcTo(r, hashPage(NEW_EN));
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${hashPage(NEW_EN)}  ${TR_HASH}\n`);
+    r.commit("bump + authorisation");
+    assert.equal(r.run(), 0);
+  } finally { r.cleanup(); }
+});
+
+test("APPROVE-FIRST: an authorisation landed before the bump still applies", () => {
+  // The natural order when the pipeline opens its own pull requests: a person
+  // grants the exception, and the automation's NEXT run advances the record. An
+  // earlier design required the line to be new in the same change, which made
+  // this permanently impossible while telling the operator to add a line that
+  // was already in the file.
+  const r = makeRepo();
+  try {
+    // step 1 — the human: new English, and the authorisation. No bump yet.
+    r.write(`site/${EN_PAGE}`, NEW_EN);
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${hashPage(NEW_EN)}  ${TR_HASH}\n`);
+    r.commit("human approves ahead of time");
+    const approved = git(r.dir, "rev-parse", "HEAD").trim();
+
+    // step 2 — the automation: advance the record, touching nothing else.
+    bumpSrcTo(r, hashPage(NEW_EN));
+    r.commit("automation settles the page");
+
+    assert.equal(r.run(approved), 0);
+  } finally { r.cleanup(); }
+});
+
+test("REPLAY: a line stops applying once the translation has moved on", () => {
+  const r = makeRepo();
+  try {
+    const TR2 = TR_BODY + "\nnuova riga\n";
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR2);
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${hashPage(NEW_EN)}  ${TR_HASH}\n`);
+    const m = r.manifest(); m[LOC][EN_PAGE].tool = "t+edit"; r.setManifest(m);
+    r.commit("translation moves on; stale line left behind");
+    const mid = git(r.dir, "rev-parse", "HEAD").trim();
+    r.write(`site/${EN_PAGE}`, NEW_EN);
+    bumpSrcTo(r, hashPage(NEW_EN));
+    r.commit("try to use the stale line");
+    assert.equal(r.run(mid), 1);
+  } finally { r.cleanup(); }
+});
+
+test("a listed English hash that is not the file on disk is REFUSED", () => {
+  const r = makeRepo();
+  try {
+    const ghost = "sha256:" + "e".repeat(64);
+    bumpSrcTo(r, ghost);
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${ghost}  ${TR_HASH}\n`);
+    r.commit("bless a source that never existed");
+    assert.equal(r.run(), 1);
+  } finally { r.cleanup(); }
+});
+
+test("an edited:true page cannot be settled by an authorisation", () => {
+  const r = makeRepo();
+  try {
+    const m0 = r.manifest(); m0[LOC][EN_PAGE].edited = true; r.setManifest(m0);
+    r.commit("hold the page");
+    const held = git(r.dir, "rev-parse", "HEAD").trim();
+    r.write(`site/${EN_PAGE}`, NEW_EN);
+    const m = r.manifest(); m[LOC][EN_PAGE].edited = false; m[LOC][EN_PAGE].src = hashPage(NEW_EN); r.setManifest(m);
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${hashPage(NEW_EN)}  ${TR_HASH}\n`);
+    r.commit("unhold and settle in one change");
+    assert.equal(r.run(held), 1);
+  } finally { r.cleanup(); }
+});
+
+test("a mode-only change does NOT count as a translation edit", () => {
+  // chmod +x leaves the bytes identical. Counting it as a change satisfied both
+  // directions at once and settled a stale page with no authorisation at all.
+  const r = makeRepo();
+  try {
+    r.write(`site/${EN_PAGE}`, NEW_EN);
+    bumpSrcTo(r, hashPage(NEW_EN));
+    chmodSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`), 0o755);
+    r.commit("mode-only + bump");
+    assert.equal(r.run(), 1);
+  } finally { r.cleanup(); }
+});
+
+test("a real translation edit with recorded provenance passes", () => {
+  const r = makeRepo();
+  try {
+    r.write(`site/${EN_PAGE}`, NEW_EN);
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("blockchain-explorers", "block-explorers"));
+    const m = r.manifest(); m[LOC][EN_PAGE].src = hashPage(NEW_EN); m[LOC][EN_PAGE].tool = "t+pass"; r.setManifest(m);
+    r.commit("real re-translation");
+    assert.equal(r.run(), 0);
+  } finally { r.cleanup(); }
+});
+
+test("an inert line naming a page that is not curated does not fail the build", () => {
+  // Retiring a page must not be blocked by a leftover authorisation.
+  const r = makeRepo();
+  try {
+    r.write("translation/verified-noops.txt", `${LOC}/guides/Gone.md  ${EN_HASH}  ${TR_HASH}\n`);
+    r.commit("leftover line for a page that no longer exists");
+    assert.equal(r.run(), 0);
+  } finally { r.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Regressions found in round-3 review. Each of these passed the whole suite
+// before it was written, which is the reason it is written.
+
+test("a mode-only change on a `-diff` path does NOT count as a translation edit", () => {
+  // `--numstat` prints "-\t-" for a path marked `-diff` even when the blob is
+  // untouched, so a line-count reading called an untouched file "changed" and
+  // let a bare source bump through. Blob identity is what actually settles it.
+  const r = makeRepo();
+  try {
+    r.write(".gitattributes", `translations/${LOC}/site/${EN_PAGE} -diff\n`);
+    r.commit("mark the translation path -diff");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const EN2 = EN_BODY.replace("explorers", "block explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    chmodSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`), 0o755);
+    const m = r.manifest();
+    m[LOC][EN_PAGE].src = hashPage(EN2);
+    r.setManifest(m);
+    r.commit("bump src, chmod the translation, change nothing inside it");
+
+    assert.equal(r.run(base), 1, "a chmod on a -diff path must not satisfy Direction 2");
+  } finally { r.cleanup(); }
+});
+
+test("an expired line actually PRINTS its notice (English moved on)", () => {
+  // The notice loop was dead for its whole life: it called translationHash()
+  // above that cache's `const`, and the ReferenceError was swallowed by the
+  // try/catch meant to stop housekeeping ending the run. Exit code alone could
+  // never see it, so this asserts on the output.
+  const r = makeRepo();
+  try {
+    const stale = "sha256:" + "0".repeat(64);
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${stale}  ${hashPage(TR_BODY)}\n`);
+    r.commit("list a page against an English that is not on disk");
+    const { code, out } = r.runOut(git(r.dir, "rev-parse", "HEAD").trim());
+    assert.equal(code, 0, "an expired line is housekeeping, never a failure");
+    assert.match(out, /no longer applies — the English it names has changed/);
+  } finally { r.cleanup(); }
+});
+
+test("an expired line actually PRINTS its notice (translation moved on)", () => {
+  const r = makeRepo();
+  try {
+    const stale = "sha256:" + "1".repeat(64);
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${hashPage(EN_BODY)}  ${stale}\n`);
+    r.commit("list a page against a translation that is not on disk");
+    const { code, out } = r.runOut(git(r.dir, "rev-parse", "HEAD").trim());
+    assert.equal(code, 0);
+    assert.match(out, /no longer applies — the translation it names has changed/);
+  } finally { r.cleanup(); }
+});
+
+test("a renamed-and-edited translation is still seen as changed", () => {
+  // `--numstat -z` reports a rename as "added\tdeleted\t\0old\0new\0" — the
+  // path field is EMPTY and two more fields follow — so a record-per-line
+  // reading dropped the record entirely. `--no-renames` keeps one path per
+  // record: the rename arrives as a delete plus an add.
+  const r = makeRepo();
+  try {
+    const NEW = "guides/Renamed.md";
+    r.write("translation/curated-pages.txt", `${NEW}\n`);
+    git(r.dir, "mv", `site/${EN_PAGE}`, `site/${NEW}`);
+    git(r.dir, "mv", `translations/${LOC}/site/${EN_PAGE}`, `translations/${LOC}/site/${NEW}`);
+    r.write(`translations/${LOC}/site/${NEW}`, TR_BODY.replace("Vedi", "Guarda"));
+    const m = r.manifest();
+    m[LOC][NEW] = m[LOC][EN_PAGE];
+    delete m[LOC][EN_PAGE];
+    r.setManifest(m);
+    r.commit("move the page and edit the translation in the same commit");
+
+    // The destination is a NEW manifest key, so neither direction can fire on
+    // it — but the run must stay parseable and green rather than erroring on a
+    // record shape it did not expect.
+    assert.equal(r.run(), 0);
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -995,3 +995,51 @@ test("a malformed locale block is reported, not a stack trace", () => {
     assert.doesNotMatch(out, /at ModuleJob\.run/, "must not surface a stack trace");
   } finally { r.cleanup(); }
 });
+
+test("deleting a locale's manifest block while its files stay is refused", () => {
+  // The only thing catching this is two lines of locale-universe bijection, and
+  // nothing tested them: deleting both lines passed the whole suite. Without it a
+  // locale silently vanishes from sync selection while its pages sit on disk —
+  // the same permanent, invisible staleness as a single page, at locale scale.
+  const r = makeRepo();
+  try {
+    const m = r.manifest();
+    delete m[LOC];                      // block gone, files kept
+    r.setManifest(m);
+    r.commit("drop the locale from the manifest, leave its files");
+    const { code, out } = r.runOut();
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /locale "it" has translations but no manifest block/),
+      `expected a locale-universe violation, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("a page held at BASE is not offered an exception either", () => {
+  // heldByHand has two clauses. Every existing test leaves edited:true set on both
+  // sides, so the first clause alone satisfied them and the base clause was never
+  // exercised — dropping it passed the suite while restoring the R7 loop, because
+  // noopAllowed refuses on the BASE entry's edited flag too.
+  const r = makeRepo();
+  try {
+    const m0 = r.manifest();
+    m0[LOC][EN_PAGE].edited = true;
+    r.setManifest(m0);
+    r.commit("hold the page as hand-edited");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    const m = r.manifest();
+    m[LOC][EN_PAGE].edited = false;     // cleared HERE; still held at base
+    m[LOC][EN_PAGE].src = hashPage(EN2);
+    r.setManifest(m);
+    r.commit("clear the flag and advance the record");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1);
+    assert.ok(!hasViolation(out, /a human can record that in/),
+      `must not offer a line noopAllowed will refuse on the base entry:\n${out}`);
+    assert.ok(hasViolation(out, /held as hand-edited at the base/),
+      `and must say which side holds it:\n${out}`);
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -568,3 +568,94 @@ test("DIRECTION 1: a mode-only provenance change is a valid reason", () => {
     assert.equal(r.run(), 0, "recording the pass in `mode` must be accepted");
   } finally { r.cleanup(); }
 });
+
+test("an unreadable blob cannot satisfy Direction 2", () => {
+  // The run is red anyway because reading the blob fails. What this pins is the
+  // CLASSIFICATION: an unreadable object must not be counted as "the translation
+  // changed", or it would be arguing the source bump is fine. Softening the
+  // `fail()` to a notice used to admit a stale page; now the decision itself
+  // refuses.
+  const r = staleRepo();
+  try {
+    const base = r.base;
+    // remember the base blob of the translation, then advance leaving it stale
+    const oid = git(r.dir, "rev-parse", `${base}:translations/${LOC}/site/${EN_PAGE}`).trim();
+    r.advance((write) => write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY + "\nuna riga in piu\n"));
+    // make that object unreadable: loose objects live at .git/objects/ab/cdef...
+    const loose = join(r.dir, ".git", "objects", oid.slice(0, 2), oid.slice(2));
+    rmSync(loose, { force: true });
+    assert.equal(r.run(base), 1, "an unreadable blob must never license a source bump");
+  } finally { r.cleanup(); }
+});
+
+test("`--no-renames` is load-bearing: a PURE rename stays parseable", () => {
+  // The earlier rename test renamed AND edited a tiny file, so git reported a
+  // delete plus an add and no rename record was ever produced — it pinned
+  // nothing. A pure rename is what actually makes git emit `R`, whose -z record
+  // carries TWO path fields and breaks a one-path-per-record reading.
+  const r = makeRepo();
+  try {
+    const NEW = "guides/Renamed.md";
+    r.write("translation/curated-pages.txt", `${NEW}\n`);
+    git(r.dir, "mv", `site/${EN_PAGE}`, `site/${NEW}`);
+    git(r.dir, "mv", `translations/${LOC}/site/${EN_PAGE}`, `translations/${LOC}/site/${NEW}`);
+    const m = r.manifest();
+    m[LOC][NEW] = m[LOC][EN_PAGE];
+    delete m[LOC][EN_PAGE];
+    r.setManifest(m);
+    r.commit("move the page, touching not one byte of it");
+
+    // git with rename detection on would report R100 here; the checker must not
+    // trip over it. Force detection on to be sure we are exercising that shape.
+    git(r.dir, "config", "diff.renames", "true");
+    const { code, out } = r.runOut();
+    assert.equal(code, 0, out);
+    assert.doesNotMatch(out, /could not parse git raw diff record/,
+      "a rename record must never reach the parser");
+  } finally { r.cleanup(); }
+});
+
+test("a page whose path cannot be expressed says so, instead of printing a bad line", () => {
+  // The allowlist is whitespace-separated and `#` starts a comment, so a path
+  // containing either cannot be written as a line. Printing the usual "copy this"
+  // suggestion would hand someone a line that fails to parse — a permanently red
+  // build whose message never mentions the real reason.
+  const PAGE = "guides/Zcash #1 Guide.md";
+  const r = makeRepo();
+  try {
+    r.write(`site/${PAGE}`, EN_BODY);
+    r.write(`translations/${LOC}/site/${PAGE}`, TR_BODY);
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${PAGE}\n`);
+    const m0 = r.manifest();
+    m0[LOC][PAGE] = { src: hashPage(EN_BODY), src_commit: "0".repeat(40), engine: "llm", mode: "diff", tool: "t", edited: false };
+    r.setManifest(m0);
+    r.commit("curate a page whose name has a space and a hash");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${PAGE}`, EN2);
+    const m = r.manifest();
+    m[LOC][PAGE].src = hashPage(EN2);
+    r.setManifest(m);
+    r.commit("bump its source without touching the translation");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1);
+    assert.match(out, /cannot be authorised: its path contains whitespace or "#"/);
+    assert.doesNotMatch(out, /a human can record that in/,
+      "it must not offer a line that cannot parse");
+  } finally { r.cleanup(); }
+});
+
+test("a dirty working tree is called out, because CI asks about the commit", () => {
+  // The whole check reads disk, so a dirty tree gets a coherent answer — about
+  // disk. That is not the question CI asks, and "invariants hold" must not be
+  // read as a promise about what is being pushed.
+  const r = makeRepo();
+  try {
+    writeFileSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`), TR_BODY + "\nnon commesso\n");
+    const { out } = r.runOut();
+    assert.match(out, /uncommitted change\(s\) under site\/, translations\/ or translation\//);
+    assert.match(out, /describes your WORKING TREE/);
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1285,29 +1285,6 @@ test("predecessors whose `edited` differs only by TYPE are ambiguous", () => {
   } finally { r.cleanup(); }
 });
 
-test("a malformed base entry cannot be a predecessor", () => {
-  // Reading .src off a null entry is a TypeError, and a throw here discards the
-  // report along with every finding in it.
-  const r = makeRepo();
-  try {
-    const m0 = r.manifest();
-    m0[LOC]["guides/Ghost.md"] = null;
-    r.setManifest(m0);
-    r.commit("a base entry that is not a record");
-    const base = git(r.dir, "rev-parse", "HEAD").trim();
-
-    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
-    const m = r.manifest();
-    m[LOC][EN_PAGE].tool = "t+pass2";
-    r.setManifest(m);
-    r.commit("edit a translation and record it");
-
-    const { code, out } = r.runOut(base);
-    assert.doesNotMatch(out, /at ModuleJob\.run/, "must not surface a stack trace");
-    assert.equal(typeof code, "number");
-  } finally { r.cleanup(); }
-});
-
 test("a non-ASCII translation filename is still seen by the bijection", () => {
   // `git ls-files` without -z C-quotes any path that is not plain ASCII:
   //   "translations/it/site/guides/Caf\\303\\251.md"
@@ -1352,4 +1329,80 @@ test("the deletion remedy, followed exactly, produces a green run", () => {
 
     assert.equal(r.run(), 0, "the prescribed remedy must actually go green");
   } finally { r.cleanup(); }
+});
+
+test("a malformed record AT BASE is refused, not read as 'no record'", () => {
+  // The base's root and locale levels were shape-checked and the record level was
+  // not — the one level where a miss loses a verdict instead of crashing. A falsy
+  // record reads exactly like "no record at this key", so the page is taken for a
+  // new one and both rules step over it while its `src` advances.
+  //
+  // The earlier version of this test put the malformed record in HEAD as well, so
+  // the HEAD check reported and exited before change-tracking ran: it asserted
+  // only that the exit code was a number, which admits 0 and 1 equally.
+  for (const bad of [null, 0, "", false]) {
+    const r = makeRepo();
+    try {
+      const m0 = r.manifest();
+      m0[LOC][EN_PAGE] = bad;                     // BASE is malformed
+      r.setManifest(m0);
+      r.commit(`base record ${JSON.stringify(bad)}`);
+      const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+      const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+      r.write(`site/${EN_PAGE}`, EN2);
+      const m = r.manifest();                      // HEAD is well-formed
+      m[LOC][EN_PAGE] = { src: hashPage(EN2), src_commit: "0".repeat(40), engine: "llm", mode: "diff", tool: "t", edited: false };
+      r.setManifest(m);
+      r.commit("advance src, leave the translation alone");
+
+      assert.equal(r.run(base), 1, `base record ${JSON.stringify(bad)} must not read as absent`);
+    } finally { r.cleanup(); }
+  }
+});
+
+test("a malformed locale block AT BASE is a finding, not a stack trace", () => {
+  // Load-bearing and previously unpinned: without this the base read crashes and
+  // the report is discarded.
+  const r = makeRepo();
+  try {
+    const m0 = r.manifest();
+    m0.fr = null;                                  // present at base only
+    r.setManifest(m0);
+    r.commit("a base locale block that is not an object");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const m = r.manifest();
+    delete m.fr;
+    r.setManifest(m);
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
+    m[LOC][EN_PAGE].tool = "t+pass2";
+    r.setManifest(m);
+    r.commit("drop it at head and edit a translation");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1);
+    assert.doesNotMatch(out, /at ModuleJob\.run/, "must not surface a stack trace");
+    assert.ok(hasViolation(out, /at base .* is not an object/), `got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("KNOWN LIMIT: 'changed' means the normalised text differs, not 'a real edit'", () => {
+  // hashPage normalises four things — line endings, trailing blank lines, Unicode
+  // form, volatile front matter. That is NOT the set of reader-invisible edits.
+  // Anything invisible OUTSIDE that set counts as a change and therefore satisfies
+  // rule 2, so a stale translation can be settled by touching it in a way no
+  // reader can see. Pinned here because the requirements used to claim otherwise.
+  const invisible = {
+    "an HTML comment": (t) => t + "<!-- -->\n",
+    "a zero-width space": (t) => t.replace("Vedi", "Ve\u200Bdi"),
+    "an interior blank line": (t) => t.replace("# Demo\n\n", "# Demo\n\n\n"),
+  };
+  for (const [name, touch] of Object.entries(invisible)) {
+    const r = staleRepo();
+    try {
+      r.advance((write) => write(`translations/${LOC}/site/${EN_PAGE}`, touch(TR_BODY)));
+      assert.equal(r.run(), 0, `documented limit: ${name} counts as a change`);
+    } finally { r.cleanup(); }
+  }
 });

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1281,3 +1281,20 @@ test("a malformed base entry cannot be a predecessor", () => {
     assert.equal(typeof code, "number");
   } finally { r.cleanup(); }
 });
+
+test("a non-ASCII translation filename is still seen by the bijection", () => {
+  // `git ls-files` without -z C-quotes any path that is not plain ASCII:
+  //   "translations/it/site/guides/Caf\\303\\251.md"
+  // The quoted form ends in a quote, not ".md", so every test the parser applies
+  // misses it and the file leaves the corpus unnoticed — an orphan translation
+  // that no bijection check can see.
+  const r = makeRepo();
+  try {
+    r.write(`translations/${LOC}/site/guides/Café.md`, TR_BODY);   // no manifest entry
+    r.commit("add a translation with a non-ASCII name and no entry");
+    const { code, out } = r.runOut();
+    assert.equal(code, 1, "an orphan translation must be caught whatever its name");
+    assert.ok(hasViolation(out, /Café|orphan|no manifest entry/i),
+      `expected the orphan to be named, got:\n${out}`);
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -72,11 +72,26 @@ function makeRepo() {
       return this.runOut(base).code;
     },
     /** exit code AND stdout — notices are part of the contract, not just the code */
-    runOut(base) {
+    runOut(base, env) {
       try {
-        const out = execFileSync("node", [CHECKER, "--base", base || this.base], { cwd: dir, encoding: "utf8", stdio: "pipe" });
+        // process.execPath, not "node": these runs may strip PATH on purpose.
+        const out = execFileSync(process.execPath, [CHECKER, "--base", base || this.base], {
+          cwd: dir, encoding: "utf8", stdio: "pipe",
+          env: { ...process.env, ...(env || {}) },
+        });
         return { code: 0, out };
       } catch (e) { return { code: e.status ?? 1, out: `${e.stdout || ""}${e.stderr || ""}` }; }
+    },
+    /** run with `git ls-files` failing but the rest of git working */
+    runWithBrokenLsFiles() {
+      const shim = mkdtempSync(join(tmpdir(), "shim-"));
+      const real = execFileSync("sh", ["-c", "command -v git"], { encoding: "utf8" }).trim();
+      writeFileSync(join(shim, "git"),
+        `#!/bin/sh\nfor a in "$@"; do\n  if [ "$a" = "ls-files" ]; then echo "fatal: simulated ls-files failure" >&2; exit 128; fi\ndone\nexec ${real} "$@"\n`);
+      chmodSync(join(shim, "git"), 0o755);
+      try {
+        return this.runOut(this.base, { PATH: `${shim}:${process.env.PATH}` });
+      } finally { rmSync(shim, { recursive: true, force: true }); }
     },
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
@@ -212,7 +227,10 @@ test("an inert line naming a page that is not curated does not fail the build", 
   try {
     r.write("translation/verified-noops.txt", `${LOC}/guides/Gone.md  ${EN_HASH}  ${TR_HASH}\n`);
     r.commit("leftover line for a page that no longer exists");
-    assert.equal(r.run(), 0);
+    const { code, out } = r.runOut();
+    assert.equal(code, 0, "retiring a page must not be blocked by a leftover line");
+    assert.match(out, /names a page that is not curated/,
+      "and the leftover must still be pointed at, or it is invisible rather than inert");
   } finally { r.cleanup(); }
 });
 
@@ -292,5 +310,116 @@ test("a renamed-and-edited translation is still seen as changed", () => {
     // it — but the run must stay parseable and green rather than erroring on a
     // record shape it did not expect.
     assert.equal(r.run(), 0);
+  } finally { r.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Round-3, second pass. The first four came from reviewers; these come from the
+// one finding that outranked them all, plus the mutations that still survived.
+
+/** A repo whose translation is GENUINELY stale: it still carries the old link. */
+function staleRepo() {
+  const r = makeRepo();
+  const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+  return {
+    ...r,
+    /** advance the English and the manifest, leaving the translation stale */
+    advance(mutateTranslation) {
+      r.write(`site/${EN_PAGE}`, EN2);
+      if (mutateTranslation) mutateTranslation(r.write);
+      const m = r.manifest();
+      m[LOC][EN_PAGE].src = hashPage(EN2);
+      m[LOC][EN_PAGE].tool = "t+pass2";   // satisfies Direction 1
+      r.setManifest(m);
+      r.commit("advance the English, record a pass, leave the translation stale");
+    },
+  };
+}
+
+test("a stale translation cannot be settled by appending blank lines", () => {
+  // THE hole this round found. hashPage ignores trailing blank lines, so this is
+  // an edit the pipeline itself calls "no edit" — but it moves the git blob. When
+  // Direction 2 asked git "did the blob change" instead of "did the page change",
+  // a translation still carrying the old link was marked current with no
+  // exception and no human anywhere near it.
+  const r = staleRepo();
+  try {
+    r.advance((write) => write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY + "\n\n"));
+    assert.equal(r.run(), 1, "trailing blank lines are not a translation edit");
+  } finally { r.cleanup(); }
+});
+
+test("a stale translation cannot be settled by switching to CRLF", () => {
+  const r = staleRepo();
+  try {
+    r.advance((write) => write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace(/\n/g, "\r\n")));
+    assert.equal(r.run(), 1, "line endings are not a translation edit");
+  } finally { r.cleanup(); }
+});
+
+test("a real translation edit is still accepted (control for the two above)", () => {
+  const r = staleRepo();
+  try {
+    r.advance((write) => write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("blockchain-explorers", "block-explorers")));
+    assert.equal(r.run(), 0, "a genuine retranslation must still pass");
+  } finally { r.cleanup(); }
+});
+
+test("a failed git listing is reported as a failed listing", () => {
+  // When `git ls-files` threw, the catch returned an empty Set. That does NOT go
+  // vacuously green — `locales` comes from the manifest, so every declared locale
+  // then reports "no translations directory" and the build is red either way.
+  // What it costs is the diagnosis: one accurate line becomes an avalanche of
+  // violations blaming the corpus for a broken listing. So the contract worth
+  // pinning is the MESSAGE, which an exit code alone cannot see.
+  const r = makeRepo();
+  try {
+    const { code, out } = r.runWithBrokenLsFiles();
+    assert.equal(code, 1, "an unreadable listing must never pass");
+    assert.match(out, /could not list translations\//,
+      "the run must say the listing failed, not blame the corpus for being absent");
+  } finally { r.cleanup(); }
+});
+
+test("a malformed allowlist line fails the build", () => {
+  const r = makeRepo();
+  try {
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${hashPage(EN_BODY)}\n`); // one hash short
+    r.commit("half a line");
+    assert.equal(r.run(), 1, "an unparseable authorisation must not be shrugged off as a notice");
+  } finally { r.cleanup(); }
+});
+
+test("a duplicate allowlist key fails the build", () => {
+  const r = makeRepo();
+  try {
+    const line = `${LOC}/${EN_PAGE}  ${hashPage(EN_BODY)}  ${hashPage(TR_BODY)}`;
+    r.write("translation/verified-noops.txt", `${line}\n${line}\n`);
+    r.commit("the same page authorised twice");
+    assert.equal(r.run(), 1);
+  } finally { r.cleanup(); }
+});
+
+test("a base entry with no `edited` field is refused, not admitted", () => {
+  // The predicate is fail-closed on both sides (`!== false`). Pin that, because
+  // the looser reading (`!== true`) passes every other test in this suite.
+  const r = makeRepo();
+  try {
+    const m0 = r.manifest();
+    delete m0[LOC][EN_PAGE].edited;          // base entry lacks the flag entirely
+    r.setManifest(m0);
+    r.commit("base entry without an edited flag");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    r.write("translation/verified-noops.txt", `${LOC}/${EN_PAGE}  ${hashPage(EN2)}  ${hashPage(TR_BODY)}\n`);
+    const m = r.manifest();
+    m[LOC][EN_PAGE].src = hashPage(EN2);
+    m[LOC][EN_PAGE].edited = false;
+    r.setManifest(m);
+    r.commit("authorise and bump");
+
+    assert.equal(r.run(base), 1, "an unknown base `edited` state must not be treated as false");
   } finally { r.cleanup(); }
 });

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -22,6 +22,12 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hashPage } from "./normalize-hash.mjs";
 
+/** violations print as "  - msg"; notices print as "  note: msg". A test that
+ *  merely greps the output cannot tell them apart, and one that did let a
+ *  fail()->note() mutation pass unnoticed. */
+const violations = (out) => out.split("\n").filter((l) => /^ {2}- /.test(l));
+const hasViolation = (out, re) => violations(out).some((l) => re.test(l));
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, "..", "..");
 const CHECKER = join("translation", "check-invariants.mjs");
@@ -544,7 +550,7 @@ test("a translation must be an ordinary file, not a symlink", () => {
 
 test("DIRECTION 1: a tool-only provenance change is a valid reason", () => {
   // `tool` alone is exactly what the refusal message tells people to write, and
-  // it is the shape commit 9dcac0e4 used on 36 entries. Nothing tested it, so
+  // it is the shape commit 9dcac0e4 used on 72 entries. Nothing tested it, so
   // dropping `tool` from the provenance comparison passed the whole suite.
   const r = makeRepo();
   try {
@@ -657,5 +663,66 @@ test("a dirty working tree is called out, because CI asks about the commit", () 
     const { out } = r.runOut();
     assert.match(out, /uncommitted change\(s\) under site\/, translations\/ or translation\//);
     assert.match(out, /describes your WORKING TREE/);
+  } finally { r.cleanup(); }
+});
+
+test("a symlink that was ALREADY there is refused, not just a new one", () => {
+  // The change detector only sees shapes that appear in a diff, so a link that
+  // predates the base never reached it. Direction 2 happened to refuse such a
+  // page anyway, but for the wrong reason — "nothing changed" rather than "this
+  // is not a page". The rule is now stated over the whole tree.
+  const r = makeRepo();
+  try {
+    r.write("attic/copy.md", TR_BODY);
+    rmSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`));
+    symlinkSync("../../../../attic/copy.md", join(r.dir, `translations/${LOC}/site/${EN_PAGE}`));
+    r.commit("a translation that is a link, from the start");
+    // Compare against THIS commit, so the link appears in no diff record at all.
+    // Otherwise the changed-record check fires with the same wording and the
+    // tree-wide rule is never the thing under test.
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /is not a regular file \(mode 120000\)/),
+      `expected a VIOLATION about the symlink, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("DIRECTION 1: an engine-only provenance change is a valid reason", () => {
+  // Switching engine for a locale (NLLB -> Google, say) is a recorded pass. It
+  // was missing from the comparison, so such a change was refused with advice to
+  // record the thing that had just been recorded.
+  const r = makeRepo();
+  try {
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
+    const m = r.manifest();
+    m[LOC][EN_PAGE].engine = "nllb";             // ONLY engine moves
+    r.setManifest(m);
+    r.commit("retranslate this locale with a different engine");
+    assert.equal(r.run(), 0, "recording the pass in `engine` must be accepted");
+  } finally { r.cleanup(); }
+});
+
+test("the refusal does not offer a line that cannot work", () => {
+  // A line pins the manifest's src to the English on disk. If the manifest
+  // records some other hash, no line satisfies that — and printing one sends the
+  // operator round a loop: they add exactly what was asked and get the same
+  // refusal back.
+  const r = makeRepo();
+  try {
+    const base = r.base;
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    const m = r.manifest();
+    m[LOC][EN_PAGE].src = "sha256:" + "7".repeat(64);   // neither base nor disk
+    r.setManifest(m);
+    r.commit("bump src to something that is not the English on disk");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /no exception can bridge that/),
+      `expected the refusal to explain the src mismatch, got:\n${out}`);
+    assert.ok(!hasViolation(out, /a human can record that in/),
+      "it must not offer a line that cannot satisfy the check");
   } finally { r.cleanup(); }
 });

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1225,3 +1225,59 @@ test("a manifest that is not an object is reported, not a stack trace", () => {
     } finally { r.cleanup(); }
   }
 });
+
+test("predecessors whose `edited` differs only by TYPE are ambiguous", () => {
+  // false and "false" print identically. noopAllowed admits one and refuses the
+  // other, so a disagreement key built by string interpolation called them
+  // equivalent — and the gate then picked whichever came first, deciding the
+  // page's verdict by array order.
+  const r = makeRepo();
+  try {
+    const TWIN = "guides/Twin.md";
+    r.write(`site/${TWIN}`, EN_BODY);
+    r.write(`translations/${LOC}/site/${TWIN}`, TR_BODY);     // identical text
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${TWIN}\n`);
+    const m0 = r.manifest();
+    m0[LOC][EN_PAGE].edited = false;
+    m0[LOC][TWIN] = { ...m0[LOC][EN_PAGE], edited: "false" };  // same text, other TYPE
+    r.setManifest(m0);
+    r.commit("two pages with identical translations, edited differing by type");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const NEW = "guides/Copy.md";
+    r.write(`site/${NEW}`, EN_BODY);
+    r.write(`translations/${LOC}/site/${NEW}`, TR_BODY);       // continues... which one?
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${TWIN}\n${NEW}\n`);
+    const m = r.manifest();
+    m[LOC][NEW] = { ...m[LOC][EN_PAGE] };
+    r.setManifest(m);
+    r.commit("add a page whose translation matches both");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1, "candidates that decide the page differently must be refused");
+    assert.ok(hasViolation(out, /do not agree/), `expected an ambiguity refusal, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("a malformed base entry cannot be a predecessor", () => {
+  // Reading .src off a null entry is a TypeError, and a throw here discards the
+  // report along with every finding in it.
+  const r = makeRepo();
+  try {
+    const m0 = r.manifest();
+    m0[LOC]["guides/Ghost.md"] = null;
+    r.setManifest(m0);
+    r.commit("a base entry that is not a record");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
+    const m = r.manifest();
+    m[LOC][EN_PAGE].tool = "t+pass2";
+    r.setManifest(m);
+    r.commit("edit a translation and record it");
+
+    const { code, out } = r.runOut(base);
+    assert.doesNotMatch(out, /at ModuleJob\.run/, "must not surface a stack trace");
+    assert.equal(typeof code, "number");
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -946,3 +946,52 @@ test("a LOCALE rename cannot settle stale translations", () => {
     assert.equal(r.run(), 1, "a locale rename must not launder stale translations");
   } finally { r.cleanup(); }
 });
+
+test("a .gitattributes filter cannot make every page look changed", () => {
+  // The base side was read with `git show`, which hands back the RAW BLOB, while
+  // the other side reads the working tree. Declaring an encoding makes those two
+  // different representations of the same page: the blob is re-canonicalised, the
+  // working tree is not. Every listed path then compares unequal forever — and
+  // "changed" is the answer that skips Direction 2, so a stale page settles with
+  // no authorisation. Both sides must be read in the form a reader sees.
+  const r = makeRepo();
+  try {
+    // UTF-16LE needs an even byte count, and a single trailing space is stripped
+    // by hashPage, so padding to even length changes nothing the gate can see.
+    const even = (t) => (Buffer.byteLength(t) % 2 ? t.replace(/\n$/, " \n") : t);
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, even(TR_BODY));
+    r.write(".gitattributes", "translations/** working-tree-encoding=UTF-16LE\n");
+    git(r.dir, "add", "-A");
+    git(r.dir, "add", "--renormalize", "-A");    // re-canonicalises the blobs
+    git(r.dir, "commit", "-qm", "declare an encoding for translated pages");
+    const v1 = git(r.dir, "rev-parse", "HEAD").trim();
+
+    // English moves on; the translation is touched only cosmetically (trailing
+    // blank lines, which hashPage normalises away) so the path is a candidate
+    // without the page having changed.
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, even(TR_BODY) + "\n\n");
+    const m = r.manifest();
+    m[LOC][EN_PAGE].src = hashPage(EN2);
+    m[LOC][EN_PAGE].tool = "cosmetic";
+    r.setManifest(m);
+    r.commit("advance the English and the record, touching the translation cosmetically");
+
+    assert.equal(r.run(v1), 1, "an encoding attribute must not settle a stale page");
+  } finally { r.cleanup(); }
+});
+test("a malformed locale block is reported, not a stack trace", () => {
+  // Object.keys(null) discards every violation collected so far.
+  const r = makeRepo();
+  try {
+    const m = r.manifest();
+    m.fr = null;
+    r.setManifest(m);
+    r.commit("a locale block that is not an object");
+    const { code, out } = r.runOut();
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /locale "fr" is not an object/), `got:\n${out}`);
+    assert.doesNotMatch(out, /at ModuleJob\.run/, "must not surface a stack trace");
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -312,9 +312,9 @@ test("a renamed-and-edited translation is still seen as changed", () => {
     r.setManifest(m);
     r.commit("move the page and edit the translation in the same commit");
 
-    // The destination is a NEW manifest key, so neither direction can fire on
-    // it — but the run must stay parseable and green rather than erroring on a
-    // record shape it did not expect.
+    // A moved page keeps the record it always had, so this still passes — but it
+    // passes because the src did not advance, NOT because a new key is exempt.
+    // That exemption was a way to settle a stale page and is gone.
     assert.equal(r.run(), 0);
   } finally { r.cleanup(); }
 });
@@ -725,4 +725,159 @@ test("the refusal does not offer a line that cannot work", () => {
     assert.ok(!hasViolation(out, /a human can record that in/),
       "it must not offer a line that cannot satisfy the check");
   } finally { r.cleanup(); }
+});
+
+test("a RENAME cannot settle a stale translation", () => {
+  // The fifth laundering route, and the most plausible: move the English, move
+  // its stale translation verbatim, move the manifest key, set src to the new
+  // English. The key is new, so Direction 2 used to skip it entirely — and the
+  // gate's own advice about a moved page tells contributors to do exactly this.
+  const r = makeRepo();
+  try {
+    const NEW = "guides/Demo_v2.md";
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write("translation/curated-pages.txt", `${NEW}\n`);
+    git(r.dir, "mv", `site/${EN_PAGE}`, `site/${NEW}`);
+    r.write(`site/${NEW}`, EN2);                                   // English moves on
+    git(r.dir, "mv", `translations/${LOC}/site/${EN_PAGE}`, `translations/${LOC}/site/${NEW}`);
+    const m = r.manifest();                                        // translation moves VERBATIM — still stale
+    m[LOC][NEW] = { ...m[LOC][EN_PAGE], src: hashPage(EN2) };
+    delete m[LOC][EN_PAGE];
+    r.setManifest(m);
+    r.commit("move the page to a new route and bump its source");
+
+    assert.equal(r.run(), 1, "a rename must not launder a stale translation fresh");
+  } finally { r.cleanup(); }
+});
+
+test("a PURE rename with no source bump still passes", () => {
+  // The control that keeps the fix honest: moving a page is ordinary
+  // housekeeping and must not start failing.
+  const r = makeRepo();
+  try {
+    const NEW = "guides/Demo_v2.md";
+    r.write("translation/curated-pages.txt", `${NEW}\n`);
+    git(r.dir, "mv", `site/${EN_PAGE}`, `site/${NEW}`);
+    git(r.dir, "mv", `translations/${LOC}/site/${EN_PAGE}`, `translations/${LOC}/site/${NEW}`);
+    const m = r.manifest();
+    m[LOC][NEW] = m[LOC][EN_PAGE];
+    delete m[LOC][EN_PAGE];
+    r.setManifest(m);
+    r.commit("move the page, changing nothing about it");
+    assert.equal(r.run(), 0, "an honest move must stay green");
+  } finally { r.cleanup(); }
+});
+
+test("a genuinely new page with a new translation still passes", () => {
+  // The other control: a page that really is new has no ancestor to inherit
+  // from, and must not be caught by the rename rule.
+  const r = makeRepo();
+  try {
+    const NEW = "guides/Brand_New.md";
+    const EN_NEW = "# Brand New\n\nSomething else entirely.\n";
+    r.write(`site/${NEW}`, EN_NEW);
+    r.write(`translations/${LOC}/site/${NEW}`, "# Brand New\n\nQualcosa di completamente diverso.\n");
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${NEW}\n`);
+    const m = r.manifest();
+    m[LOC][NEW] = { src: hashPage(EN_NEW), src_commit: "0".repeat(40), engine: "llm", mode: "seed", tool: "t", edited: false };
+    r.setManifest(m);
+    r.commit("curate and translate a brand new page");
+    assert.equal(r.run(), 0, "a genuinely new page must still be accepted");
+  } finally { r.cleanup(); }
+});
+
+test("an UNCOMMITTED translation edit is seen, and must record why", () => {
+  // The working-tree switch exists so the check reads what is on disk. Nothing
+  // asserted that: substituting the base text for the disk text passed the whole
+  // suite, which means the mechanism could be removed without a test noticing.
+  // Direction 1 must fire on an edit that exists only on disk.
+  const r = makeRepo();
+  try {
+    writeFileSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`),
+      TR_BODY.replace("Vedi", "Guarda bene"));      // edited, NOT committed
+    const { code, out } = r.runOut();
+    assert.equal(code, 1, "an unrecorded edit on disk must be refused");
+    assert.ok(hasViolation(out, /translation changed but manifest provenance did not/),
+      `expected Direction 1 to fire on the disk edit, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("an edited:true page is not offered an exception it cannot use", () => {
+  // noopAllowed refuses on `edited` before it ever looks at a line, so printing
+  // one sends the operator round the same loop: add exactly what was printed,
+  // get the identical refusal back.
+  const r = makeRepo();
+  try {
+    const m0 = r.manifest();
+    m0[LOC][EN_PAGE].edited = true;
+    r.setManifest(m0);
+    r.commit("hold this page as hand-edited");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    const m = r.manifest();
+    m[LOC][EN_PAGE].src = hashPage(EN2);
+    r.setManifest(m);
+    r.commit("advance the English and the record");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /held as hand-edited/), `expected the edited explanation, got:\n${out}`);
+    assert.ok(!hasViolation(out, /a human can record that in/),
+      "it must not offer a line that `edited` will refuse anyway");
+  } finally { r.cleanup(); }
+});
+
+// root can read a 0o000 file, so this cannot be expressed as a test there.
+const ROOT = typeof process.getuid === "function" && process.getuid() === 0;
+
+test("an unreadable page is a finding, not a crash", { skip: ROOT && "running as root" }, () => {
+  // currentHash/translationHash guarded existence but not readability, so an I/O
+  // error threw out of module evaluation and every violation already collected
+  // was discarded — a stack trace instead of the report.
+  const r = makeRepo();
+  try {
+    chmodSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`), 0o000);
+    const { code, out } = r.runOut();
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /cannot be read|could not read/),
+      `expected a read finding, got:\n${out}`);
+    assert.doesNotMatch(out, /at ModuleJob\.run/, "must not surface a stack trace");
+  } finally {
+    try { chmodSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`), 0o644); } catch {}
+    r.cleanup();
+  }
+});
+
+test("a directory where a translation should be is not a translation", () => {
+  // A directory at a page's path reads to git as a deletion, and a deletion counts
+  // as "changed" — the classification that satisfies Direction 2.
+  const r = staleRepo();
+  try {
+    r.advance(() => {});
+    rmSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`), { force: true });
+    mkdirSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`), { recursive: true });
+    const { code, out } = r.runOut(r.base);
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /no translated file there|manifest entry for missing file/),
+      `expected the directory to be refused, got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("an unreadable ENGLISH page is a finding, not a crash", { skip: ROOT && "running as root" }, () => {
+  // The change-tracking reader has its own guard, so an unreadable TRANSLATION is
+  // caught there. The English side is only ever read by currentHash, which is the
+  // path that used to throw out of module evaluation and discard the report.
+  const r = makeRepo();
+  try {
+    chmodSync(join(r.dir, `site/${EN_PAGE}`), 0o000);
+    const { code, out } = r.runOut();
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /cannot be read/), `expected a read finding, got:\n${out}`);
+    assert.doesNotMatch(out, /at ModuleJob\.run/, "must not surface a stack trace");
+  } finally {
+    try { chmodSync(join(r.dir, `site/${EN_PAGE}`), 0o644); } catch {}
+    r.cleanup();
+  }
 });

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1084,6 +1084,32 @@ test("KNOWN LIMIT: a rename that also edits escapes rule 1", () => {
   } finally { r.cleanup(); }
 });
 
+test("KNOWN LIMIT: and that escape carries a stale `src` with it", () => {
+  // The wider half of the same boundary, and the reason the limit is NOT merely a
+  // traceability one. A new key has no record to check its `src` against, so the
+  // page can move, be edited invisibly, AND claim currency it never had. An HTML
+  // comment is enough: it renders as nothing and it is a real change to hashPage,
+  // which is what stops the copy being recognised as a move.
+  const r = makeRepo();
+  try {
+    const NEW = "guides/Demo_v2.md";
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write("translation/curated-pages.txt", `${NEW}\n`);
+    git(r.dir, "mv", `site/${EN_PAGE}`, `site/${NEW}`);
+    r.write(`site/${NEW}`, EN2);                                   // English moves on
+    git(r.dir, "mv", `translations/${LOC}/site/${EN_PAGE}`, `translations/${LOC}/site/${NEW}`);
+    r.write(`translations/${LOC}/site/${NEW}`, TR_BODY + "<!-- -->\n");  // invisible edit
+    const m = r.manifest();
+    m[LOC][NEW] = { ...m[LOC][EN_PAGE], src: hashPage(EN2) };      // claims currency
+    delete m[LOC][EN_PAGE];
+    r.setManifest(m);
+    r.commit("move, edit invisibly, and claim the new English");
+
+    assert.equal(r.run(), 0,
+      "documented limit: a new key's src has no record to be checked against");
+  } finally { r.cleanup(); }
+});
+
 test("...but the same edit WITHOUT a rename is refused", () => {
   // The control that gives the limit above its exact shape.
   const r = makeRepo();

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1140,13 +1140,18 @@ test("a LOCALE rename cannot settle stale translations", () => {
   } finally { r.cleanup(); }
 });
 
-test("a .gitattributes filter cannot make every page look changed", () => {
-  // The base side was read with `git show`, which hands back the RAW BLOB, while
-  // the other side reads the working tree. Declaring an encoding makes those two
-  // different representations of the same page: the blob is re-canonicalised, the
-  // working tree is not. Every listed path then compares unequal forever — and
-  // "changed" is the answer that skips Direction 2, so a stale page settles with
-  // no authorisation. Both sides must be read in the form a reader sees.
+test("the base blob is read in the same representation as the working tree", () => {
+  // What this pins: `git show` hands back the RAW BLOB while the other side reads
+  // the working tree, so under any .gitattributes filter the two are different
+  // representations of one page and every listed path compares unequal forever —
+  // "changed", the answer that skips Direction 2. Reading the base through
+  // `--filters` puts both sides in the same form.
+  //
+  // What it does NOT pin, despite an earlier name that implied it: this fixture's
+  // working tree is still UTF-8. `git add --renormalize` on a UTF-8 tree writes a
+  // garbage blob that smudges straight back to UTF-8, so the declared encoding
+  // never reaches the disk. The head side reads bytes with readFileSync and
+  // applies no attributes at all — see limit C in the requirements.
   const r = makeRepo();
   try {
     // UTF-16LE needs an even byte count, and a single trailing space is stripped

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -16,7 +16,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, cpSync, readFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, cpSync, readFileSync, chmodSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -421,5 +421,150 @@ test("a base entry with no `edited` field is refused, not admitted", () => {
     r.commit("authorise and bump");
 
     assert.equal(r.run(base), 1, "an unknown base `edited` state must not be treated as false");
+  } finally { r.cleanup(); }
+});
+
+test("DIRECTION 1: an edited translation with no recorded provenance is REFUSED", () => {
+  // The whole first invariant had no negative case: every test that edited a
+  // translation also recorded the pass, so deleting the Direction 1 enforcement
+  // outright passed the entire suite. This is the case that makes it real —
+  // somebody changes a translated page and the manifest says nothing happened.
+  const r = makeRepo();
+  try {
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda bene"));
+    r.commit("edit a translation and record nothing");
+    assert.equal(r.run(), 1, "an unexplained translation edit must not pass");
+  } finally { r.cleanup(); }
+});
+
+test("DIRECTION 1: `edited:true` already at base is not a standing licence", () => {
+  // Flipping the flag is a reason; having flipped it once is not. Otherwise one
+  // hand-edit buys permanent freedom to change the file with no manifest trace.
+  const r = makeRepo();
+  try {
+    const m0 = r.manifest();
+    m0[LOC][EN_PAGE].edited = true;
+    r.setManifest(m0);
+    r.commit("mark the page hand-edited");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda bene"));
+    r.commit("edit it again, recording nothing");
+    assert.equal(r.run(base), 1, "edited:true at base must not license further silent edits");
+  } finally { r.cleanup(); }
+});
+
+test("DIRECTION 1: flipping edited:true in THIS change is an accepted reason", () => {
+  const r = makeRepo();
+  try {
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda bene"));
+    const m = r.manifest();
+    m[LOC][EN_PAGE].edited = true;
+    r.setManifest(m);
+    r.commit("a human fix, declared as one");
+    assert.equal(r.run(), 0, "declaring a hand-edit must remain a valid reason");
+  } finally { r.cleanup(); }
+});
+
+// Front matter is where "changed" gets subtle: some keys are churn the pipeline
+// deliberately ignores, the rest are real content. The wiring must honour that
+// distinction, and a mutation that flattened it passed every test before these.
+
+const FM = (date, title) => `---\ntitle: ${title}\ndate: ${date}\n---\n`;
+const EN_FM = FM("2026-01-01", "Demo") + EN_BODY;
+const TR_FM = FM("2026-01-01", "Demo") + TR_BODY;
+
+/** base repo whose pages carry front matter, then advance the English */
+function fmRepo() {
+  const r = makeRepo();
+  r.write(`site/${EN_PAGE}`, EN_FM);
+  r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_FM);
+  const m0 = r.manifest();
+  m0[LOC][EN_PAGE].src = hashPage(EN_FM);
+  r.setManifest(m0);
+  r.commit("give the pages front matter");
+  const base = git(r.dir, "rev-parse", "HEAD").trim();
+  const EN2 = FM("2026-01-01", "Demo") + EN_BODY.replace("blockchain-explorers", "block-explorers");
+  return {
+    ...r, base,
+    advance(newTranslation) {
+      r.write(`site/${EN_PAGE}`, EN2);
+      r.write(`translations/${LOC}/site/${EN_PAGE}`, newTranslation);
+      const m = r.manifest();
+      m[LOC][EN_PAGE].src = hashPage(EN2);
+      m[LOC][EN_PAGE].tool = "t+pass2";
+      r.setManifest(m);
+      r.commit("advance");
+      return r.run(base);
+    },
+  };
+}
+
+test("bumping only a volatile front-matter key does NOT settle a stale page", () => {
+  // `date:` is churn by design — the pipeline hashes as though it were not there.
+  // So touching only that is not a translation edit, however much the blob moved.
+  const r = fmRepo();
+  try {
+    assert.equal(r.advance(FM("2026-09-11", "Demo") + TR_BODY), 1);
+  } finally { r.cleanup(); }
+});
+
+test("changing a NON-volatile front-matter key is a real translation change", () => {
+  // The title is content: a translated title that changed really did change, and
+  // treating it as churn would refuse honest work.
+  const r = fmRepo();
+  try {
+    assert.equal(r.advance(FM("2026-01-01", "Dimostrazione") + TR_BODY), 0);
+  } finally { r.cleanup(); }
+});
+
+test("a translation must be an ordinary file, not a symlink", () => {
+  // A symlink's blob holds its TARGET PATH, so pointing a page at an identical
+  // copy moves the blob while the text a reader sees never changes — the diff
+  // said "changed" and readFileSync said "same", and a stale page settled.
+  const r = makeRepo();
+  try {
+    r.write("attic/copy.md", TR_BODY);          // identical stale content, tracked
+    r.commit("add a copy elsewhere in the tree");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    rmSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`));
+    symlinkSync("../../../../attic/copy.md", join(r.dir, `translations/${LOC}/site/${EN_PAGE}`));
+    const m = r.manifest();
+    m[LOC][EN_PAGE].src = hashPage(EN2);
+    m[LOC][EN_PAGE].tool = "t+pass2";
+    r.setManifest(m);
+    r.commit("swap the translation for a symlink");
+
+    assert.equal(r.run(base), 1, "a symlinked translation must be refused outright");
+  } finally { r.cleanup(); }
+});
+
+test("DIRECTION 1: a tool-only provenance change is a valid reason", () => {
+  // `tool` alone is exactly what the refusal message tells people to write, and
+  // it is the shape commit 9dcac0e4 used on 36 entries. Nothing tested it, so
+  // dropping `tool` from the provenance comparison passed the whole suite.
+  const r = makeRepo();
+  try {
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
+    const m = r.manifest();
+    m[LOC][EN_PAGE].tool = "t+linkrepair";      // ONLY tool moves
+    r.setManifest(m);
+    r.commit("repair a link in the translation and say so in `tool`");
+    assert.equal(r.run(), 0, "recording the pass in `tool` must be accepted");
+  } finally { r.cleanup(); }
+});
+
+test("DIRECTION 1: a mode-only provenance change is a valid reason", () => {
+  const r = makeRepo();
+  try {
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
+    const m = r.manifest();
+    m[LOC][EN_PAGE].mode = "full";              // ONLY mode moves
+    r.setManifest(m);
+    r.commit("retranslate the whole page rather than diffing it");
+    assert.equal(r.run(), 0, "recording the pass in `mode` must be accepted");
   } finally { r.cleanup(); }
 });

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1324,3 +1324,32 @@ test("a non-ASCII translation filename is still seen by the bijection", () => {
       `expected the orphan to be named, got:\n${out}`);
   } finally { r.cleanup(); }
 });
+
+test("the deletion remedy, followed exactly, produces a green run", () => {
+  // R7: a refusal must not name a remedy that cannot work. This one told people to
+  // remove the curated line and "leave translations/<locale>/site/ alone", which
+  // leaves a manifest entry for a non-curated page — refused. Removing the entries
+  // too leaves the files orphaned — also refused. Only all three together pass,
+  // and the message now says so.
+  const r = makeRepo();
+  try {
+    const KEEP = "guides/Keep.md";
+    r.write(`site/${KEEP}`, "# Keep\n\nstays.\n");
+    r.write(`translations/${LOC}/site/${KEEP}`, "# Keep\n\nresta.\n");
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${KEEP}\n`);
+    const m0 = r.manifest();
+    m0[LOC][KEEP] = { ...m0[LOC][EN_PAGE], src: hashPage("# Keep\n\nstays.\n") };
+    r.setManifest(m0);
+    r.commit("two curated pages");
+
+    // exactly what the refusal now prescribes: curated line, entries, files
+    git(r.dir, "rm", "-q", `site/${EN_PAGE}`, `translations/${LOC}/site/${EN_PAGE}`);
+    r.write("translation/curated-pages.txt", `${KEEP}\n`);
+    const m = r.manifest();
+    delete m[LOC][EN_PAGE];
+    r.setManifest(m);
+    r.commit("retire the page the way the message says to");
+
+    assert.equal(r.run(), 0, "the prescribed remedy must actually go green");
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -621,38 +621,6 @@ test("`--no-renames` is load-bearing: a PURE rename stays parseable", () => {
   } finally { r.cleanup(); }
 });
 
-test("a page whose path cannot be expressed says so, instead of printing a bad line", () => {
-  // The allowlist is whitespace-separated and `#` starts a comment, so a path
-  // containing either cannot be written as a line. Printing the usual "copy this"
-  // suggestion would hand someone a line that fails to parse — a permanently red
-  // build whose message never mentions the real reason.
-  const PAGE = "guides/Zcash #1 Guide.md";
-  const r = makeRepo();
-  try {
-    r.write(`site/${PAGE}`, EN_BODY);
-    r.write(`translations/${LOC}/site/${PAGE}`, TR_BODY);
-    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${PAGE}\n`);
-    const m0 = r.manifest();
-    m0[LOC][PAGE] = { src: hashPage(EN_BODY), src_commit: "0".repeat(40), engine: "llm", mode: "diff", tool: "t", edited: false };
-    r.setManifest(m0);
-    r.commit("curate a page whose name has a space and a hash");
-    const base = git(r.dir, "rev-parse", "HEAD").trim();
-
-    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
-    r.write(`site/${PAGE}`, EN2);
-    const m = r.manifest();
-    m[LOC][PAGE].src = hashPage(EN2);
-    r.setManifest(m);
-    r.commit("bump its source without touching the translation");
-
-    const { code, out } = r.runOut(base);
-    assert.equal(code, 1);
-    assert.match(out, /cannot be authorised: its path contains whitespace or "#"/);
-    assert.doesNotMatch(out, /a human can record that in/,
-      "it must not offer a line that cannot parse");
-  } finally { r.cleanup(); }
-});
-
 test("a dirty working tree is called out, because CI asks about the commit", () => {
   // The whole check reads disk, so a dirty tree gets a coherent answer — about
   // disk. That is not the question CI asks, and "invariants hold" must not be
@@ -880,4 +848,42 @@ test("an unreadable ENGLISH page is a finding, not a crash", { skip: ROOT && "ru
     try { chmodSync(join(r.dir, `site/${EN_PAGE}`), 0o644); } catch {}
     r.cleanup();
   }
+});
+
+test("an AMBIGUOUS move is refused rather than guessed", () => {
+  // Two removed pages can hold identical translations, and then content cannot
+  // say which one a moved file came from. A record that cannot be identified
+  // cannot be checked, so the gate refuses and asks for a human line rather than
+  // silently inheriting whichever it happened to find first.
+  const r = makeRepo();
+  try {
+    const TWIN = "guides/Twin.md";
+    r.write(`site/${TWIN}`, EN_BODY);
+    r.write(`translations/${LOC}/site/${TWIN}`, TR_BODY);   // IDENTICAL translation
+    r.write("translation/curated-pages.txt", `${EN_PAGE}\n${TWIN}\n`);
+    const m0 = r.manifest();
+    m0[LOC][TWIN] = { ...m0[LOC][EN_PAGE] };
+    r.setManifest(m0);
+    r.commit("two curated pages whose translations are identical");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    // both pages collapse into one new route
+    const MERGED = "guides/Merged.md";
+    r.write("translation/curated-pages.txt", `${MERGED}\n`);
+    git(r.dir, "rm", "-q", `site/${EN_PAGE}`, `site/${TWIN}`,
+      `translations/${LOC}/site/${EN_PAGE}`, `translations/${LOC}/site/${TWIN}`);
+    r.write(`site/${MERGED}`, EN_BODY);
+    r.write(`translations/${LOC}/site/${MERGED}`, TR_BODY);
+    const m = r.manifest();
+    m[LOC][MERGED] = { ...m[LOC][EN_PAGE] };
+    delete m[LOC][EN_PAGE];
+    delete m[LOC][TWIN];
+    r.setManifest(m);
+    r.commit("collapse both pages into one route");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /identical to 2 pages removed in this change/),
+      `expected an ambiguity refusal, got:\n${out}`);
+  } finally { r.cleanup(); }
 });

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1406,3 +1406,44 @@ test("KNOWN LIMIT: 'changed' means the normalised text differs, not 'a real edit
     } finally { r.cleanup(); }
   }
 });
+
+test("a translation that was a SYMLINK at base cannot license a source bump", () => {
+  // The rule that a translation is an ordinary file covers the tree being checked.
+  // The base's hash is evidence in the same comparison, and a symlink there reads
+  // back as its target PATH — which can never equal the page text, so the pair
+  // compares unequal forever and the bump is settled by a shape, not a change.
+  // Needs a base written before that rule existed, which is why it survived it.
+  const r = makeRepo();
+  try {
+    r.write("attic/copy.md", TR_BODY);
+    rmSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`));
+    symlinkSync("../../../../attic/copy.md", join(r.dir, `translations/${LOC}/site/${EN_PAGE}`));
+    r.commit("a base whose translation is a link");
+    const base = git(r.dir, "rev-parse", "HEAD").trim();
+
+    rmSync(join(r.dir, `translations/${LOC}/site/${EN_PAGE}`));
+    r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY);   // same text, real file
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    const m = r.manifest();
+    m[LOC][EN_PAGE].src = hashPage(EN2);
+    m[LOC][EN_PAGE].tool = "t+pass2";
+    r.setManifest(m);
+    r.commit("replace the link with a file of the same text and advance src");
+
+    const { code, out } = r.runOut(base);
+    assert.equal(code, 1, "a shape change at base must not read as a text change");
+    assert.ok(hasViolation(out, /was not a regular file at base/), `got:\n${out}`);
+  } finally { r.cleanup(); }
+});
+
+test("an unreadable exception list is a finding, not a crash", () => {
+  const r = makeRepo();
+  try {
+    mkdirSync(join(r.dir, "translation/verified-noops.txt"), { recursive: true });
+    const { code, out } = r.runOut();
+    assert.equal(code, 1);
+    assert.ok(hasViolation(out, /verified-noops\.txt: cannot be read/), `got:\n${out}`);
+    assert.doesNotMatch(out, /at ModuleJob\.run/, "must not surface a stack trace");
+  } finally { r.cleanup(); }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -1043,3 +1043,18 @@ test("a page held at BASE is not offered an exception either", () => {
       `and must say which side holds it:\n${out}`);
   } finally { r.cleanup(); }
 });
+
+test("a manifest that is not an object is reported, not a stack trace", () => {
+  // Parsing as JSON does not make it a manifest: null, a list and a string all
+  // parse. Object.keys(null) throws, and a throw here discards the report.
+  for (const bad of ["null", "[]", '"x"']) {
+    const r = makeRepo();
+    try {
+      writeFileSync(join(r.dir, "translation/sync-state.json"), `${bad}\n`);
+      const { code, out } = r.runOut();
+      assert.equal(code, 1, `${bad} must be refused`);
+      assert.ok(hasViolation(out, /is not a JSON object/), `${bad} got:\n${out}`);
+      assert.doesNotMatch(out, /at ModuleJob\.run/, `${bad} must not surface a stack trace`);
+    } finally { r.cleanup(); }
+  }
+});

--- a/translation/lib/check-invariants.integration.test.mjs
+++ b/translation/lib/check-invariants.integration.test.mjs
@@ -883,7 +883,7 @@ test("an AMBIGUOUS move is refused rather than guessed", () => {
 
     const { code, out } = r.runOut(base);
     assert.equal(code, 1);
-    assert.ok(hasViolation(out, /identical to 2 pages removed in this change/),
+    assert.ok(hasViolation(out, /identical to 2 entries removed in this change/),
       `expected an ambiguity refusal, got:\n${out}`);
   } finally { r.cleanup(); }
 });
@@ -924,5 +924,25 @@ test("...but the same edit WITHOUT a rename is refused", () => {
     r.write(`translations/${LOC}/site/${EN_PAGE}`, TR_BODY.replace("Vedi", "Guarda"));
     r.commit("edit the translation, recording nothing");
     assert.equal(r.run(), 1);
+  } finally { r.cleanup(); }
+});
+
+test("a LOCALE rename cannot settle stale translations", () => {
+  // The page-rename route one level up: move translations/it to translations/it-IT,
+  // rename the manifest's locale key, bump src, touch no translation. Searching for
+  // a predecessor only inside the same locale made every page look brand new, so
+  // Direction 2 skipped all of them — a locale-code migration marking the whole
+  // locale current in one commit.
+  const r = staleRepo();
+  try {
+    const EN2 = EN_BODY.replace("blockchain-explorers", "block-explorers");
+    r.write(`site/${EN_PAGE}`, EN2);
+    git(r.dir, "mv", `translations/${LOC}`, "translations/it-IT");
+    const m = r.manifest();
+    m["it-IT"] = { [EN_PAGE]: { ...m[LOC][EN_PAGE], src: hashPage(EN2) } };
+    delete m[LOC];
+    r.setManifest(m);
+    r.commit("migrate the locale code, leaving the translations untouched");
+    assert.equal(r.run(), 1, "a locale rename must not launder stale translations");
   } finally { r.cleanup(); }
 });

--- a/translation/lib/verified-noops.mjs
+++ b/translation/lib/verified-noops.mjs
@@ -11,8 +11,10 @@
 // now out of date against a change its own translation already contains. A later
 // run re-translates, finds nothing to alter, and the record can never be
 // settled, so the page is offered again in every window, forever, producing
-// nothing. 9dcac0e4 did exactly that to 36 entries on two pages; 20 of them are
-// still stuck.
+// nothing. 9dcac0e4 did exactly that to 36 entries on two pages. Later runs
+// happened to produce some other difference on 16 of them, which settled those;
+// the remaining 20 had nothing left to differ and are the lines in
+// translation/verified-noops.txt.
 //
 // WHY A SEPARATE FILE, AND NOT A FIELD IN THE MANIFEST.
 // The pipeline writes the manifest. If the same pipeline could also write "I

--- a/translation/lib/verified-noops.mjs
+++ b/translation/lib/verified-noops.mjs
@@ -22,7 +22,11 @@
 // writes both halves and the check waves it through. The point of an exception
 // is that somebody else agrees. So the exception lives here, in a file a human
 // edits by hand, and Direction 2 requires the manifest and this file to agree.
-// A pipeline defect cannot add itself to this list.
+//
+// Be exact about the strength of that: no sync pass has any reason to touch this
+// file, so a pipeline defect does not add itself to the list by accident. It is
+// not PREVENTED from doing so — that would take a CODEOWNERS rule, which does not
+// exist yet. This buys a deliberate, reviewable statement, not enforcement.
 //
 // Each line names the EXACT English version it is about, so it expires on its
 // own: when that page's English changes again the hash no longer matches, the
@@ -109,9 +113,17 @@ export function noopAllowed({ entry, baseEntry, listed, currentSourceHash, curre
   // Both sides of the statement must still be true. Pinning the TRANSLATION is
   // what makes a stale line harmless without needing to know whether it is new:
   // if the translation has moved on since a person looked at it, the line stops
-  // describing anything real. That closes the replay — let the source wander away
-  // and later return to a listed value and the translation will have changed in
-  // the meantime — while still letting an approval be granted ahead of time.
+  // describing anything real — while still letting an approval be granted ahead
+  // of time.
+  //
+  // Be exact about what that does and does not rule out. A line grants whenever
+  // the tree matches BOTH hashes again, whenever that happens. If the English
+  // wanders away and comes back, and the translation is also back to the text
+  // that was approved for it, the line applies again — and it should, because the
+  // statement a person made ("this translation is right for that English") is
+  // true of exactly those bytes. What is excluded is the source returning to a
+  // listed value while the translation has moved on, which is the replay that
+  // mattered.
   if (listed.src !== entry.src) return false;
   if (entry.src !== currentSourceHash) return false;
   return listed.translation === currentTranslationHash;

--- a/translation/lib/verified-noops.mjs
+++ b/translation/lib/verified-noops.mjs
@@ -11,9 +11,10 @@
 // now out of date against a change its own translation already contains. A later
 // run re-translates, finds nothing to alter, and the record can never be
 // settled, so the page is offered again in every window, forever, producing
-// nothing. 9dcac0e4 did exactly that to 36 entries on two pages. Later runs
-// happened to produce some other difference on 16 of them, which settled those;
-// the remaining 20 had nothing left to differ and are the lines in
+// nothing. 9dcac0e4 did exactly that to 72 entries across four pages. Two pages
+// later drifted into a run that produced some other difference, which settled
+// them; of the 36 on the two Akash pages, 16 settled the same way and the
+// remaining 20 had nothing left to differ. Those 20 are the lines in
 // translation/verified-noops.txt.
 //
 // WHY A SEPARATE FILE, AND NOT A FIELD IN THE MANIFEST.

--- a/translation/lib/verified-noops.mjs
+++ b/translation/lib/verified-noops.mjs
@@ -50,7 +50,8 @@
 const SHA = /^sha256:[0-9a-f]{64}$/;
 
 /**
- * Parse the allowlist. Returns { entries: Map<"loc/page", sha>, errors: [...] }.
+ * Parse the allowlist. Returns { entries: Map<"loc/page", {src, translation}>,
+ *  errors: [...] }.
  * Errors are formatting problems a human should fix; the caller decides how loud
  * to be about them. Parsing never throws on bad input.
  */

--- a/translation/lib/verified-noops.mjs
+++ b/translation/lib/verified-noops.mjs
@@ -28,7 +28,15 @@
 // become a standing "ignore this page".
 //
 //     # comments and blank lines are allowed
-//     it/guides/Akash_Network_Zcashd.md  sha256:<64 hex>
+//     it/guides/Akash_Network_Zcashd.md  sha256:<english>  sha256:<translation>
+//
+// A line names BOTH sides of what was checked: the English it was verified
+// against, and the translation that was found already correct for it. That is
+// what makes the statement self-contained — and it is what lets a person approve
+// a page BEFORE the automation gets to it, which is the natural order when the
+// pipeline opens its own pull requests. The authorisation holds exactly while the
+// state it describes holds: change either side and it stops applying, because it
+// no longer describes anything that exists.
 //
 // Absent file, or empty, means no exceptions — exactly today's behaviour.
 
@@ -48,13 +56,17 @@ export function parseVerifiedNoops(text) {
     const line = raw.replace(/#.*$/, "").trim();
     if (!line) continue;
     const parts = line.split(/\s+/);
-    if (parts.length !== 2) {
-      errors.push(`line ${i + 1}: expected "<locale>/<page> <sha256:...>", got "${line}"`);
+    if (parts.length !== 3) {
+      errors.push(`line ${i + 1}: expected "<locale>/<page> <english sha256> <translation sha256>", got "${line}"`);
       continue;
     }
-    const [key, sha] = parts;
+    const [key, sha, trans] = parts;
     if (!SHA.test(sha)) {
-      errors.push(`line ${i + 1}: "${sha}" is not a sha256:<64 hex> hash`);
+      errors.push(`line ${i + 1}: english hash "${sha}" is not a sha256:<64 hex> hash`);
+      continue;
+    }
+    if (!SHA.test(trans)) {
+      errors.push(`line ${i + 1}: translation hash "${trans}" is not a sha256:<64 hex> hash`);
       continue;
     }
     if (!key.includes("/") || key.startsWith("/") || key.endsWith("/")) {
@@ -67,7 +79,7 @@ export function parseVerifiedNoops(text) {
       errors.push(`line ${i + 1}: duplicate entry for "${key}"`);
       continue;
     }
-    entries.set(key, sha);
+    entries.set(key, { src: sha, translation: trans });
   }
   return { entries, errors };
 }
@@ -79,19 +91,12 @@ export function parseVerifiedNoops(text) {
  *   - a human listed this exact page,
  *   - against this exact source hash,
  *   - which is genuinely the English on disk right now (not a hash of nothing),
- *   - the line is NEW in this change, so each authorisation is used once,
+ *   - the translation is still exactly the one that was looked at,
  *   - and the page is open to automated sync now AND at base, so nothing that
  *     was being deliberately held can be settled by the same change.
  */
-export function noopAllowed({ entry, baseEntry, listed, listedInBase, currentSourceHash }) {
+export function noopAllowed({ entry, baseEntry, listed, currentSourceHash, currentTranslationHash }) {
   if (!entry || !listed) return false;
-  // SINGLE USE. The authorisation is consumed by the pull request that introduces
-  // it. A line already present in the base has done its work and must never
-  // authorise a second, different transition — otherwise a leftover line is a
-  // standing permit: let the source move away and later return to the listed
-  // value (a revert is enough, no hash collision required) and the old line would
-  // bless a translation made for something else.
-  if (listedInBase === listed) return false;
   // `edited:true` holds a page out of automated sync, so nothing ever re-ran on
   // it. Required BOTH now and at base: otherwise one change can flip the flag to
   // false, bump the source and take the exception in the same breath, settling a
@@ -99,5 +104,13 @@ export function noopAllowed({ entry, baseEntry, listed, listedInBase, currentSou
   if (entry.edited !== false) return false;
   if (baseEntry && baseEntry.edited !== false) return false;
   if (typeof entry.src !== "string") return false;
-  return listed === entry.src && entry.src === currentSourceHash;
+  // Both sides of the statement must still be true. Pinning the TRANSLATION is
+  // what makes a stale line harmless without needing to know whether it is new:
+  // if the translation has moved on since a person looked at it, the line stops
+  // describing anything real. That closes the replay — let the source wander away
+  // and later return to a listed value and the translation will have changed in
+  // the meantime — while still letting an approval be granted ahead of time.
+  if (listed.src !== entry.src) return false;
+  if (entry.src !== currentSourceHash) return false;
+  return listed.translation === currentTranslationHash;
 }

--- a/translation/lib/verified-noops.mjs
+++ b/translation/lib/verified-noops.mjs
@@ -1,0 +1,103 @@
+// The human-authored exception list for Direction 2 of the invariant check.
+//
+// Direction 2 refuses to let a translation's recorded source advance while the
+// translation file stands still, because that is how a stale translation gets
+// marked current. It is the right default and it must stay.
+//
+// But it also traps a real, legitimate case: a translation that is ALREADY
+// correct for the new English. It arises when one commit edits the English and
+// its translations together and records the pass only in `tool`, leaving `src`
+// behind — Direction 1 is satisfied, so nothing complains, but every entry is
+// now out of date against a change its own translation already contains. A later
+// run re-translates, finds nothing to alter, and the record can never be
+// settled, so the page is offered again in every window, forever, producing
+// nothing. 9dcac0e4 did exactly that to 36 entries on two pages; 20 of them are
+// still stuck.
+//
+// WHY A SEPARATE FILE, AND NOT A FIELD IN THE MANIFEST.
+// The pipeline writes the manifest. If the same pipeline could also write "I
+// checked, this one is fine", it would be marking its own homework: one bug
+// writes both halves and the check waves it through. The point of an exception
+// is that somebody else agrees. So the exception lives here, in a file a human
+// edits by hand, and Direction 2 requires the manifest and this file to agree.
+// A pipeline defect cannot add itself to this list.
+//
+// Each line names the EXACT English version it is about, so it expires on its
+// own: when that page's English changes again the hash no longer matches, the
+// line stops applying, and the page returns to normal handling. It can never
+// become a standing "ignore this page".
+//
+//     # comments and blank lines are allowed
+//     it/guides/Akash_Network_Zcashd.md  sha256:<64 hex>
+//
+// Absent file, or empty, means no exceptions — exactly today's behaviour.
+
+const SHA = /^sha256:[0-9a-f]{64}$/;
+
+/**
+ * Parse the allowlist. Returns { entries: Map<"loc/page", sha>, errors: [...] }.
+ * Errors are formatting problems a human should fix; the caller decides how loud
+ * to be about them. Parsing never throws on bad input.
+ */
+export function parseVerifiedNoops(text) {
+  const entries = new Map();
+  const errors = [];
+  const lines = String(text ?? "").split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const line = raw.replace(/#.*$/, "").trim();
+    if (!line) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length !== 2) {
+      errors.push(`line ${i + 1}: expected "<locale>/<page> <sha256:...>", got "${line}"`);
+      continue;
+    }
+    const [key, sha] = parts;
+    if (!SHA.test(sha)) {
+      errors.push(`line ${i + 1}: "${sha}" is not a sha256:<64 hex> hash`);
+      continue;
+    }
+    if (!key.includes("/") || key.startsWith("/") || key.endsWith("/")) {
+      errors.push(`line ${i + 1}: "${key}" is not a <locale>/<page> key`);
+      continue;
+    }
+    if (entries.has(key)) {
+      // Two lines for one page cannot both be current, and silently keeping the
+      // last would make the file's meaning depend on its order.
+      errors.push(`line ${i + 1}: duplicate entry for "${key}"`);
+      continue;
+    }
+    entries.set(key, sha);
+  }
+  return { entries, errors };
+}
+
+/**
+ * May this entry's source advance without its translation changing?
+ *
+ * Every condition must hold at once:
+ *   - a human listed this exact page,
+ *   - against this exact source hash,
+ *   - which is genuinely the English on disk right now (not a hash of nothing),
+ *   - the line is NEW in this change, so each authorisation is used once,
+ *   - and the page is open to automated sync now AND at base, so nothing that
+ *     was being deliberately held can be settled by the same change.
+ */
+export function noopAllowed({ entry, baseEntry, listed, listedInBase, currentSourceHash }) {
+  if (!entry || !listed) return false;
+  // SINGLE USE. The authorisation is consumed by the pull request that introduces
+  // it. A line already present in the base has done its work and must never
+  // authorise a second, different transition — otherwise a leftover line is a
+  // standing permit: let the source move away and later return to the listed
+  // value (a revert is enough, no hash collision required) and the old line would
+  // bless a translation made for something else.
+  if (listedInBase === listed) return false;
+  // `edited:true` holds a page out of automated sync, so nothing ever re-ran on
+  // it. Required BOTH now and at base: otherwise one change can flip the flag to
+  // false, bump the source and take the exception in the same breath, settling a
+  // page that was deliberately being held.
+  if (entry.edited !== false) return false;
+  if (baseEntry && baseEntry.edited !== false) return false;
+  if (typeof entry.src !== "string") return false;
+  return listed === entry.src && entry.src === currentSourceHash;
+}

--- a/translation/lib/verified-noops.test.mjs
+++ b/translation/lib/verified-noops.test.mjs
@@ -2,123 +2,118 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { parseVerifiedNoops, noopAllowed } from "./verified-noops.mjs";
 
-const A = "sha256:" + "a".repeat(64);
-const B = "sha256:" + "b".repeat(64);
+const EN = "sha256:" + "a".repeat(64);
+const EN2 = "sha256:" + "b".repeat(64);
+const TR = "sha256:" + "c".repeat(64);
+const TR2 = "sha256:" + "d".repeat(64);
 const KEY = "it/guides/Akash_Network_Zcashd.md";
-const entry = (x = {}) => ({ src: A, engine: "llm", mode: "diff", tool: "t", edited: false, ...x });
+const entry = (x = {}) => ({ src: EN, engine: "llm", mode: "diff", tool: "t", edited: false, ...x });
+const listed = (x = {}) => ({ src: EN, translation: TR, ...x });
+const allow = (x = {}) => noopAllowed({
+  entry: entry(), listed: listed(), currentSourceHash: EN, currentTranslationHash: TR, ...x,
+});
 
 // ---- parsing --------------------------------------------------------------
 
-test("a plain entry parses", () => {
-  const { entries, errors } = parseVerifiedNoops(`${KEY}  ${A}\n`);
+test("a line names the page, the English, and the translation", () => {
+  const { entries, errors } = parseVerifiedNoops(`${KEY}  ${EN}  ${TR}\n`);
   assert.deepEqual(errors, []);
-  assert.equal(entries.get(KEY), A);
+  assert.deepEqual(entries.get(KEY), { src: EN, translation: TR });
 });
 
 test("comments, blank lines and trailing comments are ignored", () => {
-  const { entries, errors } = parseVerifiedNoops(
-    `# header\n\n${KEY} ${A}   # why this one\n\n`);
+  const { entries, errors } = parseVerifiedNoops(`# header\n\n${KEY} ${EN} ${TR}  # why\n\n`);
   assert.deepEqual(errors, []);
   assert.equal(entries.size, 1);
 });
 
 test("an absent or empty file means no exceptions", () => {
   for (const t of [undefined, null, "", "\n\n# only comments\n"]) {
-    const { entries, errors } = parseVerifiedNoops(t);
-    assert.equal(entries.size, 0);
-    assert.deepEqual(errors, []);
+    assert.equal(parseVerifiedNoops(t).entries.size, 0);
+    assert.deepEqual(parseVerifiedNoops(t).errors, []);
   }
 });
 
-test("a malformed hash is reported, not accepted", () => {
-  const { entries, errors } = parseVerifiedNoops(`${KEY} deadbeef\n`);
+test("a two-token line is refused — the translation half is not optional", () => {
+  // It was two tokens in an earlier design; a stale line must not silently parse.
+  const { entries, errors } = parseVerifiedNoops(`${KEY} ${EN}\n`);
   assert.equal(entries.size, 0);
-  assert.match(errors[0], /not a sha256/);
+  assert.match(errors[0], /expected "<locale>\/<page> <english sha256> <translation sha256>"/);
 });
 
-test("a line missing its hash is reported", () => {
-  const { errors } = parseVerifiedNoops(`${KEY}\n`);
-  assert.match(errors[0], /expected "<locale>\/<page> <sha256/);
+test("each hash is validated, and the message says which one is wrong", () => {
+  assert.match(parseVerifiedNoops(`${KEY} nope ${TR}\n`).errors[0], /english hash/);
+  assert.match(parseVerifiedNoops(`${KEY} ${EN} nope\n`).errors[0], /translation hash/);
 });
 
 test("a duplicate page is refused rather than last-one-wins", () => {
-  // Otherwise the file's meaning would depend on its line order.
-  const { entries, errors } = parseVerifiedNoops(`${KEY} ${A}\n${KEY} ${B}\n`);
-  assert.equal(entries.get(KEY), A);
+  const { entries, errors } = parseVerifiedNoops(`${KEY} ${EN} ${TR}\n${KEY} ${EN2} ${TR2}\n`);
+  assert.deepEqual(entries.get(KEY), { src: EN, translation: TR });
   assert.match(errors[0], /duplicate entry/);
 });
 
-test("the reported line number is the real one, counting comments", () => {
-  const { errors } = parseVerifiedNoops(`# one\n# two\n${KEY} nope\n`);
-  assert.match(errors[0], /^line 3:/);
+test("the reported line number counts comments", () => {
+  assert.match(parseVerifiedNoops(`# one\n# two\n${KEY} bad ${TR}\n`).errors[0], /^line 3:/);
 });
 
 // ---- the decision ---------------------------------------------------------
 
-test("all four conditions together allow the exception", () => {
-  assert.equal(noopAllowed({ entry: entry(), listed: A, currentSourceHash: A }), true);
+test("everything matching allows the exception", () => {
+  assert.equal(allow(), true);
 });
 
-test("an unlisted page is refused — this is the whole point", () => {
-  // A pipeline defect cannot add itself to a human-edited file.
-  assert.equal(noopAllowed({ entry: entry(), listed: undefined, currentSourceHash: A }), false);
+test("an unlisted page is refused — the whole point", () => {
+  assert.equal(noopAllowed({
+    entry: entry(), listed: undefined, currentSourceHash: EN, currentTranslationHash: TR,
+  }), false);
 });
 
-test("a listing for a DIFFERENT source does not apply", () => {
-  // How a line expires: the English moved on, so the human's statement about the
-  // old English no longer says anything about this one.
-  assert.equal(noopAllowed({ entry: entry({ src: B }), listed: A, currentSourceHash: B }), false);
+test("a listing for a different English does not apply", () => {
+  assert.equal(allow({ listed: listed({ src: EN2 }) }), false);
 });
 
-test("a hash that is not the English on disk is refused", () => {
-  // Without this the list could bless a source that never existed in the tree.
-  assert.equal(noopAllowed({ entry: entry(), listed: A, currentSourceHash: B }), false);
+test("an English hash that is not the file on disk is refused", () => {
+  // Otherwise the list could bless a source that never existed in the tree.
+  assert.equal(allow({ currentSourceHash: EN2 }), false);
 });
 
-test("an edited:true page can never take the exception", () => {
-  // `edited:true` holds a page out of automated sync, so no pass re-ran the
-  // engine on it and there is nothing for anyone to have verified.
-  assert.equal(noopAllowed({ entry: entry({ edited: true }), listed: A, currentSourceHash: A }), false);
+test("a TRANSLATION that has moved on since it was looked at is refused", () => {
+  // This is what makes a stale line harmless and closes the replay: let the
+  // source wander away and return, and the translation will have changed in the
+  // meantime, so the line no longer describes anything that exists.
+  assert.equal(allow({ currentTranslationHash: TR2 }), false);
+  assert.equal(allow({ listed: listed({ translation: TR2 }) }), false);
+});
+
+test("a still-current line applies even though it is already on main", () => {
+  // Approve-first: a person may grant the exception BEFORE the automation gets
+  // to the page, which is the natural order when the pipeline opens its own PRs.
+  assert.equal(allow(), true);
+});
+
+test("edited:true can never take the exception, now or at base", () => {
+  assert.equal(allow({ entry: entry({ edited: true }) }), false);
+  assert.equal(noopAllowed({
+    entry: entry(), baseEntry: { edited: true }, listed: listed(),
+    currentSourceHash: EN, currentTranslationHash: TR,
+  }), false);
 });
 
 test("edited must be exactly false, not merely not-true", () => {
   for (const bad of [undefined, null, "false", 0]) {
-    assert.equal(noopAllowed({ entry: entry({ edited: bad }), listed: A, currentSourceHash: A }), false,
-      `edited=${JSON.stringify(bad)} must not qualify`);
+    assert.equal(allow({ entry: entry({ edited: bad }) }), false, `edited=${JSON.stringify(bad)}`);
   }
 });
 
-test("a missing entry or missing src never qualifies", () => {
-  assert.equal(noopAllowed({ entry: null, listed: A, currentSourceHash: A }), false);
-  assert.equal(noopAllowed({ entry: entry({ src: undefined }), listed: A, currentSourceHash: A }), false);
-});
-
-// ---- the two holes round 1 found ------------------------------------------
-
-test("an authorisation is spent by the change that introduces it", () => {
-  // Otherwise a leftover line is a standing permit: let the source move away and
-  // later return to the listed value — a revert is enough, no hash collision
-  // needed — and the old line would bless a translation made for something else.
-  assert.equal(noopAllowed({ entry: entry(), listed: A, listedInBase: A, currentSourceHash: A }), false);
-  assert.equal(noopAllowed({ entry: entry(), listed: A, listedInBase: undefined, currentSourceHash: A }), true);
-  // A line whose hash CHANGED in this PR is a fresh authorisation, not a replay.
-  assert.equal(noopAllowed({ entry: entry(), listed: A, listedInBase: B, currentSourceHash: A }), true);
-});
-
-test("a page held with edited:true at base cannot be settled by the same change", () => {
-  // Flipping the flag to false, bumping the source and taking the exception all
-  // in one change would settle a page that was deliberately being held out of
-  // automated sync, with nothing having re-run on it.
-  assert.equal(noopAllowed({
-    entry: entry({ edited: false }), baseEntry: { edited: true },
-    listed: A, currentSourceHash: A,
-  }), false);
-  assert.equal(noopAllowed({
-    entry: entry({ edited: false }), baseEntry: { edited: false },
-    listed: A, currentSourceHash: A,
-  }), true);
+test("a missing entry, missing src, or absent translation never qualifies", () => {
+  assert.equal(allow({ entry: null }), false);
+  assert.equal(allow({ entry: entry({ src: undefined }) }), false);
+  assert.equal(allow({ currentTranslationHash: null }), false);
 });
 
 test("a page with no base entry is not blocked by the base-edited rule", () => {
-  assert.equal(noopAllowed({ entry: entry(), baseEntry: undefined, listed: A, currentSourceHash: A }), true);
+  assert.equal(noopAllowed({
+    entry: entry(), baseEntry: undefined, listed: listed(),
+    currentSourceHash: EN, currentTranslationHash: TR,
+  }), true);
 });

--- a/translation/lib/verified-noops.test.mjs
+++ b/translation/lib/verified-noops.test.mjs
@@ -117,3 +117,15 @@ test("a page with no base entry is not blocked by the base-edited rule", () => {
     currentSourceHash: EN, currentTranslationHash: TR,
   }), true);
 });
+
+test("a key that is not <locale>/<page> is an error, not a silent entry", () => {
+  // Without this, a garbage key parses fine and simply never matches anything —
+  // an authorisation that looks present and grants nothing, which is the worst
+  // of both. Deleting the check passed every other test.
+  for (const bad of ["justapage.md", "/leading/slash.md", "it/trailing/"]) {
+    const { entries, errors } = parseVerifiedNoops(`${bad}  ${EN}  ${TR}\n`);
+    assert.equal(entries.size, 0, `"${bad}" must not become an entry`);
+    assert.equal(errors.length, 1, `"${bad}" must be reported`);
+    assert.match(errors[0], /is not a <locale>\/<page> key/);
+  }
+});

--- a/translation/lib/verified-noops.test.mjs
+++ b/translation/lib/verified-noops.test.mjs
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseVerifiedNoops, noopAllowed } from "./verified-noops.mjs";
+
+const A = "sha256:" + "a".repeat(64);
+const B = "sha256:" + "b".repeat(64);
+const KEY = "it/guides/Akash_Network_Zcashd.md";
+const entry = (x = {}) => ({ src: A, engine: "llm", mode: "diff", tool: "t", edited: false, ...x });
+
+// ---- parsing --------------------------------------------------------------
+
+test("a plain entry parses", () => {
+  const { entries, errors } = parseVerifiedNoops(`${KEY}  ${A}\n`);
+  assert.deepEqual(errors, []);
+  assert.equal(entries.get(KEY), A);
+});
+
+test("comments, blank lines and trailing comments are ignored", () => {
+  const { entries, errors } = parseVerifiedNoops(
+    `# header\n\n${KEY} ${A}   # why this one\n\n`);
+  assert.deepEqual(errors, []);
+  assert.equal(entries.size, 1);
+});
+
+test("an absent or empty file means no exceptions", () => {
+  for (const t of [undefined, null, "", "\n\n# only comments\n"]) {
+    const { entries, errors } = parseVerifiedNoops(t);
+    assert.equal(entries.size, 0);
+    assert.deepEqual(errors, []);
+  }
+});
+
+test("a malformed hash is reported, not accepted", () => {
+  const { entries, errors } = parseVerifiedNoops(`${KEY} deadbeef\n`);
+  assert.equal(entries.size, 0);
+  assert.match(errors[0], /not a sha256/);
+});
+
+test("a line missing its hash is reported", () => {
+  const { errors } = parseVerifiedNoops(`${KEY}\n`);
+  assert.match(errors[0], /expected "<locale>\/<page> <sha256/);
+});
+
+test("a duplicate page is refused rather than last-one-wins", () => {
+  // Otherwise the file's meaning would depend on its line order.
+  const { entries, errors } = parseVerifiedNoops(`${KEY} ${A}\n${KEY} ${B}\n`);
+  assert.equal(entries.get(KEY), A);
+  assert.match(errors[0], /duplicate entry/);
+});
+
+test("the reported line number is the real one, counting comments", () => {
+  const { errors } = parseVerifiedNoops(`# one\n# two\n${KEY} nope\n`);
+  assert.match(errors[0], /^line 3:/);
+});
+
+// ---- the decision ---------------------------------------------------------
+
+test("all four conditions together allow the exception", () => {
+  assert.equal(noopAllowed({ entry: entry(), listed: A, currentSourceHash: A }), true);
+});
+
+test("an unlisted page is refused — this is the whole point", () => {
+  // A pipeline defect cannot add itself to a human-edited file.
+  assert.equal(noopAllowed({ entry: entry(), listed: undefined, currentSourceHash: A }), false);
+});
+
+test("a listing for a DIFFERENT source does not apply", () => {
+  // How a line expires: the English moved on, so the human's statement about the
+  // old English no longer says anything about this one.
+  assert.equal(noopAllowed({ entry: entry({ src: B }), listed: A, currentSourceHash: B }), false);
+});
+
+test("a hash that is not the English on disk is refused", () => {
+  // Without this the list could bless a source that never existed in the tree.
+  assert.equal(noopAllowed({ entry: entry(), listed: A, currentSourceHash: B }), false);
+});
+
+test("an edited:true page can never take the exception", () => {
+  // `edited:true` holds a page out of automated sync, so no pass re-ran the
+  // engine on it and there is nothing for anyone to have verified.
+  assert.equal(noopAllowed({ entry: entry({ edited: true }), listed: A, currentSourceHash: A }), false);
+});
+
+test("edited must be exactly false, not merely not-true", () => {
+  for (const bad of [undefined, null, "false", 0]) {
+    assert.equal(noopAllowed({ entry: entry({ edited: bad }), listed: A, currentSourceHash: A }), false,
+      `edited=${JSON.stringify(bad)} must not qualify`);
+  }
+});
+
+test("a missing entry or missing src never qualifies", () => {
+  assert.equal(noopAllowed({ entry: null, listed: A, currentSourceHash: A }), false);
+  assert.equal(noopAllowed({ entry: entry({ src: undefined }), listed: A, currentSourceHash: A }), false);
+});
+
+// ---- the two holes round 1 found ------------------------------------------
+
+test("an authorisation is spent by the change that introduces it", () => {
+  // Otherwise a leftover line is a standing permit: let the source move away and
+  // later return to the listed value — a revert is enough, no hash collision
+  // needed — and the old line would bless a translation made for something else.
+  assert.equal(noopAllowed({ entry: entry(), listed: A, listedInBase: A, currentSourceHash: A }), false);
+  assert.equal(noopAllowed({ entry: entry(), listed: A, listedInBase: undefined, currentSourceHash: A }), true);
+  // A line whose hash CHANGED in this PR is a fresh authorisation, not a replay.
+  assert.equal(noopAllowed({ entry: entry(), listed: A, listedInBase: B, currentSourceHash: A }), true);
+});
+
+test("a page held with edited:true at base cannot be settled by the same change", () => {
+  // Flipping the flag to false, bumping the source and taking the exception all
+  // in one change would settle a page that was deliberately being held out of
+  // automated sync, with nothing having re-run on it.
+  assert.equal(noopAllowed({
+    entry: entry({ edited: false }), baseEntry: { edited: true },
+    listed: A, currentSourceHash: A,
+  }), false);
+  assert.equal(noopAllowed({
+    entry: entry({ edited: false }), baseEntry: { edited: false },
+    listed: A, currentSourceHash: A,
+  }), true);
+});
+
+test("a page with no base entry is not blocked by the base-edited rule", () => {
+  assert.equal(noopAllowed({ entry: entry(), baseEntry: undefined, listed: A, currentSourceHash: A }), true);
+});

--- a/translation/sync-state.json
+++ b/translation/sync-state.json
@@ -2995,16 +2995,16 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -4669,16 +4669,16 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -8017,16 +8017,16 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -9691,8 +9691,8 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -14713,16 +14713,16 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -16395,8 +16395,8 @@
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "qwen3-14b+dedupe-linkrepair",
@@ -18061,16 +18061,16 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "qwen3-14b+dedupe-linkrepair",
@@ -19735,16 +19735,16 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -21409,16 +21409,16 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -24757,16 +24757,16 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -26431,8 +26431,8 @@
       "edited": false
     },
     "guides/Akash_Network_Zcashd.md": {
-      "src": "sha256:f178e31448be3990d9fb6673450e836e199a1c0af8db6c4ce279b7c75cb0c471",
-      "src_commit": "0490cf0b5afc8f45220d1f6f1311490740252e30",
+      "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -29787,8 +29787,8 @@
       "edited": false
     },
     "guides/Akash_Network_Zebra.md": {
-      "src": "sha256:cba5beca1af06924063990104ac39529317d5c21ecfc7e00678a22d75aa40d96",
-      "src_commit": "fd4274d9da6248ee64200935954158b1df671b46",
+      "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
+      "src_commit": "9dcac0e4",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",

--- a/translation/sync-state.json
+++ b/translation/sync-state.json
@@ -2996,7 +2996,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -3004,7 +3004,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -4670,7 +4670,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -4678,7 +4678,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -8018,7 +8018,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -8026,7 +8026,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -9692,7 +9692,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -14714,7 +14714,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -14722,7 +14722,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -16396,7 +16396,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "qwen3-14b+dedupe-linkrepair",
@@ -18062,7 +18062,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -18070,7 +18070,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "qwen3-14b+dedupe-linkrepair",
@@ -19736,7 +19736,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -19744,7 +19744,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -21410,7 +21410,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -21418,7 +21418,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -24758,7 +24758,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -24766,7 +24766,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",
@@ -26432,7 +26432,7 @@
     },
     "guides/Akash_Network_Zcashd.md": {
       "src": "sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "full",
       "tool": "codex/gpt-5.4+dedupe-linkrepair",
@@ -29788,7 +29788,7 @@
     },
     "guides/Akash_Network_Zebra.md": {
       "src": "sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809",
-      "src_commit": "9dcac0e4",
+      "src_commit": "9dcac0e4acbfdd3c1c63aaf40c8cd062d2f30d86",
       "engine": "llm",
       "mode": "seed",
       "tool": "gpt-5.4+dedupe-linkrepair",

--- a/translation/verified-noops.txt
+++ b/translation/verified-noops.txt
@@ -36,22 +36,28 @@
 # HOW TO ADD A LINE
 #   <locale>/<page>  sha256:<the English>  sha256:<the translation you checked>
 # Two hashes, and both of them matter. The first says which English version you
-# read. The second pins the translated file you looked at. The check prints the
-# whole line for you when it refuses a page, so you can copy it verbatim. Add one
-# only when you have read the committed translation and are satisfied it really
-# is correct for that English.
+# read. The second pins the translated file you looked at. Add one only when you
+# have read the committed translation and are satisfied it really is correct for
+# that English.
+#
+# Where an exception is the right answer, the refusal prints the exact line to
+# add and you can copy it. Where it is NOT the right answer the refusal says so
+# instead, and offers no line — because the page has no translation file to name,
+# because its path contains whitespace or "#" and cannot be written here at all,
+# or because the manifest records a src that is not the English on disk, which no
+# line can bridge. A printed line is therefore a signal in itself: getting one
+# means an exception can actually settle this page.
 #
 # "Pins" means the same thing here as everywhere else in this pipeline: both
 # hashes are taken after stripping a leading byte-order mark and normalising line
 # endings, trailing blank lines, stray end-of-line spaces and tabs, volatile
-# front matter, and Unicode to NFC. (A
-# Markdown hard break — two or more trailing spaces — is deliberately NOT
-# normalised away, because losing one changes how the page renders.) So two
-# canonically-equivalent spellings of the same text are one file as far as this
-# gate is concerned. That is deliberate and
-# it should stay that way — hashing raw bytes here while the rest of the pipeline
-# hashes normalised text would let a page count as "changed" for the exception
-# and "unchanged" for the translator at the same moment, which is precisely the
+# front matter, and Unicode to NFC. (A Markdown hard break — two or more trailing
+# spaces — is deliberately NOT normalised away, because losing one changes how
+# the page renders.) So two canonically-equivalent spellings of the same text are
+# one file as far as this gate is concerned. That is deliberate and it should
+# stay that way: hashing raw bytes here while the rest of the pipeline hashes
+# normalised text would let a page count as "changed" for the exception and
+# "unchanged" for the translator at the same moment, which is precisely the
 # unsettleable state this file exists to get out of.
 #
 # A LINE GRANTS NOTHING ON ITS OWN

--- a/translation/verified-noops.txt
+++ b/translation/verified-noops.txt
@@ -76,8 +76,12 @@
 # HOW A LINE GOES AWAY
 # Nothing deletes lines automatically, and nothing needs to: an entry that no
 # longer matches the files grants nothing. The check prints a `note:` for lines
-# that have stopped matching, so you can tidy at your convenience. Those notes
-# never fail the check — housekeeping should not turn a build red.
+# that have stopped matching, and those notes never fail the check — housekeeping
+# should not turn a build red.
+#
+# One case is not optional, though. If a page needs an exception AGAIN and a dead
+# line for it is still here, REPLACE that line: two lines for the same key is a
+# duplicate and fails the check. The refusal says so when it applies.
 #
 # ---------------------------------------------------------------------------
 # The entries below, and how they got stuck — worth reading, because the same

--- a/translation/verified-noops.txt
+++ b/translation/verified-noops.txt
@@ -42,8 +42,9 @@
 # is correct for that English.
 #
 # "Pins" means the same thing here as everywhere else in this pipeline: both
-# hashes are taken after normalising line endings, trailing blank lines, stray
-# end-of-line spaces and tabs, volatile front matter, and Unicode to NFC. (A
+# hashes are taken after stripping a leading byte-order mark and normalising line
+# endings, trailing blank lines, stray end-of-line spaces and tabs, volatile
+# front matter, and Unicode to NFC. (A
 # Markdown hard break — two or more trailing spaces — is deliberately NOT
 # normalised away, because losing one changes how the page renders.) So two
 # canonically-equivalent spellings of the same text are one file as far as this
@@ -85,11 +86,17 @@
 # translations.
 #
 # It recorded that pass by changing `tool` on every entry, which satisfies the
-# "a changed translation must record why" rule, but it never advanced `src`. So
-# all 36 became out of date against an English change their own translations
-# already contained. 16 were settled by later sync runs that happened to produce
-# some other difference; these 20 had nothing left to differ, so they could never
-# be settled and were re-offered in every run.
+# "a changed translation must record why" rule, but it never advanced `src`.
+#
+# Note the size of that, because the shape is the point and it is easy to
+# understate. The commit did this to 72 entries across FOUR pages — 18 locales
+# each of Akash_Network_Zcashd, Akash_Network_Zebra, FROST_Threshold_Custody and
+# multisigdemo/MultiSigDemo — all of which became out of date against an English
+# change their own translations already contained. Two of those pages drifted
+# into a later sync run that produced some other difference, which settled them.
+# Of the 36 on the two Akash pages, 16 settled the same way; these 20 had nothing
+# left to differ, so they could never be settled and were re-offered in every
+# run.
 #
 # The cheap prevention is upstream: a change that edits translations to match an
 # English edit should advance `src` in the same commit, not only `tool`.

--- a/translation/verified-noops.txt
+++ b/translation/verified-noops.txt
@@ -17,9 +17,21 @@
 # WHY THE EXCEPTION LIVES HERE, AND NOT IN THE MANIFEST
 # The automation writes the manifest. If it could also write "I checked, this one
 # is fine", it would be marking its own homework: a single fault writes the claim
-# and the thing it claims about, and the check waves both through. This file is
-# edited BY HAND, and the automation cannot write it — so granting the exception
-# takes two parties who agree.
+# and the thing it claims about, and the check waves both through. Nothing in the
+# pipeline writes this file — it is edited by hand, so the claim and the thing it
+# claims about come from different places.
+#
+# Be precise about how far that goes, because the file used to overstate it.
+# Nothing PREVENTS the automation's credential from editing this file; there is
+# no CODEOWNERS rule on it yet, and adding one is the thing that would turn this
+# from a convention into a control. Nor does the check compare the list against
+# its previous version, so a single commit can add a line and take the exception
+# it grants in the same breath — the integration suite asserts exactly that,
+# because it is what makes an authorisation usable before the run it authorises.
+# What the file buys today is that the exception is a deliberate, reviewable,
+# hand-written statement that a person can be asked about, sitting somewhere no
+# automated pass has any reason to touch. That is worth having and it is not the
+# same thing as enforcement.
 #
 # HOW TO ADD A LINE
 #   <locale>/<page>  sha256:<the English it is about>  sha256:<the translation you checked>
@@ -30,8 +42,10 @@
 # is correct for that English.
 #
 # "Pins" means the same thing here as everywhere else in this pipeline: both
-# hashes are taken after normalising line endings, trailing whitespace, volatile
-# front matter and Unicode to NFC. So two canonically-equivalent spellings of the
+# hashes are taken after normalising line endings, trailing blank lines, stray
+# end-of-line spaces and tabs, volatile front matter, and Unicode to NFC. (A
+# Markdown hard break — two or more trailing spaces — is deliberately NOT
+# normalised away, because losing one changes how the page renders.) So two canonically-equivalent spellings of the
 # same text are one file as far as this gate is concerned. That is deliberate and
 # it should stay that way — hashing raw bytes here while the rest of the pipeline
 # hashes normalised text would let a page count as "changed" for the exception
@@ -60,9 +74,15 @@
 # The entries below, and how they got stuck — worth reading, because the same
 # shape will recur:
 #
-# Commit 9dcac0e4 (2026-09-01) moved two pages to new routes and, in the same
-# commit, rewrote the English AND all 36 translations to the new link. It
-# recorded that pass by changing `tool` on every entry, which satisfies the
+# Commit 9dcac0e4 (2026-09-01) deduplicated two pages that existed under two
+# routes each, deleting Using_Zcash/Blockchain_Explorers.md and
+# guides/frostdemo/Ywallet_FROST_Demo.md. The stuck pages are NOT those two.
+# They are guides/Akash_Network_Zcashd.md and guides/Akash_Network_Zebra.md,
+# which that same commit merely repointed at the surviving routes — one line
+# changed in each English page, and the matching line changed in all 36 of their
+# translations.
+#
+# It recorded that pass by changing `tool` on every entry, which satisfies the
 # "a changed translation must record why" rule, but it never advanced `src`. So
 # all 36 became out of date against an English change their own translations
 # already contained. 16 were settled by later sync runs that happened to produce

--- a/translation/verified-noops.txt
+++ b/translation/verified-noops.txt
@@ -34,7 +34,7 @@
 # same thing as enforcement.
 #
 # HOW TO ADD A LINE
-#   <locale>/<page>  sha256:<the English it is about>  sha256:<the translation you checked>
+#   <locale>/<page>  sha256:<the English>  sha256:<the translation you checked>
 # Two hashes, and both of them matter. The first says which English version you
 # read. The second pins the translated file you looked at. The check prints the
 # whole line for you when it refuses a page, so you can copy it verbatim. Add one
@@ -45,8 +45,9 @@
 # hashes are taken after normalising line endings, trailing blank lines, stray
 # end-of-line spaces and tabs, volatile front matter, and Unicode to NFC. (A
 # Markdown hard break — two or more trailing spaces — is deliberately NOT
-# normalised away, because losing one changes how the page renders.) So two canonically-equivalent spellings of the
-# same text are one file as far as this gate is concerned. That is deliberate and
+# normalised away, because losing one changes how the page renders.) So two
+# canonically-equivalent spellings of the same text are one file as far as this
+# gate is concerned. That is deliberate and
 # it should stay that way — hashing raw bytes here while the rest of the pipeline
 # hashes normalised text would let a page count as "changed" for the exception
 # and "unchanged" for the translator at the same moment, which is precisely the
@@ -59,10 +60,11 @@
 # has moved on is inert — it cannot mature into "ignore this page forever", which
 # is the failure this file exists to avoid.
 #
-# That is also why the order of the commits does not matter. You can add the line
-# before the automation settles the page or after it: the check compares the line
-# against what is actually on disk, never against what an earlier version of this
-# file used to say.
+# That is also why the check never asks WHEN the line was written. The approval
+# may land before the bump or arrive alongside it; what is checked is the state
+# of the tree under review. Note what that does not say: a bump submitted on its
+# own, without the approval present, is still refused. "Either order" is about
+# authoring, not about landing a bump unapproved and legitimising it later.
 #
 # HOW A LINE GOES AWAY
 # Nothing deletes lines automatically, and nothing needs to: an entry that no

--- a/translation/verified-noops.txt
+++ b/translation/verified-noops.txt
@@ -22,23 +22,39 @@
 # takes two parties who agree.
 #
 # HOW TO ADD A LINE
-#   <locale>/<page>  <the sha256 of the English it is about>
-# The check prints the exact line to add when it refuses a page, so you can copy
-# it. Add one only when you have looked and are satisfied the committed
-# translation really is correct for that English.
+#   <locale>/<page>  sha256:<the English it is about>  sha256:<the translation you checked>
+# Two hashes, and both of them matter. The first says which English version you
+# read. The second pins the translated file you looked at. The check prints the
+# whole line for you when it refuses a page, so you can copy it verbatim. Add one
+# only when you have read the committed translation and are satisfied it really
+# is correct for that English.
 #
-# A LINE IS USED ONCE
-# An authorisation is spent by the pull request that introduces it. Once a line is
-# on main it no longer grants anything, so a forgotten line cannot become a
-# standing permit — if that page later needs the exception again, it needs a new
-# line naming the new English.
+# "Pins" means the same thing here as everywhere else in this pipeline: both
+# hashes are taken after normalising line endings, trailing whitespace, volatile
+# front matter and Unicode to NFC. So two canonically-equivalent spellings of the
+# same text are one file as far as this gate is concerned. That is deliberate and
+# it should stay that way — hashing raw bytes here while the rest of the pipeline
+# hashes normalised text would let a page count as "changed" for the exception
+# and "unchanged" for the translator at the same moment, which is precisely the
+# unsettleable state this file exists to get out of.
+#
+# A LINE GRANTS NOTHING ON ITS OWN
+# Because a line names both sides, it stops granting the moment either side
+# moves. Change the English and the first hash no longer matches; change the
+# translation and the second no longer does. A line left behind after the page
+# has moved on is inert — it cannot mature into "ignore this page forever", which
+# is the failure this file exists to avoid.
+#
+# That is also why the order of the commits does not matter. You can add the line
+# before the automation settles the page or after it: the check compares the line
+# against what is actually on disk, never against what an earlier version of this
+# file used to say.
 #
 # HOW A LINE GOES AWAY
-# Nothing deletes lines automatically, and nothing needs to: they are inert once
-# merged, and each names the exact English version it was about. The check prints
-# a `note:` when a line has expired or has been spent, so you can tidy at your
-# convenience. Those notes never fail the check — housekeeping should not turn a
-# build red.
+# Nothing deletes lines automatically, and nothing needs to: an entry that no
+# longer matches the files grants nothing. The check prints a `note:` for lines
+# that have stopped matching, so you can tidy at your convenience. Those notes
+# never fail the check — housekeeping should not turn a build red.
 #
 # ---------------------------------------------------------------------------
 # The entries below, and how they got stuck — worth reading, because the same
@@ -56,23 +72,23 @@
 # The cheap prevention is upstream: a change that edits translations to match an
 # English edit should advance `src` in the same commit, not only `tool`.
 
-ar/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-de/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-es/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-fr/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-it/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-ko/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-pt/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-ru/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-tr/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-uk/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
-ar/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-de/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-es/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-it/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-ja/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-ko/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-pt/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-ru/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-tr/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
-zh/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+ar/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:793454a46bbc939c86f24065776ec4f4b0f61bf23ecbdac9ceb49f848e57c383
+de/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:333b5c475189088b067e66c9eb559e8689f8b2d38cbe60e20769fb912386f33e
+es/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:b1007b1186b68de4e5f893687fa3ba077e58d02045816139e3ff2a2815fc5185
+fr/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:2c763c2a6c46239e5d32224bb03575966e7f0861f394691c75070bfbdac1d6e6
+it/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:3f6cb43847a2a2179d0d2821f234eaba43752e2f0e56d516c6fdbd7bd32205b6
+ko/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:7b21589be81f8487a8376d954394aa5a38e7fb1e86106c265f40a4d2664b48a2
+pt/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:bcdcea4497fdb7d95d00155d7e9c468be08545de16e7bf666b1d2e6daaf8f603
+ru/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:f7708cc437f48499f00c2adf7ed849903ab045ceed7a86737a1854d31bd046ef
+tr/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:6de2d5e7fae72094411eb7a2c14fe0b4917045b878a8d74b1e176a0ebc89133a
+uk/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c  sha256:7d5748dafb7b949ed681c1e9e81b2c952df3a18d64ac8329a4d00bb1a6c42a01
+ar/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:9da0b24e88665c9772865c95cedf5fea09adce46e2662037e4835fbaca6f08b5
+de/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:ea2e08453200b213fdda895e4c97a526b4af3a6bbe685e3590c1b8359a5b724f
+es/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:5f29bf5f56a692e0bf4def64ac4fc4b7ecac44a6e81897073ce17cb7bb316288
+it/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:c9ca8937aa9a6e1d41bf22d6c82c70e6b2ab19f168ada3aef06121af9682fa34
+ja/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:5c41f89f51a4b884c27d1c4cb7231f986d1a30ebe2cde7b22f511c196f77d88a
+ko/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:a404d7cfb7f6acffe22c73f8133c54153fe6250f2d4516c65a4f5e5df3ab9652
+pt/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:4755c792c1fe7f79dd14df2a49582e1a444109e18b04329e195cf9a79375cb3c
+ru/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:a6581f70f472ffd9762523ada250c0b551f1f771f6817a3ab80558c7b52bbe75
+tr/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:ef91971ac3ef3b9469aa7a4623cf6fd32a386f8c848e45c5e98e87283caa0632
+zh/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809  sha256:0a3f50d5a902f52cef782599b093dd97d2186387f3c252e8524cf57a9f785cc8

--- a/translation/verified-noops.txt
+++ b/translation/verified-noops.txt
@@ -1,0 +1,78 @@
+# Verified no-ops — the one exception to "a record may not move on its own"
+#
+# WHAT THIS FILE IS
+# Every translated page carries a record of which English text it was made from.
+# When that English changes, the page is out of date and gets re-translated, and
+# the record moves with it. The invariant check refuses to let a record move
+# while the translation file itself stands still, because that is exactly how an
+# out-of-date translation would get marked current without anyone noticing.
+#
+# WHY AN EXCEPTION IS NEEDED AT ALL
+# Sometimes a translation is ALREADY correct for the new English — usually
+# because an earlier maintenance pass fixed the same thing in the translation
+# but did not update its record. The engine then re-translates, returns a file
+# identical to the last byte, and the record can never be settled. The page is
+# offered again in every run, forever, producing nothing each time.
+#
+# WHY THE EXCEPTION LIVES HERE, AND NOT IN THE MANIFEST
+# The automation writes the manifest. If it could also write "I checked, this one
+# is fine", it would be marking its own homework: a single fault writes the claim
+# and the thing it claims about, and the check waves both through. This file is
+# edited BY HAND, and the automation cannot write it — so granting the exception
+# takes two parties who agree.
+#
+# HOW TO ADD A LINE
+#   <locale>/<page>  <the sha256 of the English it is about>
+# The check prints the exact line to add when it refuses a page, so you can copy
+# it. Add one only when you have looked and are satisfied the committed
+# translation really is correct for that English.
+#
+# A LINE IS USED ONCE
+# An authorisation is spent by the pull request that introduces it. Once a line is
+# on main it no longer grants anything, so a forgotten line cannot become a
+# standing permit — if that page later needs the exception again, it needs a new
+# line naming the new English.
+#
+# HOW A LINE GOES AWAY
+# Nothing deletes lines automatically, and nothing needs to: they are inert once
+# merged, and each names the exact English version it was about. The check prints
+# a `note:` when a line has expired or has been spent, so you can tidy at your
+# convenience. Those notes never fail the check — housekeeping should not turn a
+# build red.
+#
+# ---------------------------------------------------------------------------
+# The entries below, and how they got stuck — worth reading, because the same
+# shape will recur:
+#
+# Commit 9dcac0e4 (2026-09-01) moved two pages to new routes and, in the same
+# commit, rewrote the English AND all 36 translations to the new link. It
+# recorded that pass by changing `tool` on every entry, which satisfies the
+# "a changed translation must record why" rule, but it never advanced `src`. So
+# all 36 became out of date against an English change their own translations
+# already contained. 16 were settled by later sync runs that happened to produce
+# some other difference; these 20 had nothing left to differ, so they could never
+# be settled and were re-offered in every run.
+#
+# The cheap prevention is upstream: a change that edits translations to match an
+# English edit should advance `src` in the same commit, not only `tool`.
+
+ar/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+de/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+es/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+fr/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+it/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+ko/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+pt/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+ru/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+tr/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+uk/guides/Akash_Network_Zcashd.md  sha256:d425b917d3958a079d4cdf5f63aeb68c73d2eec58fa7c23c08639c249f065f1c
+ar/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+de/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+es/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+it/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+ja/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+ko/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+pt/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+ru/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+tr/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809
+zh/guides/Akash_Network_Zebra.md  sha256:ec1a4f782c1adbb5696d7b867c6135c93193f334d9bfe92947b0dc268cab9809


### PR DESCRIPTION
Twenty pages are stuck: their translations are already correct for the current English, but
their records still point at the old English, so every sync window re-translates them, gets
byte-identical output, and can never settle them. Commit `9dcac0e4` caused it by fixing a
link in the English and in all its translations while recording only `tool`, never advancing
`src`. It did that to 72 entries across four pages; two pages drifted into later runs that
happened to produce some other difference, and these 20 had nothing left to differ.

A queue that cannot reach zero is not a queue that can be automated, so the gate needs a way
to say "this one is genuinely already correct". The pipeline cannot be the one to say it —
it writes the manifest, so letting it also certify the manifest means one defect writes both
halves.

## What this adds

`translation/verified-noops.txt`, hand-edited, one line per authorisation:

```
<locale>/<page>  sha256:<the English>  sha256:<the translation>
```

A line grants the Direction-2 exception only while the manifest, the English on disk and the
translation on disk all still match it, and only for a page that is not held `edited:true`.
Because it names both sides, it stops granting the moment either moves — it cannot mature
into "ignore this page forever". Delete the file and the repo returns to today's behaviour:
exactly 20 refusals.

## What else changed

Hardening the gate that the exception relies on. Each of these was a way to mark a stale
translation current with no authorisation, and each has a test that fails when its fix is
reverted:

- a change invisible to the pipeline's own notion of "changed" — trailing blank lines, CRLF
- a file mode change, including on a path marked `-diff`
- a symlink to an identical copy, in the tree or already at the base
- a directory at the page's path
- a page rename, and a locale rename (`translations/it` → `translations/it-IT`)
- a copy whose predecessor is identified ambiguously

Plus: unreadable files, failed git listings and malformed manifests are now findings rather
than crashes that discard the report; refusals no longer print remedies the check would
reject; and both `git ls-files` listings are NUL-separated, since a C-quoted non-ASCII path
left the corpus unseen.

## Known limits, documented rather than implied

- **Transitions only.** A `(locale, page)` with no record at the base is a first appearance,
  and its `src` claim has nothing to be checked against.
- **"Changed" means the normalised text differs.** That is not the same as "a reader would
  see it": an HTML comment or a zero-width character counts as a change.
- **The working tree is taken to be the text.** No `.gitattributes` filter is applied when
  hashing. None in this repo reaches `site/` or `translations/`.

Reasoning and measurements: [requirements](https://github.com/bloxster/zcashinside-strategy/blob/main/zechub/translation-gate-requirements.md).

## Checks

171 tests (`node --test translation/lib/*.test.mjs`), 169 on Node 20 where two permission
tests skip. Replayed against 45 real merged commits with no change in verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
