### PR TITLE
docs: retire obsolete Dework links and correct ZecHub-Namada issues URL

### DIFF
--- a/site/Zcash_Community/Community_Links.md
+++ b/site/Zcash_Community/Community_Links.md
@@ -75,4 +75,4 @@ Zcash has an active global presence on X. Key accounts to follow:
 - [ZecHub Wiki](https://zechub.wiki)
 - [Zcash Grants Hub](https://forum.zcashcommunity.com/t/introducing-zcash-grants-hub-browse-zcg-coinholder-grants-apply-via-betther-ui-and-explore-zechub-dao-proposals/55267)
 - [Zcash Global Ambassadors](https://zechub.wiki/zcash-community/zcash-global-ambassadors) - program overview on this wiki (zcashambassadors.com is offline)
-- [ZecHub DAO on Dework](https://app.dework.xyz/zechub-2424)
+- [ZecHub Bounties](https://bounties.zechub.wiki/)

--- a/site/Zcash_Community/Zcash_Global_Ambassadors.md
+++ b/site/Zcash_Community/Zcash_Global_Ambassadors.md
@@ -39,6 +39,6 @@ Ambassadors have creative freedom over the activities they plan, enabling them t
 ## Apply to Become an Ambassador
 
 You can also get involved by:
-- Contributing to [ZecHub DAO](https://app.dework.xyz/zechub-2424) bounties
+- Contributing to [ZecHub](https://bounties.zechub.wiki/) bounties
 - Joining the [Zcash Global Discord](https://discord.gg/zcash)
 

--- a/site/contribute/Help_build_ZecHub.md
+++ b/site/contribute/Help_build_ZecHub.md
@@ -37,7 +37,7 @@ We post issues for tasks that we currently have bounties open every Monday. You 
 
 [ZecHub-Wiki Github Issues](https://github.com/ZecHub/zechub-wiki/issues)
 
-[ZecHub-Namada Github Issues](https://app.dework.xyz/zechub-2424)
+[ZecHub-Namada Github Issues](https://github.com/ZecHub/Namada/issues)
 
 
 


### PR DESCRIPTION
### Summary

Resolves ZecHub Bounty `cmtre6l4d004bcvacgtk8cgpb` (0.07 ZEC): *"Contributor onboarding pages still route people to the retired Dework platform"*.
Tag: @ZecHub/bounties cmtre6l4d004bcvacgtk8cgpb

### Changes Made

- In `site/Zcash_Community/Community_Links.md` (line 78), repointed retired Dework link to `https://bounties.zechub.wiki/`.
- In `site/Zcash_Community/Zcash_Global_Ambassadors.md` (line 42), repointed retired Dework link to `https://bounties.zechub.wiki/`.
- In `site/contribute/Help_build_ZecHub.md` (line 40), corrected mislabelled Dework link to the canonical repository issues page: `https://github.com/ZecHub/Namada/issues`.