### PR TITLE
Fix Cloudflare Tunnel install step in BTCPay Server Zcash guide

### DIFF
--- a/site/guides/BTCPayServer_Zcash_Plugin.md
+++ b/site/guides/BTCPayServer_Zcash_Plugin.md
@@ -479,8 +479,14 @@ It also helps you **avoid the cost of renting a VPS**, which is ideal if cryptoc
 2. On your **home server**, install Cloudflare Tunnel:
 
 ```
+# Add Cloudflare's official package repo and GPG key, then install cloudflared
+# (cloudflared is not in Debian/Raspberry Pi OS default repos, and apt has no --legacy option)
+sudo mkdir -p --mode=0755 /usr/share/keyrings
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared bookworm main' \
+  | sudo tee /etc/apt/sources.list.d/cloudflared.list
 sudo apt update
-sudo apt install cloudflared --legacy
+sudo apt install cloudflared
 ```
 
 3. Authenticate with Cloudflare:


### PR DESCRIPTION
@ZecHub/bounties #cmtunbvy9008cc - applying via UI is currently broken ("Failed to submit application", see ZecHub/zec-bounties#225). Please consider this PR as the submission.

## Fix
`site/guides/BTCPayServer_Zcash_Plugin.md` told readers to run `sudo apt install cloudflared --legacy` for the Cloudflare Tunnel step. That command fails twice: apt has no `--legacy` option, and cloudflared is not in the default Debian/Raspberry Pi OS package repos.

## Change
Replaces the broken block with Cloudflare's documented `pkg.cloudflare.com` install: add the GPG key and repo, then `sudo apt install cloudflared`. The repo serves arm64 builds, so this works on the Raspberry Pi target this guide is written for, and it survives `apt upgrade` (unlike a one-off .deb download).
