### PR TITLE
docs: repair four reference 404 links across Crosslink, FROST demo, Mining Pools, and Start Here

### DIFF
--- a/site/Start_Here/What_is_ZEC_and_Zcash.md
+++ b/site/Start_Here/What_is_ZEC_and_Zcash.md
@@ -52,7 +52,7 @@ Zcash solves Bitcoin's biggest flaw; private ownership and transfer of data. In 
 
 [How It Works](https://z.cash/technology/)
 
-[The HTTPS of Blockchains](https://nakamoto.com/zcash-the-https-of-blockchains/)
+[The HTTPS of Blockchains](https://web.archive.org/web/20230325022830/https://nakamoto.com/zcash-the-https-of-blockchains/)
 
 ---
 

--- a/site/Using_Zcash/Zcash_Mining_Pools.md
+++ b/site/Using_Zcash/Zcash_Mining_Pools.md
@@ -62,13 +62,13 @@ Zcash mining pools are services that allow individual miners to combine their co
 
 ---
 
-### [Nanopool](https://zec.nanopool.org/login)
+### [Nanopool](https://zec.nanopool.org)
 
-<a href="https://zec.nanopool.org/login">
+<a href="https://zec.nanopool.org">
     <img src="https://github.com/gorgagian123/Exchanges-Logo/blob/main/Nanopool.jpg?raw=true" alt="Nanopool Logo" width="200" height="100"/>
 </a>
 
-- Website: [Nanopool](https://zec.nanopool.org/login)
+- Website: [Nanopool](https://zec.nanopool.org)
 - Private Payouts: No
 - Pool Type: Pay Per Last N 
 - Pool fee: 1%

--- a/site/Zcash_Tech/Crosslink_Protocol.md
+++ b/site/Zcash_Tech/Crosslink_Protocol.md
@@ -90,7 +90,7 @@ The Crosslink Protocol is being actively developed and deployed by Shielded Labs
 * Activation Logic: The introduction of Crosslink requires changes to the Zcash consensus rules, including defining the stake distribution process and updating network protocol rules to support hybrid consensus.
 * Phased Deployment: The protocol will roll out in stages to ensure network stability and community adaptation. Initial phases focus on technical implementation, followed by governance integration for selecting notaries.
 
-You can explore the technical details and track its progress via the [Crosslink Deployment Repository on GitHub](https://github.com/ShieldedLabs/crosslink-deployment).
+You can explore the technical details and track its progress via the [Crosslink Monorepo on GitHub](https://github.com/ShieldedLabs/crosslink_monolith).
 
 ## Practical Implications
 

--- a/site/guides/Ywallet_FROST_Demo.md
+++ b/site/guides/Ywallet_FROST_Demo.md
@@ -16,7 +16,7 @@
 
 ## Compile FROST bins
 
-[Github link](https://github.com/ZcashFoundation/frost-zcash-demo/tree/update-zcash-sign)
+[Github link](https://github.com/ZcashFoundation/frost-tools)
 
 Use the above repo and follow directions on compiling: 
 


### PR DESCRIPTION
Resolves ZecHub Bounty ID: `cmtvev69r008zcvacuy5ztphj` ("Four reference links 404 across the Crosslink, FROST, mining and Start Here pages")

@ZecHub/bounties cmtvev69r008zcvacuy5ztphj – submission for bounty.

### Summary of Changes
1. **Crosslink Protocol:**
   - `site/Zcash_Tech/Crosslink_Protocol.md`: Updated dead link `github.com/ShieldedLabs/crosslink-deployment` (404) to Shielded Labs's active crosslink repository `github.com/ShieldedLabs/crosslink_monolith`.
2. **Ywallet FROST Demo:**
   - `site/guides/Ywallet_FROST_Demo.md`: Updated obsolete pointer to defunct branch `ZcashFoundation/frost-zcash-demo/tree/update-zcash-sign` to the canonical repository and default branch `ZcashFoundation/frost-tools`.
3. **Zcash Mining Pools:**
   - `site/Using_Zcash/Zcash_Mining_Pools.md`: Dropped dead `/login` subpaths from Nanopool links (which 404ed) to point directly to live pool home `https://zec.nanopool.org` (returning 200).
4. **What is ZEC and Zcash:**
   - `site/Start_Here/What_is_ZEC_and_Zcash.md`: Repointed dead Nakamoto article link (which 404s on live domain) to its Wayback Machine snapshot so the historical "The HTTPS of Blockchains" reference remains accessible.