### PR TITLE
docs(guides): update Zenith zcash-haskell clone URL to code.vergara.tech

### DIFF
--- a/site/guides/Zenith_Installation.md
+++ b/site/guides/Zenith_Installation.md
@@ -70,7 +70,7 @@ enable_cookie_auth = false
 
 > rmdir zcash-haskell
 
-> git clone https://git.vergara.tech/Vergara_Tech/zcash-haskell.git
+> git clone https://code.vergara.tech/Vergara_Tech/zcash-haskell.git
 
 
 ### Install Depedencies


### PR DESCRIPTION
### Summary

Resolves ZecHub Bounty `cmtum9pi90088cvachwivjkl6` (0.09 ZEC): *"Zenith wallet install guide clones from the retired git.vergara.tech host, so the build fails"*.
Tag: @ZecHub/bounties cmtum9pi90088cvachwivjkl6

### Changes Made

- In `site/guides/Zenith_Installation.md` line 73, updated `git clone https://git.vergara.tech/Vergara_Tech/zcash-haskell.git` to `git clone https://code.vergara.tech/Vergara_Tech/zcash-haskell.git`.
- `git.vergara.tech` rejects TLS handshakes, whereas `code.vergara.tech` is the active live git host.